### PR TITLE
fix simplification indexing for rules with variables under \equals

### DIFF
--- a/kore/src/Kore/Rewrite/Axiom/EvaluationStrategy.hs
+++ b/kore/src/Kore/Rewrite/Axiom/EvaluationStrategy.hs
@@ -70,15 +70,6 @@ import Pretty (
  )
 import Pretty qualified
 
--- |Describes whether simplifiers are allowed to return multiple results or not.
-data AcceptsMultipleResults = WithMultipleResults | OnlyOneResult
-    deriving stock (Eq, Ord, Show)
-
--- |Converts 'AcceptsMultipleResults' to Bool.
-acceptsMultipleResults :: AcceptsMultipleResults -> Bool
-acceptsMultipleResults WithMultipleResults = True
-acceptsMultipleResults OnlyOneResult = False
-
 {- | Creates an evaluator for a function from the full set of rules
 that define it.
 -}
@@ -168,19 +159,6 @@ simplificationEvaluation equation =
                             (SideCondition.toRepresentation condition)
                     _ -> return NotApplicable
 
-{- | Creates an evaluator that choses the result of the first evaluator that
-returns Applicable.
-
-If that result contains more than one pattern, or it contains a reminder,
-the evaluation fails with 'error' (may change in the future).
--}
-firstFullEvaluation ::
-    [BuiltinAndAxiomSimplifier] ->
-    BuiltinAndAxiomSimplifier
-firstFullEvaluation simplifiers =
-    BuiltinAndAxiomSimplifier
-        (applyFirstSimplifierThatWorks simplifiers OnlyOneResult)
-
 {- | Creates an evaluator that choses the result of the first evaluator if it
 returns Applicable, otherwise returns the result of the second.
 -}
@@ -230,105 +208,3 @@ evaluateBuiltin
       where
         isValue pat =
             maybe False TermLike.isConstructorLike $ asConcrete pat
-
-{- |Whether a term cannot be simplified regardless of the side condition,
-or only with the current side condition.
-
-Example usage for @applyFirstSimplifierThatWorksWorker@:
-
-We start assuming that if we can't simplify the current term, we will never
-be able to simplify it.
-
-If we manage to apply one of the evaluators with an acceptable result
-(e.g. without remainders), we just return the result and we ignore the
-value of the @NonSimplifiability@ argument.
-
-If the result is not acceptable, we continue trying other evaluators, but we
-assume that, even if we are not able to simplify the term right now, that may
-change when the current side condition changes (i.e. we send @Conditional@
-as an argument to the next @applyFirstSimplifierThatWorksWorker@ call).
-
-If we finished trying all the evaluators without an acceptable result,
-we mark the term as simplified according to the 'NonSimplifiability' argument,
-either as "always simplified", or as "simplified while the current side
-condition is unchanged".
--}
-data NonSimplifiability
-    = Always
-    | Conditional
-
-applyFirstSimplifierThatWorks ::
-    forall simplifier.
-    MonadSimplify simplifier =>
-    [BuiltinAndAxiomSimplifier] ->
-    AcceptsMultipleResults ->
-    TermLike RewritingVariableName ->
-    SideCondition RewritingVariableName ->
-    simplifier (AttemptedAxiom RewritingVariableName)
-applyFirstSimplifierThatWorks evaluators multipleResults =
-    applyFirstSimplifierThatWorksWorker evaluators multipleResults Always
-
-applyFirstSimplifierThatWorksWorker ::
-    forall simplifier.
-    MonadSimplify simplifier =>
-    [BuiltinAndAxiomSimplifier] ->
-    AcceptsMultipleResults ->
-    NonSimplifiability ->
-    TermLike RewritingVariableName ->
-    SideCondition RewritingVariableName ->
-    simplifier (AttemptedAxiom RewritingVariableName)
-applyFirstSimplifierThatWorksWorker [] _ Always _ _ =
-    return AttemptedAxiom.NotApplicable
-applyFirstSimplifierThatWorksWorker [] _ Conditional _ sideCondition =
-    return $
-        AttemptedAxiom.NotApplicableUntilConditionChanges $
-            SideCondition.toRepresentation sideCondition
-applyFirstSimplifierThatWorksWorker
-    (BuiltinAndAxiomSimplifier evaluator : evaluators)
-    multipleResults
-    nonSimplifiability
-    patt
-    sideCondition =
-        do
-            applicationResult <- evaluator patt sideCondition
-
-            case applicationResult of
-                AttemptedAxiom.Applied
-                    AttemptedAxiomResults
-                        { results = orResults
-                        , remainders = orRemainders
-                        }
-                        | acceptsMultipleResults multipleResults -> return applicationResult
-                        -- below this point multiple results are not accepted
-                        | length orResults > 1 ->
-                            -- We should only allow multiple simplification results
-                            -- when they are created by unification splitting the
-                            -- configuration.
-                            -- However, right now, we shouldn't be able to get more
-                            -- than one result, so we throw an error.
-                            error . show . Pretty.vsep $
-                                [ "Unexpected simplification result with more \
-                                  \than one configuration:"
-                                , Pretty.indent 2 "input:"
-                                , Pretty.indent 4 (unparse patt)
-                                , Pretty.indent 2 "results:"
-                                , (Pretty.indent 4 . Pretty.vsep)
-                                    (unparse <$> toList orResults)
-                                , Pretty.indent 2 "remainders:"
-                                , (Pretty.indent 4 . Pretty.vsep)
-                                    (unparse <$> toList orRemainders)
-                                ]
-                        | not (OrPattern.isFalse orRemainders) ->
-                            tryNextSimplifier Conditional
-                        | otherwise -> return applicationResult
-                AttemptedAxiom.NotApplicable -> tryNextSimplifier nonSimplifiability
-                AttemptedAxiom.NotApplicableUntilConditionChanges _ ->
-                    tryNextSimplifier Conditional
-      where
-        tryNextSimplifier nonSimplifiability' =
-            applyFirstSimplifierThatWorksWorker
-                evaluators
-                multipleResults
-                nonSimplifiability'
-                patt
-                sideCondition

--- a/kore/src/Kore/Rewrite/Axiom/Identifier.hs
+++ b/kore/src/Kore/Rewrite/Axiom/Identifier.hs
@@ -132,6 +132,15 @@ matchAxiomIdentifier = Recursive.fold matchWorker
             InternalBytesF _ -> pure DV
             InternalIntF _ -> pure DV
             InternalStringF _ -> pure DV
+            -- TODO(dwightguth): this is unsound. If we are simplifying a \ceil
+            -- or \equals pattern whose children is not one of the above types
+            -- of term, then this function will return Nothing, meaning that no
+            -- axioms are applied, even if the user explicitly wrote
+            -- simplification rules that do match. I have covered the cases for
+            -- the simplification rules I have needed so far, but this is still
+            -- a known issue which may lead to simplification rules that were
+            -- written by the user to simplify \equals or \ceil not being
+            -- applied.
             _ -> empty
 
     listToId internalList

--- a/kore/src/Kore/Rewrite/Axiom/Identifier.hs
+++ b/kore/src/Kore/Rewrite/Axiom/Identifier.hs
@@ -66,8 +66,8 @@ identifier of its left-hand-side is the same as the term's identifier.
 data AxiomIdentifier
     = -- | An application pattern with the given symbol identifier.
       Application !Id
-      -- | Any domain value pattern.
-    | DV
+    | -- | Any domain value pattern.
+      DV
     | -- | A @\\ceil@ pattern with the given child.
       Ceil !AxiomIdentifier
     | -- | An @\\equals@ pattern with the given children.

--- a/kore/src/Kore/Rewrite/Axiom/Identifier.hs
+++ b/kore/src/Kore/Rewrite/Axiom/Identifier.hs
@@ -66,6 +66,8 @@ identifier of its left-hand-side is the same as the term's identifier.
 data AxiomIdentifier
     = -- | An application pattern with the given symbol identifier.
       Application !Id
+      -- | Any domain value pattern.
+    | DV
     | -- | A @\\ceil@ pattern with the given child.
       Ceil !AxiomIdentifier
     | -- | An @\\equals@ pattern with the given children.
@@ -82,6 +84,7 @@ data AxiomIdentifier
 
 instance Pretty AxiomIdentifier where
     pretty (Application name) = unparse name
+    pretty DV = "\\dv{_}(_)"
     pretty (Ceil axiomIdentifier) =
         "\\ceil" <> Pretty.parens (pretty axiomIdentifier)
     pretty (Equals first second) =
@@ -124,6 +127,11 @@ matchAxiomIdentifier = Recursive.fold matchWorker
             InternalListF internalList -> listToId internalList
             InternalSetF internalSet -> mapToId internalSet
             InternalMapF internalMap -> setToId internalMap
+            DomainValueF _ -> pure DV
+            InternalBoolF _ -> pure DV
+            InternalBytesF _ -> pure DV
+            InternalIntF _ -> pure DV
+            InternalStringF _ -> pure DV
             _ -> empty
 
     listToId internalList

--- a/kore/src/Kore/Simplify/Simplify.hs
+++ b/kore/src/Kore/Simplify/Simplify.hs
@@ -124,7 +124,7 @@ import Kore.Log.WarnFunctionWithoutEvaluators (
     warnFunctionWithoutEvaluators,
  )
 import Kore.Rewrite.Axiom.Identifier (
-    AxiomIdentifier(..),
+    AxiomIdentifier (..),
  )
 import Kore.Rewrite.Axiom.Identifier qualified as Axiom.Identifier
 import Kore.Rewrite.Function.Memo qualified as Memo
@@ -468,23 +468,23 @@ lookupAxiomSimplifier termLike = do
             Axiom.Identifier.Application _ -> exact
             Variable -> exact
             Ceil _ ->
-              let inexact = Map.lookup (Ceil Variable) simplifierMap
-              in combineEvaluators [exact, inexact]
+                let inexact = Map.lookup (Ceil Variable) simplifierMap
+                 in combineEvaluators [exact, inexact]
             Exists _ ->
-              let inexact = Map.lookup (Exists Variable) simplifierMap
-              in combineEvaluators [exact, inexact]
+                let inexact = Map.lookup (Exists Variable) simplifierMap
+                 in combineEvaluators [exact, inexact]
             Equals id1 id2 ->
-              let inexact1 = Map.lookup (Equals Variable id2) simplifierMap
-                  inexact2 = Map.lookup (Equals id1 Variable) simplifierMap
-                  inexact12 = Map.lookup (Equals Variable Variable) simplifierMap
-              in combineEvaluators [exact, inexact1, inexact2, inexact12]
+                let inexact1 = Map.lookup (Equals Variable id2) simplifierMap
+                    inexact2 = Map.lookup (Equals id1 Variable) simplifierMap
+                    inexact12 = Map.lookup (Equals Variable Variable) simplifierMap
+                 in combineEvaluators [exact, inexact1, inexact2, inexact12]
   where
     getHook = Attribute.getHook . Attribute.hook . symbolAttributes
     combineEvaluators maybeEvaluators =
-      case catMaybes maybeEvaluators of
-        [] -> Nothing
-        [a] -> Just a
-        as -> Just $ firstFullEvaluation as
+        case catMaybes maybeEvaluators of
+            [] -> Nothing
+            [a] -> Just a
+            as -> Just $ firstFullEvaluation as
 
 -- |Describes whether simplifiers are allowed to return multiple results or not.
 data AcceptsMultipleResults = WithMultipleResults | OnlyOneResult

--- a/kore/src/Kore/Simplify/Simplify.hs
+++ b/kore/src/Kore/Simplify/Simplify.hs
@@ -467,6 +467,7 @@ lookupAxiomSimplifier termLike = do
         case axiomIdentifier of
             Axiom.Identifier.Application _ -> exact
             Variable -> exact
+            DV -> exact
             Ceil _ ->
                 let inexact = Map.lookup (Ceil Variable) simplifierMap
                  in combineEvaluators [exact, inexact]

--- a/kore/test/Test/Kore/Rewrite/Function/Integration.hs
+++ b/kore/test/Test/Kore/Rewrite/Function/Integration.hs
@@ -61,7 +61,6 @@ import Kore.Internal.TermLike
 import Kore.Rewrite.Axiom.EvaluationStrategy (
     builtinEvaluation,
     definitionEvaluation,
-    firstFullEvaluation,
     simplificationEvaluation,
     simplifierWithFallback,
  )

--- a/kore/test/Test/Kore/Simplify/Application.hs
+++ b/kore/test/Test/Kore/Simplify/Application.hs
@@ -26,9 +26,6 @@ import Kore.Internal.SideCondition qualified as SideCondition (
  )
 import Kore.Internal.Substitution qualified as Substitution
 import Kore.Internal.TermLike as TermLike
-import Kore.Rewrite.Axiom.EvaluationStrategy (
-    firstFullEvaluation,
- )
 import Kore.Rewrite.Axiom.Identifier qualified as AxiomIdentifier (
     AxiomIdentifier (..),
  )

--- a/kore/test/Test/Kore/Simplify/Condition.hs
+++ b/kore/test/Test/Kore/Simplify/Condition.hs
@@ -36,9 +36,6 @@ import Kore.Internal.SideCondition qualified as SideCondition (
  )
 import Kore.Internal.Substitution qualified as Substitution
 import Kore.Internal.TermLike
-import Kore.Rewrite.Axiom.EvaluationStrategy (
-    firstFullEvaluation,
- )
 import Kore.Rewrite.Axiom.Identifier qualified as AxiomIdentifier (
     AxiomIdentifier (..),
  )

--- a/kore/test/Test/Kore/Simplify/Integration.hs
+++ b/kore/test/Test/Kore/Simplify/Integration.hs
@@ -11,8 +11,8 @@ import Control.Lens qualified as Lens
 import Data.Default qualified as Default
 import Data.Generics.Product
 import Data.Map.Strict qualified as Map
-import Kore.Builtin.Builtin qualified as Builtin
 import Kore.Builtin.Bool qualified as Bool
+import Kore.Builtin.Builtin qualified as Builtin
 import Kore.Builtin.Int qualified as Int
 import Kore.Builtin.List qualified as List
 import Kore.Builtin.Map qualified as Map
@@ -687,7 +687,7 @@ test_simplificationIntegration =
                     { term = mkTop Mock.testSort
                     , predicate = makeEqualsPredicate (Mock.functional10 (mkElemVar Mock.xConfig)) (Mock.functional10 (mkElemVar Mock.yConfig))
                     , substitution = mempty
-                     }
+                    }
             expected = OrPattern.topOf Mock.testSort
         actual <-
             evaluateWithAxioms
@@ -713,7 +713,7 @@ test_simplificationIntegration =
                     { term = mkTop Mock.testSort
                     , predicate = makeEqualsPredicate (Mock.fBool (mkElemVar Mock.xConfigBool)) (Bool.asInternal Mock.boolSort True)
                     , substitution = mempty
-                     }
+                    }
             expected = OrPattern.topOf Mock.testSort
         actual <-
             evaluateWithAxioms


### PR DESCRIPTION
### Scope:

Previously, if you had a simplification rule whose left-hand side was \equals and one of the children of the \equals was a variable, it would not correctly find that axiom in the index if the term being simplified was an equality between two application patterns.

I have not been able to minimize the example that I was using for testing; when I did, the simplifier was able to solve it even without this change, and I'm not entirely sure what the issue is. If someone wants to help by writing a test for this, that would be great.

### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
