### PR TITLE
Jb/2626 json kore hs backend

### DIFF
--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -129,6 +129,7 @@ common library
   -- Dependencies of the library, shared in common with the tests
   build-depends: adjunctions >=4.4
   build-depends: aeson >=1.4
+  build-depends: aeson-pretty == 0.8.9
   build-depends: array
   build-depends: async >=2.2
   build-depends: binary >=0.8.8.0
@@ -195,6 +196,7 @@ library
   import: haskell
   import: library
   exposed-modules:
+    KoreJson
     Changed
     Control.Monad.Counter
     Data.Graph.TopologicalSort

--- a/kore/src/KoreJson.hs
+++ b/kore/src/KoreJson.hs
@@ -7,7 +7,6 @@ module KoreJson (
     ) where
 
 --    KorePattern(..)
-
 import Data.Aeson as Json
 import Data.Aeson.Encode.Pretty as Json
 import Data.ByteString.Lazy (ByteString)

--- a/kore/src/KoreJson.hs
+++ b/kore/src/KoreJson.hs
@@ -17,11 +17,11 @@ import GHC.Generics -- FIXME switch to TH-generated Json instances
 import Kore.Attribute.Attributes (ParsedPattern)
 import Kore.Internal.Pattern (Pattern)
 import Kore.Syntax.PatternF (PatternF (..))
-
 -- import Kore.Internal.TermLike.TermLike (TermLikeF(..))
 import Kore.Parser (embedParsedPattern)
 import Kore.Sort qualified as Kore
-import Kore.Syntax.Variable (ElementVariableName (..), SetVariableName (..), SomeVariable (..), SomeVariableName (..), Variable (..), VariableName (..))
+import Kore.Syntax qualified as Kore
+import Kore.Syntax.Variable (ElementVariableName (..), SetVariableName (..), SomeVariableName (..), Variable (..), VariableName (..))
 import Prelude.Kore as Prelude
 
 {- | Json representation of Kore patterns as a Haskell type.
@@ -46,7 +46,7 @@ data KorePattern
       -- | application pattern (symbol, [arg] )
       KJApp
         { name :: Id -- may start by a '\\'
-        , sort :: Sort
+        , sorts :: [Sort]
         , args :: [KorePattern]
         }
     | -- | string literal
@@ -159,7 +159,7 @@ instance FromJSON Sort where
 
 -- TODO could omit the args field if empty (custom instance)
 
--- names and arity of known ML connectives
+-- names of known ML connectives. Arity checked during conversion
 data Connective
     = Top
     | Bottom
@@ -173,16 +173,6 @@ data Connective
 
 -- string-tag encoded in the generated instance. Should they be lower-case?
 
-connArity :: Connective -> Int
-connArity Top = 0
-connArity Bottom = 0
-connArity Not = 1
-connArity And = 2
-connArity Or = 2
-connArity Implies = 2
-connArity Iff = 2
-
---
 data Quant
     = Forall
     | Exists
@@ -223,6 +213,8 @@ decodePattern bs =
 data JsonError
     = -- | Problem reported by json parser
       ParseError String
+    | -- | Wrong arg count for a connective or other construct
+      WrongArgCount String Int
     | -- | Inconsistent data parsed. TODO: refine!
       KoreError String
     | NotImplemented String
@@ -234,31 +226,80 @@ decodeKoreJson = Json.eitherDecode'
 -- see Parser.y
 toParsedPattern :: KorePattern -> Either JsonError ParsedPattern
 toParsedPattern = \case
-    KJEVar n s -> do
-        variableName <- eVarName n
-        variableSort <- mkSort s
-        pure $
-            embedParsedPattern $
-                VariableF $
-                    Const $
-                        Variable{variableName, variableSort}
-    x -> Prelude.Left . NotImplemented $ show x
+    KJEVar n s ->
+      embedVar (SomeVariableNameElement . ElementVariableName) n s
+
+    KJSVar n s ->
+      embedVar (SomeVariableNameSet . SetVariableName) n s
+
+    KJApp n ss as ->
+      fmap (embedParsedPattern . ApplicationF) $
+      Kore.Application <$> toSymbol n ss <*> traverse toParsedPattern as
+
+    KJString t ->
+      embedParsedPattern . StringLiteralF . Const <$> pure (Kore.StringLiteral t)
+
+    KJConnective c s as ->
+      embedParsedPattern <$> mkConnective c s as
+
+    x -> todo $ show x
+
   where
-    mkSort :: Sort -> Either JsonError Kore.Sort
-    mkSort Sort{name, args} =
-        fmap (Kore.SortActualSort . Kore.SortActual (koreId name)) $
-            mapM mkSort args
-    mkSort (SortVariable name) =
-        pure . Kore.SortVariableSort $ Kore.SortVariable (koreId $ Id name)
+    todo = Prelude.Left . NotImplemented
 
-    koreId :: Id -> Kore.Id
-    koreId (Id name) = Kore.Id name Kore.AstLocationNone
+    embedVar :: (VariableName -> SomeVariableName VariableName)
+             -> Id -> Sort -> Either JsonError ParsedPattern
+    embedVar cons n s =
+      fmap (embedParsedPattern . VariableF . Const) $
+      Variable <$> mkVarName cons n <*> mkSort s
 
-    eVarName :: Id -> Either JsonError (SomeVariableName VariableName)
-    eVarName = pure . SomeVariableNameElement . ElementVariableName . flip VariableName Nothing . koreId
+    mkVarName :: (VariableName -> SomeVariableName VariableName)
+            -> Id
+            -> Either JsonError (SomeVariableName VariableName)
+    mkVarName embed = pure . embed . flip VariableName Nothing . koreId
+
+    toSymbol :: Id -> [Sort] -> Either JsonError Kore.SymbolOrAlias
+    toSymbol n sorts = Kore.SymbolOrAlias <$> pure (koreId n) <*> traverse mkSort sorts
 
 -- TODO check well-formed (initial letter, char. set)
 -- FIXME do we need to read a numeric suffix? (-> Parser.y:getVariableName)
+
+koreId :: Id -> Kore.Id
+koreId (Id name) = Kore.Id name Kore.AstLocationNone
+
+mkSort :: Sort -> Either JsonError Kore.Sort
+mkSort Sort{name, args} =
+  fmap (Kore.SortActualSort . Kore.SortActual (koreId name)) $
+  mapM mkSort args
+mkSort (SortVariable name) =
+  pure . Kore.SortVariableSort $ Kore.SortVariable (koreId $ Id name)
+
+mkConnective :: Connective
+             -> Sort
+             -> [KorePattern]
+             -> Either JsonError (PatternF VariableName ParsedPattern)
+mkConnective Top s [] =
+  TopF . Kore.Top <$> (mkSort s)
+mkConnective Bottom s [] =
+  BottomF . Kore.Bottom <$> (mkSort s)
+mkConnective Not s [a] =
+  fmap NotF $
+  Kore.Not <$> mkSort s <*> toParsedPattern a
+mkConnective And s [a,b] =
+  fmap AndF $
+  Kore.And <$> mkSort s <*> toParsedPattern a <*> toParsedPattern b
+mkConnective Or s [a,b] =
+  fmap OrF $
+  Kore.Or <$> mkSort s <*> toParsedPattern a <*> toParsedPattern b
+mkConnective Implies s [a,b] =
+  fmap ImpliesF $
+  Kore.Implies <$> mkSort s <*> toParsedPattern a <*> toParsedPattern b
+mkConnective Iff s [a,b] =
+  fmap IffF $
+  Kore.Iff <$> mkSort s <*> toParsedPattern a <*> toParsedPattern b
+-- fall-through cases because of wrong argument count
+mkConnective conn _ as = Prelude.Left $ WrongArgCount (show conn) (length as)
+
 
 ------------------------------------------------------------
 -- writing

--- a/kore/src/KoreJson.hs
+++ b/kore/src/KoreJson.hs
@@ -1,0 +1,219 @@
+{-# Language DeriveAnyClass #-}
+{-# Options -Wno-partial-fields #-}
+
+module KoreJson
+  (
+--    KorePattern(..)
+  ) where
+
+import Prelude
+import Data.Aeson as Json
+import Data.Aeson.Encode.Pretty as Json
+import Data.ByteString.Lazy (ByteString)
+import Data.Char (toLower)
+import Data.Either.Extra
+import Data.Text (Text)
+import GHC.Generics
+import Kore.Attribute.Attributes (ParsedPattern)
+import Kore.Internal.Pattern (Pattern)
+
+-- | Json representation of Kore patterns as a Haskell type.
+-- Modeled after kore-syntax.md, merging some of the ML pattern
+-- productions. Cursorily checked to be consistent with Parser.y
+data KorePattern =
+  -- variable pattern
+  -- | element variable with sort
+    KJEVar
+     { name :: Id
+     , sort :: Sort
+     }
+   -- | set variable with sort
+  | KJSVar
+     { name :: Id  -- must start by '@'
+     , sort :: Sort
+     }
+  -- application pattern
+  -- | application pattern (symbol, [arg] )
+  | KJApp
+    { name :: Id   -- may start by a '\\'
+    , sort :: Sort
+    , args :: [KorePattern]
+    }
+  -- | string literal
+  | KJString { value :: Text }
+  -- matching logic pattern
+  -- | Connective (top, bottom, not, and, or, implies, iff)
+  | KJConnective
+    { conn :: Connective
+    , sort :: Sort
+    , args :: [KorePattern] -- arg count checked in conversion to TermLike, not here
+    }
+  -- | Quantifiers: forall, exists
+  | KJQuantifier
+    { quant :: Quant
+    , sort :: Sort
+    , var   :: Id
+    , varSort :: Sort
+    , arg   :: KorePattern
+    }
+  -- | mu, nu
+  | KJFixpoint
+    { combinator :: Fix
+    -- no sort
+    , var :: Id
+    , varSort :: Sort
+    , arg :: KorePattern
+    }
+  -- | ceil, floor, equals, in. NOTE these do not really fit together
+  -- nicely... the two sorts have vastly different meaning
+  | KJPredicate
+    { pred :: Pred
+    , sort :: Sort
+    , sort2 :: Sort
+    , args :: [KorePattern]
+    }
+  -- next, rewrites
+  -- | goes to 'dest' next
+  | KJNext
+    { sort :: Sort
+    , dest :: KorePattern
+    }
+  -- | source rewrites to dest (same sort)
+  | KJRewrites
+    { sort :: Sort
+    , source :: KorePattern
+    , dest :: KorePattern
+   }
+   -- | domain value, a string literal. ???
+  | KJDomainValue { value :: Text}
+  -- syntactic sugar
+  -- | left/right associative or-cascade
+  | KJMultiOr
+    { assoc :: LeftRight
+    , args :: [KorePattern]
+    }
+  -- | left/right associative app pattern
+  | KJMultiApp
+    { assoc :: LeftRight
+    , symbol :: Id  -- may start by a '\\'
+    , sort :: Sort
+    , args :: [KorePattern]
+    }
+  deriving stock (Eq, Show,  Generic)
+
+instance ToJSON KorePattern where
+  toJSON = genericToJSON codecOptions
+
+instance FromJSON KorePattern where
+  parseJSON = genericParseJSON codecOptions
+
+codecOptions :: Json.Options
+codecOptions =
+  Json.defaultOptions
+  { constructorTagModifier
+  , omitNothingFields = True
+  , sumEncoding = ObjectWithSingleField
+  , unwrapUnaryRecords = True
+  , tagSingleConstructors = True
+  , rejectUnknownFields = True
+  }
+  where
+    constructorTagModifier = \case
+      'K':'J':x:rest -> toLower x : rest
+      x:rest         -> toLower x : rest
+      []             -> [] -- can happen on rogue json input
+
+
+newtype Id = Id Text
+  deriving stock (Eq, Show, Generic)
+  deriving newtype (ToJSON, FromJSON)
+
+data Sort =
+  Sort
+    { name :: Id     -- may start by a backslash
+    , args :: [Sort]
+    }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+-- TODO could omit the args field if empty (custom instance)
+
+-- names and arity of known ML connectives
+data Connective =
+  Top
+  | Bottom
+  | Not
+  | And
+  | Or
+  | Implies
+  | Iff
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+-- TODO are these string-tag encoded in the generated instance?
+
+connArity :: Connective -> Int
+connArity Top = 0
+connArity Bottom = 0
+connArity Not = 1
+connArity And = 2
+connArity Or = 2
+connArity Implies = 2
+connArity Iff = 2
+
+--
+data Quant =
+  Forall
+  | Exists
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+data Fix =
+  Mu
+  | Nu
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+data Pred =
+  Ceil
+  | Floor
+  | Equals
+  | In
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+data LeftRight =
+  Left
+  | Right
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+--------------------------------------------------
+-- parsing utilities
+
+-- | low-level: read text into KorePattern
+decodeKoreJson :: ByteString -> Either String KorePattern
+decodeKoreJson = Json.eitherDecode'
+
+
+-- | read text into KorePattern, then check for consistency and
+-- construct a ParsedPattern
+decodePattern :: ByteString -> Either JsonError ParsedPattern
+decodePattern bs =
+  mapLeft ParseError (decodeKoreJson bs) >>= toParsedPattern
+
+-- | Errors relating to the json codec
+data JsonError =
+  -- | Problem reported by json parser
+  ParseError String
+  -- | Inconsistent data parsed. TODO: refine!
+  | KoreError String
+
+toParsedPattern :: KorePattern -> Either JsonError ParsedPattern
+toParsedPattern x = Prelude.Left (KoreError $ "not implemented: " ++ show x)
+
+
+-- | Write a Pattern to a json byte string
+encodePattern :: Pattern a -> ByteString
+encodePattern = Json.encodePretty . fromParsedPattern
+
+fromParsedPattern :: Pattern a -> KorePattern
+fromParsedPattern _ = error "not implemented"

--- a/kore/src/KoreJson.hs
+++ b/kore/src/KoreJson.hs
@@ -1,12 +1,12 @@
-{-# Language DeriveAnyClass #-}
+{-# LANGUAGE DeriveAnyClass #-}
+
 {-# Options -Wno-partial-fields #-}
 
-module KoreJson
-  (
---    KorePattern(..)
-  ) where
+module KoreJson (
+    ) where
 
-import Prelude
+--    KorePattern(..)
+
 import Data.Aeson as Json
 import Data.Aeson.Encode.Pretty as Json
 import Data.ByteString.Lazy (ByteString)
@@ -16,138 +16,145 @@ import Data.Text (Text)
 import GHC.Generics
 import Kore.Attribute.Attributes (ParsedPattern)
 import Kore.Internal.Pattern (Pattern)
+import Prelude
 
--- | Json representation of Kore patterns as a Haskell type.
--- Modeled after kore-syntax.md, merging some of the ML pattern
--- productions. Cursorily checked to be consistent with Parser.y
-data KorePattern =
-  -- variable pattern
-  -- | element variable with sort
-    KJEVar
-     { name :: Id
-     , sort :: Sort
-     }
-   -- | set variable with sort
-  | KJSVar
-     { name :: Id  -- must start by '@'
-     , sort :: Sort
-     }
-  -- application pattern
-  -- | application pattern (symbol, [arg] )
-  | KJApp
-    { name :: Id   -- may start by a '\\'
-    , sort :: Sort
-    , args :: [KorePattern]
-    }
-  -- | string literal
-  | KJString { value :: Text }
-  -- matching logic pattern
-  -- | Connective (top, bottom, not, and, or, implies, iff)
-  | KJConnective
-    { conn :: Connective
-    , sort :: Sort
-    , args :: [KorePattern] -- arg count checked in conversion to TermLike, not here
-    }
-  -- | Quantifiers: forall, exists
-  | KJQuantifier
-    { quant :: Quant
-    , sort :: Sort
-    , var   :: Id
-    , varSort :: Sort
-    , arg   :: KorePattern
-    }
-  -- | mu, nu
-  | KJFixpoint
-    { combinator :: Fix
-    -- no sort
-    , var :: Id
-    , varSort :: Sort
-    , arg :: KorePattern
-    }
-  -- | ceil, floor, equals, in. NOTE these do not really fit together
-  -- nicely... the two sorts have vastly different meaning
-  | KJPredicate
-    { pred :: Pred
-    , sort :: Sort
-    , sort2 :: Sort
-    , args :: [KorePattern]
-    }
-  -- next, rewrites
-  -- | goes to 'dest' next
-  | KJNext
-    { sort :: Sort
-    , dest :: KorePattern
-    }
-  -- | source rewrites to dest (same sort)
-  | KJRewrites
-    { sort :: Sort
-    , source :: KorePattern
-    , dest :: KorePattern
-   }
-   -- | domain value, a string literal. ???
-  | KJDomainValue { value :: Text}
-  -- syntactic sugar
-  -- | left/right associative or-cascade
-  | KJMultiOr
-    { assoc :: LeftRight
-    , args :: [KorePattern]
-    }
-  -- | left/right associative app pattern
-  | KJMultiApp
-    { assoc :: LeftRight
-    , symbol :: Id  -- may start by a '\\'
-    , sort :: Sort
-    , args :: [KorePattern]
-    }
-  deriving stock (Eq, Show,  Generic)
+{- | Json representation of Kore patterns as a Haskell type.
+ Modeled after kore-syntax.md, merging some of the ML pattern
+ productions. Cursorily checked to be consistent with Parser.y
+-}
+data KorePattern
+    = -- variable pattern
+
+      -- | element variable with sort
+      KJEVar
+        { name :: Id
+        , sort :: Sort
+        }
+    | -- | set variable with sort
+      KJSVar
+        { name :: Id -- must start by '@'
+        , sort :: Sort
+        }
+    | -- application pattern
+
+      -- | application pattern (symbol, [arg] )
+      KJApp
+        { name :: Id -- may start by a '\\'
+        , sort :: Sort
+        , args :: [KorePattern]
+        }
+    | -- | string literal
+      KJString {value :: Text}
+    | -- matching logic pattern
+
+      -- | Connective (top, bottom, not, and, or, implies, iff)
+      KJConnective
+        { conn :: Connective
+        , sort :: Sort
+        , args :: [KorePattern] -- arg count checked in conversion to TermLike, not here
+        }
+    | -- | Quantifiers: forall, exists
+      KJQuantifier
+        { quant :: Quant
+        , sort :: Sort
+        , var :: Id
+        , varSort :: Sort
+        , arg :: KorePattern
+        }
+    | -- | mu, nu
+      KJFixpoint
+        { combinator :: Fix
+        , -- no sort
+          var :: Id
+        , varSort :: Sort
+        , arg :: KorePattern
+        }
+    | -- | ceil, floor, equals, in. NOTE these do not really fit together
+      -- nicely... the two sorts have vastly different meaning
+      KJPredicate
+        { pred :: Pred
+        , sort :: Sort
+        , sort2 :: Sort
+        , args :: [KorePattern]
+        }
+    | -- next, rewrites
+
+      -- | goes to 'dest' next
+      KJNext
+        { sort :: Sort
+        , dest :: KorePattern
+        }
+    | -- | source rewrites to dest (same sort)
+      KJRewrites
+        { sort :: Sort
+        , source :: KorePattern
+        , dest :: KorePattern
+        }
+    | -- | domain value, a string literal. ???
+      KJDomainValue {value :: Text}
+    | -- syntactic sugar
+
+      -- | left/right associative or-cascade
+      KJMultiOr
+        { assoc :: LeftRight
+        , args :: [KorePattern]
+        }
+    | -- | left/right associative app pattern
+      KJMultiApp
+        { assoc :: LeftRight
+        , symbol :: Id -- may start by a '\\'
+        , sort :: Sort
+        , args :: [KorePattern]
+        }
+    deriving stock (Eq, Show, Generic)
 
 instance ToJSON KorePattern where
-  toJSON = genericToJSON codecOptions
+    toJSON = genericToJSON codecOptions
 
 instance FromJSON KorePattern where
-  parseJSON = genericParseJSON codecOptions
+    parseJSON = genericParseJSON codecOptions
 
 codecOptions :: Json.Options
 codecOptions =
-  Json.defaultOptions
-  { constructorTagModifier
-  , omitNothingFields = True
-  , sumEncoding = ObjectWithSingleField
-  , unwrapUnaryRecords = True
-  , tagSingleConstructors = True
-  , rejectUnknownFields = True
-  }
+    Json.defaultOptions
+        { constructorTagModifier
+        , omitNothingFields = True
+        , sumEncoding = ObjectWithSingleField
+        , unwrapUnaryRecords = True
+        , tagSingleConstructors = True
+        , rejectUnknownFields = True
+        }
   where
     constructorTagModifier = \case
-      'K':'J':x:rest -> toLower x : rest
-      x:rest         -> toLower x : rest
-      []             -> [] -- can happen on rogue json input
-
+        'K' : 'J' : x : rest -> toLower x : rest
+        x : rest -> toLower x : rest
+        [] -> [] -- can happen on rogue json input
 
 newtype Id = Id Text
-  deriving stock (Eq, Show, Generic)
-  deriving newtype (ToJSON, FromJSON)
+    deriving stock (Eq, Show, Generic)
+    deriving newtype (ToJSON, FromJSON)
 
-data Sort =
-  Sort
-    { name :: Id     -- may start by a backslash
+data Sort = Sort
+    { name :: Id -- may start by a backslash
     , args :: [Sort]
     }
-  deriving stock (Eq, Show, Generic)
-  deriving anyclass (ToJSON, FromJSON)
+    deriving stock (Eq, Show, Generic)
+    deriving anyclass (ToJSON, FromJSON)
+
 -- TODO could omit the args field if empty (custom instance)
 
 -- names and arity of known ML connectives
-data Connective =
-  Top
-  | Bottom
-  | Not
-  | And
-  | Or
-  | Implies
-  | Iff
-  deriving stock (Eq, Show, Generic)
-  deriving anyclass (ToJSON, FromJSON)
+data Connective
+    = Top
+    | Bottom
+    | Not
+    | And
+    | Or
+    | Implies
+    | Iff
+    deriving stock (Eq, Show, Generic)
+    deriving anyclass (ToJSON, FromJSON)
+
 -- TODO are these string-tag encoded in the generated instance?
 
 connArity :: Connective -> Int
@@ -160,31 +167,31 @@ connArity Implies = 2
 connArity Iff = 2
 
 --
-data Quant =
-  Forall
-  | Exists
-  deriving stock (Eq, Show, Generic)
-  deriving anyclass (ToJSON, FromJSON)
+data Quant
+    = Forall
+    | Exists
+    deriving stock (Eq, Show, Generic)
+    deriving anyclass (ToJSON, FromJSON)
 
-data Fix =
-  Mu
-  | Nu
-  deriving stock (Eq, Show, Generic)
-  deriving anyclass (ToJSON, FromJSON)
+data Fix
+    = Mu
+    | Nu
+    deriving stock (Eq, Show, Generic)
+    deriving anyclass (ToJSON, FromJSON)
 
-data Pred =
-  Ceil
-  | Floor
-  | Equals
-  | In
-  deriving stock (Eq, Show, Generic)
-  deriving anyclass (ToJSON, FromJSON)
+data Pred
+    = Ceil
+    | Floor
+    | Equals
+    | In
+    deriving stock (Eq, Show, Generic)
+    deriving anyclass (ToJSON, FromJSON)
 
-data LeftRight =
-  Left
-  | Right
-  deriving stock (Eq, Show, Generic)
-  deriving anyclass (ToJSON, FromJSON)
+data LeftRight
+    = Left
+    | Right
+    deriving stock (Eq, Show, Generic)
+    deriving anyclass (ToJSON, FromJSON)
 
 --------------------------------------------------
 -- parsing utilities
@@ -193,23 +200,22 @@ data LeftRight =
 decodeKoreJson :: ByteString -> Either String KorePattern
 decodeKoreJson = Json.eitherDecode'
 
-
--- | read text into KorePattern, then check for consistency and
--- construct a ParsedPattern
+{- | read text into KorePattern, then check for consistency and
+ construct a ParsedPattern
+-}
 decodePattern :: ByteString -> Either JsonError ParsedPattern
 decodePattern bs =
-  mapLeft ParseError (decodeKoreJson bs) >>= toParsedPattern
+    mapLeft ParseError (decodeKoreJson bs) >>= toParsedPattern
 
 -- | Errors relating to the json codec
-data JsonError =
-  -- | Problem reported by json parser
-  ParseError String
-  -- | Inconsistent data parsed. TODO: refine!
-  | KoreError String
+data JsonError
+    = -- | Problem reported by json parser
+      ParseError String
+    | -- | Inconsistent data parsed. TODO: refine!
+      KoreError String
 
 toParsedPattern :: KorePattern -> Either JsonError ParsedPattern
 toParsedPattern x = Prelude.Left (KoreError $ "not implemented: " ++ show x)
-
 
 -- | Write a Pattern to a json byte string
 encodePattern :: Pattern a -> ByteString

--- a/kore/src/KoreJson.hs
+++ b/kore/src/KoreJson.hs
@@ -90,8 +90,11 @@ data KorePattern
         , source :: KorePattern
         , dest :: KorePattern
         }
-    | -- | domain value, a string literal. ???
-      KJDomainValue {value :: Text}
+    | -- | domain value, a string literal with a sort
+      KJDomainValue
+        { sort :: Sort
+        , value :: Text
+        }
     | -- syntactic sugar
 
       -- | left/right associative or-cascade

--- a/kore/src/KoreJson.hs
+++ b/kore/src/KoreJson.hs
@@ -148,7 +148,12 @@ data Sort = Sort
     }
     | SortVariable Text -- may start by a backslash
     deriving stock (Eq, Show, Generic)
-    deriving anyclass (ToJSON, FromJSON)
+
+instance ToJSON Sort where
+    toJSON = genericToJSON codecOptions { sumEncoding = UntaggedValue }
+
+instance FromJSON Sort where
+    parseJSON = genericParseJSON codecOptions { sumEncoding = UntaggedValue }
 
 -- TODO could omit the args field if empty (custom instance)
 
@@ -249,7 +254,7 @@ toParsedPattern = \case
     koreId (Id name) = Kore.Id name Kore.AstLocationNone
 
     eVarName :: Id -> Either JsonError (SomeVariableName VariableName)
-    eVarName = pure . ElementVariableName . flip VariableName Nothing
+    eVarName = pure . SomeVariableNameElement . ElementVariableName . flip VariableName Nothing . koreId
     -- TODO check well-formed (initial letter, char. set)
     -- FIXME do we need to read a numeric suffix? (-> Parser.y:getVariableName)
 

--- a/kore/src/KoreJson.hs
+++ b/kore/src/KoreJson.hs
@@ -4,7 +4,7 @@
 {-# Options -Wno-partial-fields #-}
 
 module KoreJson (
-  ) where
+    ) where
 
 import Data.Aeson as Json
 import Data.Aeson.Encode.Pretty as Json
@@ -25,7 +25,7 @@ import Kore.Sort qualified as Kore
 import Kore.Syntax qualified as Kore
 import Kore.Syntax.Variable (ElementVariableName (..), SetVariableName (..), SomeVariableName (..), Variable (..), VariableName (..))
 import Prelude.Kore hiding (Left, Right, pred)
-import Prelude.Kore qualified as Prelude (Either(..))
+import Prelude.Kore qualified as Prelude (Either (..))
 
 {- | Json representation of Kore patterns as a Haskell type.
  Modeled after kore-syntax.md, merging some of the ML pattern
@@ -112,8 +112,9 @@ data KorePattern
         , sort :: Sort
         , args :: [KorePattern]
         }
-        -- TODO textual parser also understands And/Implies/Iff
-    | -- | left/right associative app pattern
+    | -- TODO textual parser also understands And/Implies/Iff
+
+      -- | left/right associative app pattern
       KJMultiApp
         { assoc :: LeftRight
         , symbol :: Id -- may start by a '\\'
@@ -244,45 +245,50 @@ toParsedPattern = \case
         embedParsedPattern . StringLiteralF . Const <$> pure (Kore.StringLiteral t)
     KJConnective c s as ->
         embedParsedPattern <$> mkConnective c s as
-    KJQuantifier {quant = Forall, sort, var, varSort, arg} ->
-        fmap (embedParsedPattern . ForallF) $ Kore.Forall
-            <$> mkSort sort
-            <*> (Variable (ElementVariableName (koreVar var)) <$> mkSort varSort)
-            <*> toParsedPattern arg
-    KJQuantifier {quant = Exists, sort, var, varSort, arg} ->
-        fmap (embedParsedPattern . ExistsF) $ Kore.Exists
-            <$> mkSort sort
-            <*> (Variable (ElementVariableName (koreVar var)) <$> mkSort varSort)
-            <*> toParsedPattern arg
-    KJFixpoint {combinator = Mu, var, varSort, arg} ->
-        fmap (embedParsedPattern . MuF) $ Kore.Mu
-            <$> (Variable (SetVariableName (koreVar var)) <$> mkSort varSort)
-            <*> toParsedPattern arg
-    KJFixpoint {combinator = Nu, var, varSort, arg} ->
-        fmap (embedParsedPattern . NuF) $ Kore.Nu
-            <$> (Variable (SetVariableName (koreVar var)) <$> mkSort varSort)
-            <*> toParsedPattern arg
-    KJPredicate {pred, sort, sort2, args} ->
+    KJQuantifier{quant = Forall, sort, var, varSort, arg} ->
+        fmap (embedParsedPattern . ForallF) $
+            Kore.Forall
+                <$> mkSort sort
+                <*> (Variable (ElementVariableName (koreVar var)) <$> mkSort varSort)
+                <*> toParsedPattern arg
+    KJQuantifier{quant = Exists, sort, var, varSort, arg} ->
+        fmap (embedParsedPattern . ExistsF) $
+            Kore.Exists
+                <$> mkSort sort
+                <*> (Variable (ElementVariableName (koreVar var)) <$> mkSort varSort)
+                <*> toParsedPattern arg
+    KJFixpoint{combinator = Mu, var, varSort, arg} ->
+        fmap (embedParsedPattern . MuF) $
+            Kore.Mu
+                <$> (Variable (SetVariableName (koreVar var)) <$> mkSort varSort)
+                <*> toParsedPattern arg
+    KJFixpoint{combinator = Nu, var, varSort, arg} ->
+        fmap (embedParsedPattern . NuF) $
+            Kore.Nu
+                <$> (Variable (SetVariableName (koreVar var)) <$> mkSort varSort)
+                <*> toParsedPattern arg
+    KJPredicate{pred, sort, sort2, args} ->
         embedParsedPattern <$> mkPredicate pred sort sort2 args
-    KJNext { sort, dest} ->
-        fmap (embedParsedPattern . NextF) $ Kore.Next
-            <$> mkSort sort
-            <*> toParsedPattern dest
-    KJRewrites { sort, source, dest} ->
-        fmap (embedParsedPattern . RewritesF) $ Kore.Rewrites
-            <$> mkSort sort
-            <*> toParsedPattern source
-            <*> toParsedPattern dest
-    KJDomainValue { sort, value} ->
-        fmap (embedParsedPattern . DomainValueF) $ Kore.DomainValue
-            <$> mkSort sort
-            <*> toParsedPattern (KJString value)
-    KJMultiOr {assoc, sort, args} ->
-      withAssoc assoc <$> mkOr sort <*> traverse toParsedPattern args
-
-    KJMultiApp { assoc, symbol, sorts, args} ->
-      withAssoc assoc <$> mkF symbol sorts <*> traverse toParsedPattern args
-
+    KJNext{sort, dest} ->
+        fmap (embedParsedPattern . NextF) $
+            Kore.Next
+                <$> mkSort sort
+                <*> toParsedPattern dest
+    KJRewrites{sort, source, dest} ->
+        fmap (embedParsedPattern . RewritesF) $
+            Kore.Rewrites
+                <$> mkSort sort
+                <*> toParsedPattern source
+                <*> toParsedPattern dest
+    KJDomainValue{sort, value} ->
+        fmap (embedParsedPattern . DomainValueF) $
+            Kore.DomainValue
+                <$> mkSort sort
+                <*> toParsedPattern (KJString value)
+    KJMultiOr{assoc, sort, args} ->
+        withAssoc assoc <$> mkOr sort <*> traverse toParsedPattern args
+    KJMultiApp{assoc, symbol, sorts, args} ->
+        withAssoc assoc <$> mkF symbol sorts <*> traverse toParsedPattern args
   where
     embedVar ::
         (VariableName -> SomeVariableName VariableName) ->
@@ -290,7 +296,7 @@ toParsedPattern = \case
         Sort ->
         Either JsonError (Variable (SomeVariableName VariableName))
     embedVar cons n s =
-            Variable <$> mkVarName cons n <*> mkSort s
+        Variable <$> mkVarName cons n <*> mkSort s
 
     mkVarName ::
         (VariableName -> SomeVariableName VariableName) ->
@@ -307,19 +313,20 @@ toParsedPattern = \case
 
     mkOr :: Sort -> Either JsonError (ParsedPattern -> ParsedPattern -> ParsedPattern)
     mkOr s = do
-      sort <- mkSort s
-      pure (\a b -> embedParsedPattern $ OrF $ Kore.Or sort a b)
+        sort <- mkSort s
+        pure (\a b -> embedParsedPattern $ OrF $ Kore.Or sort a b)
 
     mkF :: Id -> [Sort] -> Either JsonError (ParsedPattern -> ParsedPattern -> ParsedPattern)
     mkF n sorts = do
-      sym <- toSymbol n sorts -- TODO should maybe check that length ss == 2?
-      pure (\a b -> embedParsedPattern $ ApplicationF $ Kore.Application sym [a, b])
+        sym <- toSymbol n sorts -- TODO should maybe check that length ss == 2?
+        pure (\a b -> embedParsedPattern $ ApplicationF $ Kore.Application sym [a, b])
 
 koreId :: Id -> Kore.Id
 koreId (Id name) = Kore.Id name Kore.AstLocationNone
 
 koreVar :: Id -> Kore.VariableName
 koreVar = flip VariableName Nothing . koreId
+
 -- TODO check well-formed (initial letter, char. set)
 -- FIXME do we need to read a numeric suffix? (-> Parser.y:getVariableName)
 
@@ -356,7 +363,7 @@ mkConnective Iff s [a, b] =
         Kore.Iff <$> mkSort s <*> toParsedPattern a <*> toParsedPattern b
 -- fall-through cases because of wrong argument count
 mkConnective conn _ as =
-  Prelude.Left $ WrongArgCount (show conn) (length as)
+    Prelude.Left $ WrongArgCount (show conn) (length as)
 
 mkPredicate ::
     Pred ->
@@ -365,20 +372,19 @@ mkPredicate ::
     [KorePattern] ->
     Either JsonError (PatternF VariableName ParsedPattern)
 mkPredicate Ceil s s2 [a] =
-  fmap CeilF $
-      Kore.Ceil <$> mkSort s <*> mkSort s2 <*> toParsedPattern a
+    fmap CeilF $
+        Kore.Ceil <$> mkSort s <*> mkSort s2 <*> toParsedPattern a
 mkPredicate Floor s s2 [a] =
-  fmap FloorF $
-      Kore.Floor <$> mkSort s <*> mkSort s2 <*> toParsedPattern a
+    fmap FloorF $
+        Kore.Floor <$> mkSort s <*> mkSort s2 <*> toParsedPattern a
 mkPredicate Equals s s2 [a, b] =
-  fmap EqualsF $
-      Kore.Equals <$> mkSort s <*> mkSort s2 <*> toParsedPattern a <*> toParsedPattern b
+    fmap EqualsF $
+        Kore.Equals <$> mkSort s <*> mkSort s2 <*> toParsedPattern a <*> toParsedPattern b
 mkPredicate In s s2 [a, b] =
-  fmap InF $
-      Kore.In <$> mkSort s <*> mkSort s2 <*> toParsedPattern a <*> toParsedPattern b
+    fmap InF $
+        Kore.In <$> mkSort s <*> mkSort s2 <*> toParsedPattern a <*> toParsedPattern b
 mkPredicate pred _ _ as =
-  Prelude.Left $ WrongArgCount (show pred) (length as)
-
+    Prelude.Left $ WrongArgCount (show pred) (length as)
 
 ------------------------------------------------------------
 -- writing

--- a/kore/src/KoreJson.hs
+++ b/kore/src/KoreJson.hs
@@ -168,10 +168,10 @@ data Connective
     | Or
     | Implies
     | Iff
-    deriving stock (Eq, Show, Generic)
+    deriving stock (Eq, Show, Generic, Enum, Bounded)
     deriving anyclass (ToJSON, FromJSON)
 
--- TODO are these string-tag encoded in the generated instance?
+-- string-tag encoded in the generated instance. Should they be lower-case?
 
 connArity :: Connective -> Int
 connArity Top = 0
@@ -186,13 +186,13 @@ connArity Iff = 2
 data Quant
     = Forall
     | Exists
-    deriving stock (Eq, Show, Generic)
+    deriving stock (Eq, Show, Generic, Enum, Bounded)
     deriving anyclass (ToJSON, FromJSON)
 
 data Fix
     = Mu
     | Nu
-    deriving stock (Eq, Show, Generic)
+    deriving stock (Eq, Show, Generic, Enum, Bounded)
     deriving anyclass (ToJSON, FromJSON)
 
 data Pred
@@ -200,13 +200,13 @@ data Pred
     | Floor
     | Equals
     | In
-    deriving stock (Eq, Show, Generic)
+    deriving stock (Eq, Show, Generic, Enum, Bounded)
     deriving anyclass (ToJSON, FromJSON)
 
 data LeftRight
     = Left
     | Right
-    deriving stock (Eq, Show, Generic)
+    deriving stock (Eq, Show, Generic, Enum, Bounded)
     deriving anyclass (ToJSON, FromJSON)
 
 ------------------------------------------------------------

--- a/nix/kore.nix.d/kore.nix
+++ b/nix/kore.nix.d/kore.nix
@@ -36,6 +36,7 @@
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."adjunctions" or (errorHandler.buildDepError "adjunctions"))
           (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+          (hsPkgs."aeson-pretty" or (errorHandler.buildDepError "aeson-pretty"))
           (hsPkgs."array" or (errorHandler.buildDepError "array"))
           (hsPkgs."async" or (errorHandler.buildDepError "async"))
           (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
@@ -102,6 +103,7 @@
           ];
         buildable = true;
         modules = [
+          "KoreJson"
           "Changed"
           "Control/Monad/Counter"
           "Data/Graph/TopologicalSort"
@@ -641,6 +643,7 @@
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."adjunctions" or (errorHandler.buildDepError "adjunctions"))
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."aeson-pretty" or (errorHandler.buildDepError "aeson-pretty"))
             (hsPkgs."array" or (errorHandler.buildDepError "array"))
             (hsPkgs."async" or (errorHandler.buildDepError "async"))
             (hsPkgs."binary" or (errorHandler.buildDepError "binary"))

--- a/notes-json-kore.org
+++ b/notes-json-kore.org
@@ -80,7 +80,7 @@ The CofreeF structure makes the encoding unsuitable for external consumption.
 
 ** IN_PROGRESS model textual kore in Haskell data types (follow Ana's general model)
 *** DONE Haskell data types to model a simple json format for textual kore
-*** write a Json schema along the textual core specification
+*** DONE write a Json schema along the textual core specification
 
 
 *** write a conversion to/from internal types. "to" is probably incomplete

--- a/notes-json-kore.org
+++ b/notes-json-kore.org
@@ -1,0 +1,96 @@
+#+Title: JSON format to represent Kore terms
+
+* Purpose and goals:
+** exchange data between pyk, front-end, llvm-backend, hs-backend
+  - a single format to exchange data between all components
+  - scenario for the current (first) use case:
+    1) HS backend server initialises
+       - definitions are loaded (server state)
+       - server is ready to use
+    2) Pyk makes a request, e.g., "simplify: <kore-term>" or
+       "run-rewrite: <kore-term>"
+    3) HS backend responds with simplified/rewritten term
+  - Pyk tracks all "current state" of the particular term,
+    HS Backend state is only the general model loaded/kompiled
+** Statements (from ticket)
+- should be oriented on the textual kore format,
+  https://github.com/runtimeverification/haskell-backend/blob/master/docs/kore-syntax.md
+- should strive for "reusing code" (example: and/or representation as
+  simple "connectives" rather than their own AST nodes)
+- should not carry any artefacts for a particular component's purpose
+  - *However*, how to convert from json to internal representations?
+    There will be information missing that cannot be easily added.
+
+* Approaches
+1) use Haskell data types as-is, with From/ToJSON instances (maybe
+   tweaked)
+   - noisy if all data is kept
+   - lossy if data is dropped in ToJSON (see below)
+2) separate format/data types oriented on textual format
+   - cannot construct attributes and (other) metadata present in HS
+     backend only
+     - What is that metadata? Can it be computed?
+
+* Possible Work
+** OBSOLETE hack in first version, instances on the existing types
+*** DONE Starting in TermLikeF, notes as I go:
+- can simply use deriving anyclass (ToJSON, FromJSON)
+- instances can be customised using `genericToJSON/genericParseJSON`
+  which take _Options_ to modify the encoding
+- Id is a very basic type used in many others.
+  - stores an ASTLocation. Should be omitted, supplying manual
+    instance (following other instances, supplies AstLocationNone)
+- _TermLikeF_ contains a few cases holding _InternalAc_ (Map, Set),
+  whose JSON instances recurse to _Symbol_. Symbols have a list of
+  attributes stored with them (e.g., whether this symbol is hooked to
+  an internal implementation, whether it is a function, etc.).
+  - these attributes cannot be reconstructed at all, nor should we
+    expect anything to work without them.
+  - Symbol-containing data cannot be represented in JSON.
+  - *InternalAc stubbed out for the time being*
+- Another complex case stepping out of Syntax: *Inj*, making use of
+  _Symbol_ attributes (but only attributes) again. *Stubbed out*
+- One case of _TermLikeF_ recurses into _TermLike VariableName_
+  (ApplyAliasF), *stubbing out CofreeF*
+  - which is actually quite besides the point! Better implement it
+    properly.
+  - TermLike = _CofreeF (TermLikeF v) (TermAttributes v) (TermLike v)_
+    so it is recursively using _TermLike v_ for _child_ in _TermLikeF_
+  - Attributes are less interesting, though, so _tailF_ to get the
+    _TermLikeF v (TermLike v)_ out (and JSON-print it).
+
+- another case using _Symbol_, ApplySymbolF, *stubbing out _Symbol_*
+
+**** This approach was discarded as things become too entangled with internals
+The CofreeF structure makes the encoding unsuitable for external consumption.
+*** and a way to get a term out. Repl to dump the term as json
+ - from repl/Main.hs
+ - via Kore.Exec, and Kore.Repl
+ - to Kore.Repl.Interpreter's _replInterpreter_ which
+   - runs one command
+   - mutating the interpreter state _ReplState_
+ - inside Kore.Repl.Interpreter, we find that it operates on an _OrPattern_
+   - which is a kind of _Pattern_
+   - which is a _Conditional _ (TermLike VariableName)_
+ - Meanwhile, after talking to Sam:
+   - the json codec should replace a /parsing/ step in the Json-RPC server
+   - parseKorePattern :: Text -> Parser ParsedPattern
+
+
+
+** IN_PROGRESS model textual kore in Haskell data types (follow Ana's general model)
+*** write a Json schema along the textual core specification
+
+
+
+*** write a conversion to/from internal types. "to" is probably incomplete
+- Kore.Attribute.Attributes, Kore.Internal.Pattern
+  #+BEGIN_EXAMPLE
+  type ParsedPattern = Pattern VariableName Attribute.Null         -- Kore.Attribute.Attributes
+  type Pattern variable = Conditional variable (TermLike variable) -- Kore.Internal.Pattern
+  #+END_EXAMPLE
+- a _Conditional v t_ (Kore.Internal.Conditional) has
+  - term (:: t),
+  - predicate (another Cofree thing) and substitutions working with v
+
+*** implement a way to get a term out. As above, Repl, or (first) a round-trip test.

--- a/notes-json-kore.org
+++ b/notes-json-kore.org
@@ -79,8 +79,8 @@ The CofreeF structure makes the encoding unsuitable for external consumption.
 
 
 ** IN_PROGRESS model textual kore in Haskell data types (follow Ana's general model)
+*** DONE Haskell data types to model a simple json format for textual kore
 *** write a Json schema along the textual core specification
-
 
 
 *** write a conversion to/from internal types. "to" is probably incomplete

--- a/src/main/json/kore-schema.json
+++ b/src/main/json/kore-schema.json
@@ -1,0 +1,355 @@
+{
+    "type": "object",
+
+    "oneOf": [
+        { "properties": { "eVar": { "$ref": "#/definitions/KoreJSONEVar" }},
+	  "required": ["eVar"]
+        },
+        { "properties": { "sVar": { "$ref": "#/definitions/KoreJSONSVar" }},
+	  "required": ["sVar"]
+        },
+        { "properties": { "app": { "$ref": "#/definitions/KoreJSONApp" }},
+	  "required": ["app"]
+        },
+        { "properties": { "string": { "type": "string" }},
+          "required": ["string"]
+        },
+        { "properties": { "connective": { "$ref": "#/definitions/KoreJSONConnective" }},
+	  "required": ["connective"]
+        },
+        { "properties": { "quantifier": { "$ref": "#/definitions/KoreJSONQuantifier" }},
+	  "required": ["quantifier"]
+        },
+        { "properties": { "fixpoint": { "$ref": "#/definitions/KoreJSONFixpoint" }},
+	  "required": ["fixpoint"]
+        },
+        { "properties": { "predicate": { "$ref": "#/definitions/KoreJSONPredicate" }},
+	  "required": ["predicate"]
+        },
+        { "properties": { "next": { "$ref": "#/definitions/KoreJSONNext" }},
+	  "required": ["next"]
+        },
+        { "properties": { "rewrites": { "$ref": "#/definitions/KoreJSONRewrites" }},
+	  "required": ["rewrites"]
+        },
+        { "properties": { "domainValue": { "$ref": "#/definitions/KoreJSONDomainValue" }},
+	  "required": ["domainValue"]
+        },
+        { "properties": { "multiOr": { "$ref": "#/definitions/KoreJSONMultiOr" }},
+	  "required": ["multiOr"]
+        },
+        { "properties": { "multiApp": { "$ref": "#/definitions/KoreJSONMultiApp" }},
+	  "required": ["multiApp"]
+        }
+    ],
+
+    "definitions": {
+        "KoreJSONEVar": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "sort": {
+                    "$ref": "#/definitions/Sort"
+                }
+            },
+            "required": [
+                "name",
+                "sort"
+            ],
+            "title": "EVar"
+        },
+
+        "KoreJSONSVar": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "sort": {
+                    "$ref": "#/definitions/Sort"
+                }
+            },
+            "required": [
+                "name",
+                "sort"
+            ],
+            "title": "SVar"
+        },
+
+        "KoreJSONApp": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "sort": {
+                    "$ref": "#/definitions/Sort"
+                },
+                "args": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#"
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "sort",
+                "args"
+            ],
+            "title": "App"
+        },
+
+        "KoreJSONString": {
+            "type": "string",
+            "title": "String"
+        },
+
+        "KoreJSONConnective": {
+            "type": "object",
+            "properties": {
+                "conn": {
+                    "type": "string",
+                    "enum": [ "Top", "Bottom", "Not", "And", "Or", 		"Implies", "Iff" ]
+                },
+                "sort": {
+                    "$ref": "#/definitions/Sort"
+                },
+                "args": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#"
+                    }
+                }
+            },
+            "required": [
+                "args",
+                "conn",
+                "sort"
+            ],
+            "title": "Connective"
+        },
+
+        "KoreJSONQuantifier": {
+            "type": "object",
+            "properties": {
+                "quant": {
+                    "type": "string",
+                    "enum": [ "Forall", "Exists" ]
+                },
+                "sort": {
+                    "$ref": "#/definitions/Sort"
+                },
+                "var": {
+                    "type": "string"
+                },
+                "varSort": {
+                    "$ref": "#/definitions/Sort"
+                },
+                "arg": {
+                    "$ref": "#"
+                }
+            },
+            "required": [
+                "quant",
+                "sort",
+                "var",
+                "varSort",
+                "arg"
+            ],
+            "title": "Quantifier"
+        },
+
+        "KoreJSONFixpoint": {
+            "type": "object",
+            "properties": {
+                "combinator": {
+                    "type": "string",
+                    "enum": [ "Mu", "Nu" ]
+                },
+                "var": {
+                    "type": "string"
+                },
+                "varSort": {
+                    "$ref": "#/definitions/Sort"
+                },
+                "arg": {
+                    "$ref": "#"
+                }
+            },
+            "required": [
+                "combinator",
+                "var",
+                "varSort",
+                "arg"
+            ],
+            "title": "Fixpoint"
+        },
+
+        "KoreJSONPredicate": {
+            "type": "object",
+            "properties": {
+                "pred": {
+                    "type": "string",
+                    "enum": [ "Ceil", "Floor", "Equals", "In" ]
+                },
+                "sort": {
+                    "$ref": "#/definitions/Sort"
+                },
+                "sort2": {
+                    "$ref": "#/definitions/Sort"
+                },
+                "args": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#"
+                    }
+                }
+            },
+            "required": [
+                "pred",
+                "sort",
+                "sort2",
+                "args"
+            ],
+            "title": "Fixpoint"
+        },
+
+        "KoreJSONNext": {
+            "type": "object",
+            "properties": {
+                "sort": {
+                    "$ref": "#/definitions/Sort"
+                },
+                "dest": {
+                    "$ref": "#"
+                }
+            },
+            "required": [
+                "sort",
+                "dest"
+            ],
+            "title": "Next"
+        },
+
+        "KoreJSONRewrites": {
+            "type": "object",
+            "properties": {
+                "sort": {
+                    "$ref": "#/definitions/Sort"
+                },
+                "source": {
+                    "$ref": "#"
+                },
+                "dest": {
+                    "$ref": "#"
+                }
+            },
+            "required": [
+                "sort",
+                "source",
+                "dest"
+            ],
+            "title": "Rewrites"
+        },
+
+        "KoreJSONDomainValue": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "sort": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "sort",
+                "value"
+            ],
+            "title": "DomainValue"
+        },
+
+        "KoreJSONMultiOr": {
+            "type": "object",
+            "properties": {
+                "assoc": {
+                    "type": "string",
+                    "enum": [ "Left", "Right" ]
+                },
+                "args": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#"
+                    }
+                }
+            },
+            "required": [
+                "assoc",
+                "args"
+            ],
+            "title": "MultiOr"
+        },
+
+        "KoreJSONMultiApp": {
+            "type": "object",
+            "properties": {
+                "assoc": {
+                    "type": "string",
+                    "enum": [ "Left", "Right" ]
+                },
+                "symbol": {
+                    "type": "string"
+                },
+                "sort": {
+                    "$ref": "#/definitions/Sort"
+                },
+                "args": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#"
+                    }
+                }
+            },
+            "required": [
+                "assoc",
+                "symbol",
+                "sort",
+                "args"
+            ],
+            "title": "MultiApp"
+        },
+
+        "Sort": {
+            "oneOf": [
+              { "$ref": "#/definitions/SortApp" },
+              { "$ref": "#/definitions/SortVar" }
+            ]
+        },
+
+        "SortApp": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "args": {
+                    "type": "array",
+                    "items": {}
+                }
+            },
+            "required": [
+                "args",
+                "name"
+            ],
+            "title": "Sort"
+        },
+
+        "SortVar": {
+            "type": "string"
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2626 

### Scope:
* Defines a json-schema for kore patterns;
* defines simple data types representing the json format for Kore patterns;
* provides conversion functions `KoreJson -> ParsedPattern` and `Pattern VariableName ann -> KoreJson`;
* json parsing and marshaling are automatic, providing
  `ByteString -> ParsedPattern` and `Pattern VariableName ann -> ByteString`

### Estimate:
2 more dev.days 

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
