### PR TITLE
enable parallel build of kore libraries

### DIFF
--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -194,6 +194,8 @@ common library
   build-depends: zlib >=0.6
   build-tool-depends: happy:happy
   build-tool-depends: alex:alex
+  ghc-options:
+    -j
 
 library
   import: haskell


### PR DESCRIPTION
### Scope:

GHC --make supports parallel builds within a single module, but stack and cabal, to the best of my knowledge, do not yet explicitly support this level of parallelism. Thus, we enable parallel builds by default on the components that most benefit from it, by means of a ghc-options flag in kore.cabal.

### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
