### PR TITLE
Remove work-dir option from ghcid targets

### DIFF
--- a/kore/Makefile
+++ b/kore/Makefile
@@ -41,22 +41,22 @@ coverage:
 	$(stack) test --coverage --work-dir .stack-work-coverage
 
 ghcid:
-	$(stack) exec -- ghcid -c "stack ghci $(package) --test --work-dir .stack-work-ghci --ghci-options='-fobject-code -fno-warn-unused-do-bind' --main-is $(package):kore-exec"
+	$(stack) exec -- ghcid -c "stack ghci $(package) --test --ghci-options='-fobject-code -fno-warn-unused-do-bind' --main-is $(package):kore-exec"
 
 ghcid-repl:
-	$(stack) exec -- ghcid -c "stack ghci $(package) --test --ghci-options='-fobject-code -fno-warn-unused-do-bind' --main-is $(package):kore-repl --work-dir .stack-work-ghci"
+	$(stack) exec -- ghcid -c "stack ghci $(package) --test --ghci-options='-fobject-code -fno-warn-unused-do-bind' --main-is $(package):kore-repl"
 
 ghcid-match:
-	$(stack) exec -- ghcid -c "stack ghci $(package) --test --ghci-options='-fobject-code -fno-warn-unused-do-bind' --main-is $(package):kore-match-disjunction --work-dir .stack-work-ghci"
+	$(stack) exec -- ghcid -c "stack ghci $(package) --test --ghci-options='-fobject-code -fno-warn-unused-do-bind' --main-is $(package):kore-match-disjunction"
 
 ghcid-check-func:
-	$(stack) exec -- ghcid -c "stack ghci $(package) --test --ghci-options='-fobject-code -fno-warn-unused-do-bind' --main-is $(package):kore-check-functions --work-dir .stack-work-ghci"
+	$(stack) exec -- ghcid -c "stack ghci $(package) --test --ghci-options='-fobject-code -fno-warn-unused-do-bind' --main-is $(package):kore-check-functions"
 
 ghcid-parser:
-	$(stack) exec -- ghcid -c "stack ghci $(package) --test --ghci-options='-fobject-code -fno-warn-unused-do-bind' --main-is $(package):kore-parser --work-dir .stack-work-ghci"
+	$(stack) exec -- ghcid -c "stack ghci $(package) --test --ghci-options='-fobject-code -fno-warn-unused-do-bind' --main-is $(package):kore-parser"
 
 ghcid-format:
-	$(stack) exec -- ghcid -c "stack ghci $(package) --test --ghci-options='-fobject-code -fno-warn-unused-do-bind' --main-is $(package):kore-format --work-dir .stack-work-ghci"
+	$(stack) exec -- ghcid -c "stack ghci $(package) --test --ghci-options='-fobject-code -fno-warn-unused-do-bind' --main-is $(package):kore-format"
 
 # TODO(Vladimir): remove 'hyperlink-source' when we upgrade from lts-12.10 (8.4.3)
 hoogle-gen:


### PR DESCRIPTION
### Scope:
Running `make ghcid` from `kore/kore` would output:
```
/Users/anapantilie/RV/kore/kore/src/Kore/Parser/LexerWrapper.hs:33:1: error:
    Could not load module 'Kore.Parser.Lexer'
    It is a member of the hidden package 'kore-0.60.0.0'.
    You can run ':set -package kore' to expose it.
    (Note: this unloads all the modules in the current scope.)
    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
   |
33 | import Kore.Parser.Lexer
   | ^^^^^^^^^^^^^^^^^^^^^^^^
<no location info>: error:
    Could not load module 'Control.Monad.Counter'
    It is a member of the hidden package 'kore-0.60.0.0'.
    You can run ':set -package kore' to expose it.
    (Note: this unloads all the modules in the current scope.)
```
Through trial and error, removing the `--work-dir` option from the command seems to fix the problem.

### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
