### PR TITLE
#3103 compile GlobalMain only once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,13 @@ haddock:
 		--fast \
 		>haddock.log 2>&1 \
 		|| ( cat haddock.log; exit 1; )
-	cat haddock.log
-	if grep -B 2 'Module header' haddock.log; then \
+        #remove header warning for Paths_kore
+	sed "N;N;/[^\n]*in 'Paths_kore'\n.*\n.*/d" haddock.log | tee haddock.log.noPaths
+	if grep -B 2 'Module header' haddock.log.noPaths; then \
 		echo >&2 "Please fix the missing documentation!"; \
 		exit 1; \
 	else \
-		rm haddock.log; \
+		rm haddock.log*; \
 	fi
 
 haskell_documentation: haddock

--- a/kore/app/share/GlobalMain.hs
+++ b/kore/app/share/GlobalMain.hs
@@ -1,5 +1,9 @@
 {-# LANGUAGE TemplateHaskell #-}
 
+{- |
+Copyright   : (c) Runtime Verification, 2020-2022
+License     : BSD-3-Clause
+-}
 module GlobalMain (
     MainOptions (..),
     GlobalOptions (..),

--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -127,18 +127,16 @@ common exe
 
 common library
   -- Dependencies of the library, shared in common with the tests
-  build-depends: binary >=0.8.8.0
-  build-depends: compact >= 0.2.0.0
-  build-depends: time >=1.9.3
-
   build-depends: adjunctions >=4.4
   build-depends: aeson >=1.4
   build-depends: array
   build-depends: async >=2.2
+  build-depends: binary >=0.8.8.0
   build-depends: bytestring >=0.10
   build-depends: clock >=0.8
   build-depends: co-log >=0.4
   build-depends: comonad >=5.0
+  build-depends: compact >= 0.2.0.0
   build-depends: conduit-extra >=1.3
   build-depends: containers >=0.5.8
   build-depends: cryptonite >=0.25
@@ -184,6 +182,7 @@ common library
   build-depends: temporary >=1.3
   build-depends: text >=1.2
   build-depends: these >=1.0
+  build-depends: time >=1.9.3
   build-depends: transformers >=0.4
   build-depends: unordered-containers >=0.2
   build-depends: vector >=0.12

--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -127,15 +127,13 @@ common exe
 
 common global-main
   -- Common options for all executables that depend on GlobalMain
-  other-modules:
-    GlobalMain
-    Paths_kore
-  hs-source-dirs: app/share
+  -- other-modules:
+  --   GlobalMain
+  --   Paths_kore
+  -- hs-source-dirs: app/share
   build-depends: kore
-  build-depends: binary >=0.8.8.0
   build-depends: bytestring >=0.10
   build-depends: clock >=0.8
-  build-depends: compact >= 0.2.0.0
   build-depends: containers >=0.5
   build-depends: deepseq >=1.4
   build-depends: directory >=1.3
@@ -146,10 +144,13 @@ common global-main
   build-depends: megaparsec >=7.0
   build-depends: optparse-applicative >=0.14
   build-depends: text >=1.2
-  build-depends: time >=1.9.3
 
 common library
   -- Dependencies of the library, shared in common with the tests
+  build-depends: binary >=0.8.8.0
+  build-depends: compact >= 0.2.0.0
+  build-depends: time >=1.9.3
+
   build-depends: adjunctions >=4.4
   build-depends: aeson >=1.4
   build-depends: array
@@ -223,6 +224,7 @@ library
     Debug
     ErrorContext
     From
+    GlobalMain
     Injection
     Kore.AST.ApplicativeKore
     Kore.AST.AstWithLocation
@@ -580,6 +582,7 @@ library
     Options.SMT
     Pair
     Partial
+    Paths_kore
     Prelude.Kore
     Pretty
     Prof
@@ -593,7 +596,9 @@ library
     SQL.SOP
     SQL.SQL
     Stats
-  hs-source-dirs: src
+  hs-source-dirs:
+    src
+    app/share
   if !flag(release)
     ghc-options: -fno-specialise
 
@@ -609,6 +614,7 @@ executable kore-exec
   build-depends: exceptions >=0.10
   build-depends: extra >=1.6
   build-depends: generic-lens >=1.1
+  build-depends: time >=1.9.3
   ghc-options: -eventlog
 
 executable kore-rpc

--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -125,26 +125,6 @@ common exe
   else
     ghc-options: -rtsopts "-with-rtsopts=-A32M -T"
 
-common global-main
-  -- Common options for all executables that depend on GlobalMain
-  -- other-modules:
-  --   GlobalMain
-  --   Paths_kore
-  -- hs-source-dirs: app/share
-  build-depends: kore
-  build-depends: bytestring >=0.10
-  build-depends: clock >=0.8
-  build-depends: containers >=0.5
-  build-depends: deepseq >=1.4
-  build-depends: directory >=1.3
-  build-depends: exceptions >=0.10
-  build-depends: filepath >=1.4
-  build-depends: generic-lens >=1.1
-  build-depends: lens >=4.17
-  build-depends: megaparsec >=7.0
-  build-depends: optparse-applicative >=0.14
-  build-depends: text >=1.2
-
 common library
   -- Dependencies of the library, shared in common with the tests
   build-depends: binary >=0.8.8.0
@@ -605,38 +585,47 @@ library
 executable kore-exec
   import: haskell
   import: exe
-  import: global-main
   main-is: Main.hs
   hs-source-dirs: app/exec
+  build-depends: kore
+  build-depends: clock >=0.8
   build-depends: compact >=0.2.0.0
+  build-depends: containers >=0.5
   build-depends: data-default >=0.7
   build-depends: directory >=1.3
   build-depends: exceptions >=0.10
   build-depends: extra >=1.6
+  build-depends: filepath >=1.4
   build-depends: generic-lens >=1.1
+  build-depends: lens >=4.17
+  build-depends: optparse-applicative >=0.14
+  build-depends: text >=1.2
   build-depends: time >=1.9.3
   ghc-options: -eventlog
 
 executable kore-rpc
   import: haskell
   import: exe
-  import: global-main
   main-is: Main.hs
   hs-source-dirs: app/rpc
+  build-depends: kore
 
 executable kore-format
   import: haskell
   import: exe
-  import: global-main
   main-is: Main.hs
   hs-source-dirs: app/format
+  build-depends: kore
+  build-depends: optparse-applicative >=0.14
+  build-depends: text >=1.2
 
 executable kore-parser
   import: haskell
   import: exe
-  import: global-main
   main-is: Main.hs
   hs-source-dirs: app/parser
+  build-depends: kore
+  build-depends: containers >=0.5
   build-depends: exceptions >=0.10
 
 executable kore-prof
@@ -644,39 +633,47 @@ executable kore-prof
   import: exe
   main-is: Main.hs
   hs-source-dirs: app/prof
+  build-depends: kore
   build-depends: eventlog2speedscope
   build-depends: optparse-applicative >=0.14
 
 executable kore-repl
   import: haskell
   import: exe
-  import: global-main
   main-is: Main.hs
   hs-source-dirs: app/repl
+  build-depends: kore
+  build-depends: clock >=0.8
   build-depends: exceptions >=0.10
+  build-depends: optparse-applicative >=0.14
 
 executable kore-match-disjunction
   import: haskell
   import: exe
-  import: global-main
   main-is: Main.hs
   hs-source-dirs: app/match-disjunction
+  build-depends: kore
+  build-depends: clock >=0.8
+  build-depends: optparse-applicative >=0.14
   build-depends: transformers >= 0.5
 
 executable kore-check-functions
   import: haskell
   import: exe
-  import: global-main
   main-is: Main.hs
   hs-source-dirs: app/check-functions
+  build-depends: kore
+  build-depends: clock >=0.8
   build-depends: exceptions >=0.10
 
 executable kore-simplify
   import: haskell
   import: exe
-  import: global-main
   main-is: Main.hs
   hs-source-dirs: app/simplify
+  build-depends: kore
+  build-depends: clock >=0.8
+  build-depends: optparse-applicative >=0.14
 
 test-suite kore-test
   import: haskell

--- a/nix/kore.nix.d/kore.nix
+++ b/nix/kore.nix.d/kore.nix
@@ -38,10 +38,12 @@
           (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
           (hsPkgs."array" or (errorHandler.buildDepError "array"))
           (hsPkgs."async" or (errorHandler.buildDepError "async"))
+          (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
           (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
           (hsPkgs."co-log" or (errorHandler.buildDepError "co-log"))
           (hsPkgs."comonad" or (errorHandler.buildDepError "comonad"))
+          (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
           (hsPkgs."conduit-extra" or (errorHandler.buildDepError "conduit-extra"))
           (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
           (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
@@ -87,6 +89,7 @@
           (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           (hsPkgs."these" or (errorHandler.buildDepError "these"))
+          (hsPkgs."time" or (errorHandler.buildDepError "time"))
           (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
           (hsPkgs."unordered-containers" or (errorHandler.buildDepError "unordered-containers"))
           (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
@@ -107,6 +110,7 @@
           "Debug"
           "ErrorContext"
           "From"
+          "GlobalMain"
           "Injection"
           "Kore/AST/ApplicativeKore"
           "Kore/AST/AstWithLocation"
@@ -464,6 +468,7 @@
           "Options/SMT"
           "Pair"
           "Partial"
+          "Paths_kore"
           "Prelude/Kore"
           "Pretty"
           "Prof"
@@ -478,34 +483,29 @@
           "SQL/SQL"
           "Stats"
           ];
-        hsSourceDirs = [ "src" ];
+        hsSourceDirs = [ "src" "app/share" ];
         };
       exes = {
         "kore-exec" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
             (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
             (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
             (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
+            (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
             (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
             (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
             (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
-            (hsPkgs."megaparsec" or (errorHandler.buildDepError "megaparsec"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."time" or (errorHandler.buildDepError "time"))
-            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
-            (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
             ];
           buildable = true;
-          modules = [ "GlobalMain" "Paths_kore" ];
-          hsSourceDirs = [ "app/share" "app/exec" ];
+          hsSourceDirs = [ "app/exec" ];
           mainPath = (([
             "Main.hs"
             ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
@@ -516,25 +516,9 @@
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
-            (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
-            (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
-            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
-            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
-            (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
-            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
-            (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
-            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
-            (hsPkgs."megaparsec" or (errorHandler.buildDepError "megaparsec"))
-            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-            (hsPkgs."text" or (errorHandler.buildDepError "text"))
-            (hsPkgs."time" or (errorHandler.buildDepError "time"))
             ];
           buildable = true;
-          modules = [ "GlobalMain" "Paths_kore" ];
-          hsSourceDirs = [ "app/share" "app/rpc" ];
+          hsSourceDirs = [ "app/rpc" ];
           mainPath = (([
             "Main.hs"
             ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
@@ -545,25 +529,11 @@
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
-            (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
-            (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
-            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
-            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
-            (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
-            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
-            (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
-            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
-            (hsPkgs."megaparsec" or (errorHandler.buildDepError "megaparsec"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
-            (hsPkgs."time" or (errorHandler.buildDepError "time"))
             ];
           buildable = true;
-          modules = [ "GlobalMain" "Paths_kore" ];
-          hsSourceDirs = [ "app/share" "app/format" ];
+          hsSourceDirs = [ "app/format" ];
           mainPath = (([
             "Main.hs"
             ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
@@ -574,25 +544,11 @@
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
-            (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
-            (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
-            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
             (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
-            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
-            (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
-            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
-            (hsPkgs."megaparsec" or (errorHandler.buildDepError "megaparsec"))
-            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-            (hsPkgs."text" or (errorHandler.buildDepError "text"))
-            (hsPkgs."time" or (errorHandler.buildDepError "time"))
             ];
           buildable = true;
-          modules = [ "GlobalMain" "Paths_kore" ];
-          hsSourceDirs = [ "app/share" "app/parser" ];
+          hsSourceDirs = [ "app/parser" ];
           mainPath = (([
             "Main.hs"
             ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
@@ -602,6 +558,7 @@
         "kore-prof" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
             (hsPkgs."eventlog2speedscope" or (errorHandler.buildDepError "eventlog2speedscope"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
             ];
@@ -617,25 +574,12 @@
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
-            (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
-            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
-            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
             (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
-            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
-            (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
-            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
-            (hsPkgs."megaparsec" or (errorHandler.buildDepError "megaparsec"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-            (hsPkgs."text" or (errorHandler.buildDepError "text"))
-            (hsPkgs."time" or (errorHandler.buildDepError "time"))
             ];
           buildable = true;
-          modules = [ "GlobalMain" "Paths_kore" ];
-          hsSourceDirs = [ "app/share" "app/repl" ];
+          hsSourceDirs = [ "app/repl" ];
           mainPath = (([
             "Main.hs"
             ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
@@ -646,26 +590,12 @@
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
-            (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
-            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
-            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
-            (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
-            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
-            (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
-            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
-            (hsPkgs."megaparsec" or (errorHandler.buildDepError "megaparsec"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-            (hsPkgs."text" or (errorHandler.buildDepError "text"))
-            (hsPkgs."time" or (errorHandler.buildDepError "time"))
             (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
             ];
           buildable = true;
-          modules = [ "GlobalMain" "Paths_kore" ];
-          hsSourceDirs = [ "app/share" "app/match-disjunction" ];
+          hsSourceDirs = [ "app/match-disjunction" ];
           mainPath = (([
             "Main.hs"
             ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
@@ -676,25 +606,11 @@
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
-            (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
-            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
-            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
             (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
-            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
-            (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
-            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
-            (hsPkgs."megaparsec" or (errorHandler.buildDepError "megaparsec"))
-            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-            (hsPkgs."text" or (errorHandler.buildDepError "text"))
-            (hsPkgs."time" or (errorHandler.buildDepError "time"))
             ];
           buildable = true;
-          modules = [ "GlobalMain" "Paths_kore" ];
-          hsSourceDirs = [ "app/share" "app/check-functions" ];
+          hsSourceDirs = [ "app/check-functions" ];
           mainPath = (([
             "Main.hs"
             ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
@@ -705,25 +621,11 @@
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
-            (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
-            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
-            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
-            (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
-            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
-            (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
-            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
-            (hsPkgs."megaparsec" or (errorHandler.buildDepError "megaparsec"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-            (hsPkgs."text" or (errorHandler.buildDepError "text"))
-            (hsPkgs."time" or (errorHandler.buildDepError "time"))
             ];
           buildable = true;
-          modules = [ "GlobalMain" "Paths_kore" ];
-          hsSourceDirs = [ "app/share" "app/simplify" ];
+          hsSourceDirs = [ "app/simplify" ];
           mainPath = (([
             "Main.hs"
             ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
@@ -739,10 +641,12 @@
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."array" or (errorHandler.buildDepError "array"))
             (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
             (hsPkgs."co-log" or (errorHandler.buildDepError "co-log"))
             (hsPkgs."comonad" or (errorHandler.buildDepError "comonad"))
+            (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
             (hsPkgs."conduit-extra" or (errorHandler.buildDepError "conduit-extra"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
             (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
@@ -788,6 +692,7 @@
             (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."these" or (errorHandler.buildDepError "these"))
+            (hsPkgs."time" or (errorHandler.buildDepError "time"))
             (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
             (hsPkgs."unordered-containers" or (errorHandler.buildDepError "unordered-containers"))
             (hsPkgs."vector" or (errorHandler.buildDepError "vector"))


### PR DESCRIPTION
Moves `GlobalMain` and `Paths_kore` away from the applications into the library, so it will be compiled only once.

Build time with stack dropped from 1m51s to 1m40s on my machine (Intel I9 12thGen)

### Scope:

### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [X] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
