### PR TITLE
Add script for running tests from elrond-multisig

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,12 @@ RUN    apt-get update               \
 
 # This _might_ be temporary, until we have better support from elrond-mutlisig for regression test generation.
 # Or it might need to stay.
-RUN apt install gnupg
+RUN apt install --yes gnupg
 RUN curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg
 RUN mv bazel.gpg /etc/apt/trusted.gpg.d/
 RUN echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
 RUN    apt update        \
-    && apt install bazel
+    && apt install --yes bazel
 
 ARG STACK=2.5.1
 RUN curl -sSL https://raw.githubusercontent.com/commercialhaskell/stack/v$STACK/etc/scripts/get-stack.sh | sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ RUN    apt update              \
     && apt upgrade --yes       \
     && apt install --yes       \
            libtinfo-dev        \
-           curl git make unzip \
-           bazel
+           curl git make unzip
 
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN    apt-get update               \
@@ -19,11 +18,12 @@ RUN    apt-get update               \
 
 # This _might_ be temporary, until we have better support from elrond-mutlisig for regression test generation.
 # Or it might need to stay.
-RUN sudo apt install curl gnupg
+RUN apt install gnupg
 RUN curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg
-RUN sudo mv bazel.gpg /etc/apt/trusted.gpg.d/
-RUN echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-RUN sudo apt update && sudo apt install bazel
+RUN mv bazel.gpg /etc/apt/trusted.gpg.d/
+RUN echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
+RUN    apt update        \
+    && apt install bazel
 
 ARG STACK=2.5.1
 RUN curl -sSL https://raw.githubusercontent.com/commercialhaskell/stack/v$STACK/etc/scripts/get-stack.sh | sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,14 @@ RUN    apt-get update               \
     && apt-get upgrade --yes        \
     && apt-get install --yes nodejs
 
+# This _might_ be temporary, until we have better support from elrond-mutlisig for regression test generation.
+# Or it might need to stay.
+RUN sudo apt install curl gnupg
+RUN curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg
+RUN sudo mv bazel.gpg /etc/apt/trusted.gpg.d/
+RUN echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
+RUN sudo apt update && sudo apt install bazel
+
 ARG STACK=2.5.1
 RUN curl -sSL https://raw.githubusercontent.com/commercialhaskell/stack/v$STACK/etc/scripts/get-stack.sh | sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN    apt update              \
     && apt upgrade --yes       \
     && apt install --yes       \
            libtinfo-dev        \
-           curl git make unzip
+           curl git make unzip \
+           bazel
 
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN    apt-get update               \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,6 +101,16 @@ pipeline {
                 '''
               }
             }
+            stage('Elrond Regression Tests') {
+              options {
+                timeout(time: 20, unit: 'MINUTES')
+              }
+              steps {
+                sh '''
+                  ./scripts/elrond-regression-tests.sh
+                '''
+              }
+            }
           }
         }
         stage('Update K Submodules') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,9 +106,11 @@ pipeline {
                 timeout(time: 20, unit: 'MINUTES')
               }
               steps {
-                sh '''
-                  ./scripts/elrond-regression-tests.sh
-                '''
+                sshagent(['rv-jenkins-github']) {
+                  sh '''
+                    ./scripts/elrond-regression-tests.sh
+                  '''
+                }
               }
             }
           }

--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -857,7 +857,7 @@ test-suite kore-test
   build-depends: quickcheck-instances >=0.3
   build-depends: tasty >=1.2
   build-depends: tasty-golden >=2.3
-  build-depends: tasty-hedgehog >=1.0
+  build-depends: tasty-hedgehog >=1.0 && <1.2
   build-depends: tasty-hunit >=0.10
   build-depends: tasty-quickcheck >=0.10
   build-depends: tasty-test-reporter >=0.1

--- a/scripts/elrond-regression-tests.sh
+++ b/scripts/elrond-regression-tests.sh
@@ -1,6 +1,6 @@
 set -eu
 
-prep-elrond() {
+prep_elrond() {
     cd $KORE
     git clone git@github.com:runtimeverification/elrond-multisig.git
     cd elrond-multisig
@@ -10,7 +10,7 @@ prep-elrond() {
     bazel clean
 }
 
-run-elrond() {
+run_elrond() {
     cd $KORE/elrond-multisig
     bazel run //protocol-correctness/proof/lemmas/0/signers:lemma-at-most-this-signer-0-count-can-sign-function
     bazel run //protocol-correctness/proof/lemmas/1/list/contains:lemma-list-contains-last-to-start
@@ -20,6 +20,6 @@ run-elrond() {
 }
 
 export KORE=$(pwd)
-prep-elrond
-run-elrond
+prep_elrond
+run_elrond
 rm -rf elrond-multisig

--- a/scripts/elrond-regression-tests.sh
+++ b/scripts/elrond-regression-tests.sh
@@ -6,6 +6,7 @@ prep-elrond() {
     cd elrond-multisig
     cd kompile-tool
     ./prepare-k.sh
+    cd ..
     bazel clean
 }
 

--- a/scripts/elrond-regression-tests.sh
+++ b/scripts/elrond-regression-tests.sh
@@ -1,0 +1,24 @@
+set -euo pipefail
+
+prep-elrond() {
+    cd $KORE
+    git clone git@github.com:runtimeverification/elrond-multisig.git
+    cd elrond-multisig
+    cd kompile-tool
+    ./prepare-k.sh
+    bazel clean
+}
+
+run-elrond() {
+    cd $KORE/elrond-multisig
+    bazel run //protocol-correctness/proof/lemmas/0/signers:lemma-at-most-this-signer-0-count-can-sign-function
+    bazel run //protocol-correctness/proof/lemmas/1/list/contains:lemma-list-contains-last-to-start
+    bazel run //protocol-correctness/proof/functions:proof-change-user-role-New
+    bazel run //protocol-correctness/proof/functions:proof-perform-action-add-proposer-None
+    bazel run //protocol-correctness/proof/malicious-user/can-be-deleted/run-external-call-from-user:proof-recfu-sign-error
+}
+
+export KORE=$(pwd)
+prep-elrond
+run-elrond
+rm -rf elrond-multisig

--- a/scripts/elrond-regression-tests.sh
+++ b/scripts/elrond-regression-tests.sh
@@ -1,5 +1,7 @@
 set -eu
 
+export PATH="$(stack path --local-bin)${PATH:+:$PATH}"
+
 prep_elrond() {
     cd $KORE
     git clone git@github.com:runtimeverification/elrond-multisig.git

--- a/scripts/elrond-regression-tests.sh
+++ b/scripts/elrond-regression-tests.sh
@@ -1,4 +1,4 @@
-set -euo pipefail
+set -eu
 
 prep-elrond() {
     cd $KORE


### PR DESCRIPTION
Fixes #2974

### Scope:

- [x] adds regression testing script for elrond-multisig (clones, builds, and runs 5 proofs)
- [ ] Get CI to run that script when testing

This is intended to be a temporary holdover until `elrond-multisig` has support for us to build in advance during our weekly regression test update job.

### Estimate:

3/13

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [x] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
