### PR TITLE
Revert "enable parallel build of kore libraries"

### DIFF
--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -194,8 +194,6 @@ common library
   build-depends: zlib >=0.6
   build-tool-depends: happy:happy
   build-tool-depends: alex:alex
-  ghc-options:
-    -j
 
 library
   import: haskell


### PR DESCRIPTION
Reverts runtimeverification/haskell-backend#3028

Testing to see if this fixes the failed PRs.