### PR TITLE
Add log entry for created substitutions

### DIFF
--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -365,6 +365,7 @@ library
     Kore.Log.DebugAppliedRewriteRules
     Kore.Log.DebugAttemptedRewriteRules
     Kore.Log.DebugBeginClaim
+    Kore.Log.DebugCreatedSubstitution
     Kore.Log.DebugEvaluateCondition
     Kore.Log.DebugProven
     Kore.Log.DebugRetrySolverQuery

--- a/kore/src/Kore/Log/DebugCreatedSubstitution.hs
+++ b/kore/src/Kore/Log/DebugCreatedSubstitution.hs
@@ -1,0 +1,56 @@
+{- |
+Copyright   : (c) Runtime Verification, 2022
+License     : BSD-3-Clause
+-}
+
+module Kore.Log.DebugCreatedSubstitution (
+    DebugCreatedSubstitution,
+    debugCreatedSubstitution,
+) where
+import Kore.Internal.Substitution (Substitution)
+import Kore.Rewrite.RewritingVariable (RewritingVariableName)
+import Log
+import Prelude.Kore
+import Pretty (Pretty(..))
+import Pretty qualified
+import Kore.Sort (Sort)
+import Kore.Internal.Substitution qualified as Substitution
+import Kore.Internal.Predicate qualified as Predicate
+import Kore.Unparser (unparse, layoutPrettyUnbounded)
+
+data DebugCreatedSubstitution = 
+    DebugCreatedSubstitution
+        { substitution :: Substitution RewritingVariableName
+        , resultSort :: Sort
+        }
+        deriving stock (Show)
+
+instance Pretty DebugCreatedSubstitution where
+    pretty (DebugCreatedSubstitution {substitution, resultSort}) =
+        Pretty.vsep 
+        [ "Created and applied the following substitution:"
+        , Pretty.indent 4 (unparse substitutionTerm)
+        ]
+      where
+        substitutionTerm =
+            Predicate.fromPredicate resultSort
+            . Substitution.toPredicate
+            $ substitution
+
+instance Entry DebugCreatedSubstitution where 
+    entrySeverity _ = Debug
+    oneLineDoc =
+        pretty
+        . Pretty.renderString
+        . layoutPrettyUnbounded
+        . Pretty.group
+        . pretty
+    helpDoc _ = "log every substitution created when applying semantic rules"
+
+debugCreatedSubstitution ::
+    MonadLog log =>
+    Substitution RewritingVariableName ->
+    Sort ->
+    log ()
+debugCreatedSubstitution substitution resultSort =
+    logEntry (DebugCreatedSubstitution {substitution, resultSort})

--- a/kore/src/Kore/Log/DebugCreatedSubstitution.hs
+++ b/kore/src/Kore/Log/DebugCreatedSubstitution.hs
@@ -2,49 +2,48 @@
 Copyright   : (c) Runtime Verification, 2022
 License     : BSD-3-Clause
 -}
-
 module Kore.Log.DebugCreatedSubstitution (
     DebugCreatedSubstitution,
     debugCreatedSubstitution,
 ) where
+
+import Kore.Internal.Predicate qualified as Predicate
 import Kore.Internal.Substitution (Substitution)
+import Kore.Internal.Substitution qualified as Substitution
 import Kore.Rewrite.RewritingVariable (RewritingVariableName)
+import Kore.Sort (Sort)
+import Kore.Unparser (layoutPrettyUnbounded, unparse)
 import Log
 import Prelude.Kore
-import Pretty (Pretty(..))
+import Pretty (Pretty (..))
 import Pretty qualified
-import Kore.Sort (Sort)
-import Kore.Internal.Substitution qualified as Substitution
-import Kore.Internal.Predicate qualified as Predicate
-import Kore.Unparser (unparse, layoutPrettyUnbounded)
 
-data DebugCreatedSubstitution = 
-    DebugCreatedSubstitution
-        { substitution :: Substitution RewritingVariableName
-        , resultSort :: Sort
-        }
-        deriving stock (Show)
+data DebugCreatedSubstitution = DebugCreatedSubstitution
+    { substitution :: Substitution RewritingVariableName
+    , resultSort :: Sort
+    }
+    deriving stock (Show)
 
 instance Pretty DebugCreatedSubstitution where
-    pretty (DebugCreatedSubstitution {substitution, resultSort}) =
-        Pretty.vsep 
-        [ "Created and applied the following substitution:"
-        , Pretty.indent 4 (unparse substitutionTerm)
-        ]
+    pretty (DebugCreatedSubstitution{substitution, resultSort}) =
+        Pretty.vsep
+            [ "Created and applied the following substitution:"
+            , Pretty.indent 4 (unparse substitutionTerm)
+            ]
       where
         substitutionTerm =
             Predicate.fromPredicate resultSort
-            . Substitution.toPredicate
-            $ substitution
+                . Substitution.toPredicate
+                $ substitution
 
-instance Entry DebugCreatedSubstitution where 
+instance Entry DebugCreatedSubstitution where
     entrySeverity _ = Debug
     oneLineDoc =
         pretty
-        . Pretty.renderString
-        . layoutPrettyUnbounded
-        . Pretty.group
-        . pretty
+            . Pretty.renderString
+            . layoutPrettyUnbounded
+            . Pretty.group
+            . pretty
     helpDoc _ = "log every substitution created when applying semantic rules"
 
 debugCreatedSubstitution ::
@@ -53,4 +52,4 @@ debugCreatedSubstitution ::
     Sort ->
     log ()
 debugCreatedSubstitution substitution resultSort =
-    logEntry (DebugCreatedSubstitution {substitution, resultSort})
+    logEntry (DebugCreatedSubstitution{substitution, resultSort})

--- a/kore/src/Kore/Log/Registry.hs
+++ b/kore/src/Kore/Log/Registry.hs
@@ -161,6 +161,7 @@ import Type.Reflection (
     someTypeRep,
     typeOf,
  )
+import Kore.Log.DebugCreatedSubstitution (DebugCreatedSubstitution)
 
 data Registry = Registry
     { textToType :: !(Map Text SomeTypeRep)
@@ -229,6 +230,7 @@ entryHelpDocsErr, entryHelpDocsNoErr :: [Pretty.Doc ()]
             , mk $ Proxy @WarnUnsimplifiedPredicate
             , mk $ Proxy @WarnUnsimplifiedCondition
             , mk $ Proxy @WarnRestartSolver
+            , mk $ Proxy @DebugCreatedSubstitution
             ]
         ,
             [ mk $ Proxy @ErrorBottomTotalFunction

--- a/kore/src/Kore/Log/Registry.hs
+++ b/kore/src/Kore/Log/Registry.hs
@@ -47,6 +47,7 @@ import Kore.Log.DebugAttemptedRewriteRules (
 import Kore.Log.DebugBeginClaim (
     DebugBeginClaim,
  )
+import Kore.Log.DebugCreatedSubstitution (DebugCreatedSubstitution)
 import Kore.Log.DebugEvaluateCondition (
     DebugEvaluateCondition,
  )
@@ -161,7 +162,6 @@ import Type.Reflection (
     someTypeRep,
     typeOf,
  )
-import Kore.Log.DebugCreatedSubstitution (DebugCreatedSubstitution)
 
 data Registry = Registry
     { textToType :: !(Map Text SomeTypeRep)

--- a/kore/src/Kore/Rewrite/RewriteStep.hs
+++ b/kore/src/Kore/Rewrite/RewriteStep.hs
@@ -77,6 +77,7 @@ import Logic (
  )
 import Logic qualified
 import Prelude.Kore
+import Kore.Log.DebugCreatedSubstitution (debugCreatedSubstitution)
 
 withoutUnification :: UnifiedRule rule -> rule
 withoutUnification = Conditional.term
@@ -167,6 +168,7 @@ constructConfiguration
             finalTerm' = substitute substitution' finalTerm
         -- TODO (thomas.tuegel): Should the final term be simplified after
         -- substitution?
+        debugCreatedSubstitution substitution (termLikeSort finalTerm)
         return (finalTerm' `Pattern.withCondition` finalCondition)
 
 finalizeAppliedClaim ::

--- a/kore/src/Kore/Rewrite/RewriteStep.hs
+++ b/kore/src/Kore/Rewrite/RewriteStep.hs
@@ -39,6 +39,7 @@ import Kore.Internal.TermLike as TermLike
 import Kore.Log.DebugAppliedRewriteRules (
     debugAppliedRewriteRules,
  )
+import Kore.Log.DebugCreatedSubstitution (debugCreatedSubstitution)
 import Kore.Log.ErrorRewritesInstantiation (
     checkSubstitutionCoverage,
  )
@@ -77,7 +78,6 @@ import Logic (
  )
 import Logic qualified
 import Prelude.Kore
-import Kore.Log.DebugCreatedSubstitution (debugCreatedSubstitution)
 
 withoutUnification :: UnifiedRule rule -> rule
 withoutUnification = Conditional.term

--- a/nix/kore.nix.d/kore.nix
+++ b/nix/kore.nix.d/kore.nix
@@ -251,6 +251,7 @@
           "Kore/Log/DebugAppliedRewriteRules"
           "Kore/Log/DebugAttemptedRewriteRules"
           "Kore/Log/DebugBeginClaim"
+          "Kore/Log/DebugCreatedSubstitution"
           "Kore/Log/DebugEvaluateCondition"
           "Kore/Log/DebugProven"
           "Kore/Log/DebugRetrySolverQuery"


### PR DESCRIPTION
Fixes #3029

### Scope:

Example log entry, standard format:
```
kore-exec: [1097047] Debug (DebugCreatedSubstitution):
    (InfoReachability) while applying axioms:
    Created and applied the following substitution:
        /* Spa */
        \and{SortGeneratedTopCell{}}(
            /* Spa */
            \and{SortGeneratedTopCell{}}(
                /* Spa */
                \and{SortGeneratedTopCell{}}(
                    /* Spa */
                    \and{SortGeneratedTopCell{}}(
                        /* Spa */
                        \and{SortGeneratedTopCell{}}(
                            /* Spa */
                            \equals{SortGeneratedCounterCell{}, SortGeneratedTopCell{}}(
                                /* Fl Fn D Sfa */
                                RuleVar'Unds'DotVar0:SortGeneratedCounterCell{},
                                /* Fl Fn D Sfa */
                                Lbl'-LT-'generatedCounter'-GT-'{}(
                                    /* Fl Fn D Sfa */
                                    ConfigVar'Unds'DotVar1:SortInt{}
                                )
                            ),
                            /* Spa */
                            \equals{SortK{}, SortGeneratedTopCell{}}(
                                /* Fl Fn D Sfa */ RuleVar'Unds'DotVar2:SortK{},
                                /* Fl Fn D Sfa Cl */ dotk{}()
                            )
                        ),
                        /* Spa */
                        \equals{SortMap{}, SortGeneratedTopCell{}}(
                            /* Fl Fn D Sfa */ RuleVar'Unds'DotVar3:SortMap{},
                            /* Fl Fn D Sfa */
                            /* InternalMap: */ Lbl'Unds'Map'Unds'{}(
                                /* concrete element: */ Lbl'UndsPipe'-'-GT-Unds'{}(
                                    /* Inj: */ inj{SortId{}, SortKItem{}}(
                                        \dv{SortId{}}("a")
                                    ),
                                    /* Fl Fn D Sfa */
                                    /* Inj: */ inj{SortInt{}, SortKItem{}}(
                                        /* Fl Fn D Sfa */ ConfigVarA:SortInt{}
                                    )
                                ),
                                /* concrete element: */ Lbl'UndsPipe'-'-GT-Unds'{}(
                                    /* Inj: */ inj{SortId{}, SortKItem{}}(
                                        \dv{SortId{}}("b")
                                    ),
                                    /* Fl Fn D Sfa */
                                    /* Inj: */ inj{SortInt{}, SortKItem{}}(
                                        /* Fl Fn D Sfa */ ConfigVarB:SortInt{}
                                    )
                                )
                            )
                        )
                    ),
                    /* Spa */
                    \equals{SortKItem{}, SortGeneratedTopCell{}}(
                        /* Fl Fn D Sfa */ RuleVar'Unds'Gen0:SortKItem{},
                        /* Fl Fn D Sfa */ ConfigVar'Unds'Gen0:SortKItem{}
                    )
                ),
                /* Spa */
                \equals{SortInt{}, SortGeneratedTopCell{}}(
                    /* Fl Fn D Sfa */ RuleVarI:SortInt{},
                    /* Fl Fn D Sfa */ ConfigVarA:SortInt{}
                )
            ),
            /* Spa */
            \equals{SortId{}, SortGeneratedTopCell{}}(
                /* Fl Fn D Sfa */ RuleVarX:SortId{},
                /* Fl Fn D Sfa Cl */ \dv{SortId{}}(/* Fl Fn D Sfa Cl */ "max")
            )
        )
```

Example log entry, one line format:
```
kore-exec: [874823] Debug (DebugCreatedSubstitution): Created and applied the following substitution:     /* Spa */ \and{SortGeneratedTopCell{}}(/* Spa */ \and{SortGeneratedTopCell{}}(/* Spa */ \and{SortGeneratedTopCell{}}(/* Spa */ \and{SortGeneratedTopCell{}}(/* Spa */ \and{SortGeneratedTopCell{}}(/* Spa */ \equals{SortGeneratedCounterCell{}, SortGeneratedTopCell{}}(/* Fl Fn D Sfa */ RuleVar'Unds'DotVar0:SortGeneratedCounterCell{}, /* Fl Fn D Sfa */ Lbl'-LT-'generatedCounter'-GT-'{}(/* Fl Fn D Sfa */ ConfigVar'Unds'DotVar1:SortInt{})), /* Spa */ \equals{SortK{}, SortGeneratedTopCell{}}(/* Fl Fn D Sfa */ RuleVar'Unds'DotVar2:SortK{}, /* Fl Fn D Sfa Cl */ dotk{}())), /* Spa */ \equals{SortMap{}, SortGeneratedTopCell{}}(/* Fl Fn D Sfa */ RuleVar'Unds'DotVar3:SortMap{}, /* Fl Fn D Sfa */ /* InternalMap: */ Lbl'Unds'Map'Unds'{}(    /* concrete element: */ Lbl'UndsPipe'-'-GT-Unds'{}(/* Inj: */ inj{SortId{}, SortKItem{}}(\dv{SortId{}}("a")), /* Fl Fn D Sfa */ /* Inj: */ inj{SortInt{}, SortKItem{}}(/* Fl Fn D Sfa */ ConfigVarA:SortInt{})),     /* concrete element: */ Lbl'UndsPipe'-'-GT-Unds'{}(/* Inj: */ inj{SortId{}, SortKItem{}}(\dv{SortId{}}("b")), /* Fl Fn D Sfa */ /* Inj: */ inj{SortInt{}, SortKItem{}}(/* Fl Fn D Sfa */ ConfigVarB:SortInt{}))))), /* Spa */ \equals{SortKItem{}, SortGeneratedTopCell{}}(/* Fl Fn D Sfa */ RuleVar'Unds'Gen0:SortKItem{}, /* Fl Fn D Sfa */ ConfigVar'Unds'Gen0:SortKItem{})), /* Spa */ \equals{SortInt{}, SortGeneratedTopCell{}}(/* Fl Fn D Sfa */ RuleVarI:SortInt{}, /* Fl Fn D Sfa */ ConfigVarA:SortInt{})), /* Spa */ \equals{SortId{}, SortGeneratedTopCell{}}(/* Fl Fn D Sfa */ RuleVarX:SortId{}, /* Fl Fn D Sfa Cl */ \dv{SortId{}}(/* Fl Fn D Sfa Cl */ "max")))
```

### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
