### PR TITLE
fix off by one error in lexer

### DIFF
--- a/kore/src/Kore/Parser/Lexer.x
+++ b/kore/src/Kore/Parser/Lexer.x
@@ -295,7 +295,7 @@ unescape t =
   let dropQuotes str = Text.take (Text.length str - 2) . Text.drop 1 $ str
       escape rest c = either Left (\s -> Right (c : s)) $ go rest
       validate rest c
-          | c >= 0x10ffff = Left ("code point " ++ show c ++ " outside range of Unicode")
+          | c > 0x10ffff = Left ("code point " ++ show c ++ " outside range of Unicode")
           | generalCategory (chr c) == Surrogate 
               = Left ("surrogate character " ++ show (chr c) ++ " in string literal")
           | otherwise = escape rest $ chr c


### PR DESCRIPTION
### Scope:

The unit tests failed on one of my other PRs because the random generation of inputs in the Unparse tests happened to generate a 0x10ffff unicode character, which was erroneously being forbidden by the lexer due to this off-by-one error. Should be a very simple fix to review and merge.

### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
