### PR TITLE
Fix hlint breakage, pin version in github workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,6 +209,8 @@ jobs:
   hlint:
     name: 'HLint'
     runs-on: ubuntu-latest
+    env:
+      hlint_version: "3.4.1"
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -217,7 +219,7 @@ jobs:
           submodules: recursive
 
       - name: Run hlint
-        run: curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/run.sh | sh -s kore -j
+        run: curl -sSL https://raw.github.com/ndmitchell/hlint/v${{ env.hlint_version }}/misc/run.sh | sh -s kore -j
 
   performance:
     needs: [nix-build]

--- a/kore/app/repl/Main.hs
+++ b/kore/app/repl/Main.hs
@@ -189,9 +189,8 @@ main = do
             (Just envName)
             (parseKoreReplOptions startTime)
             parserInfoModifiers
-    case localOptions options of
-        Nothing -> pure ()
-        Just koreReplOptions -> mainWithOptions koreReplOptions
+    maybe (pure ()) mainWithOptions $
+        localOptions options
 
 mainWithOptions :: LocalOptions KoreReplOptions -> IO ()
 mainWithOptions LocalOptions{execOptions, simplifierx} = do

--- a/kore/app/repl/Main.hs
+++ b/kore/app/repl/Main.hs
@@ -11,6 +11,7 @@ import Control.Monad.Catch (
     handle,
     throwM,
  )
+import Control.Monad.Extra (whenJust)
 import GlobalMain
 import Kore.BugReport
 import Kore.Exec (
@@ -189,8 +190,7 @@ main = do
             (Just envName)
             (parseKoreReplOptions startTime)
             parserInfoModifiers
-    maybe (pure ()) mainWithOptions $
-        localOptions options
+    whenJust (localOptions options) mainWithOptions
 
 mainWithOptions :: LocalOptions KoreReplOptions -> IO ()
 mainWithOptions LocalOptions{execOptions, simplifierx} = do

--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -650,6 +650,7 @@ executable kore-repl
   build-depends: kore
   build-depends: clock >=0.8
   build-depends: exceptions >=0.10
+  build-depends: extra >= 1.7
   build-depends: optparse-applicative >=0.14
 
 executable kore-match-disjunction

--- a/kore/src/Kore/Repl/Parser.hs
+++ b/kore/src/Kore/Repl/Parser.hs
@@ -418,9 +418,8 @@ alias = do
     literal "alias"
     name <- word
     arguments <- many $ wordWithout "="
-    if nub arguments /= arguments
-        then customFailure "Error when parsing alias: duplicate argument name."
-        else pure ()
+    when (nub arguments /= arguments) $
+        customFailure "Error when parsing alias: duplicate argument name."
     literal "="
     command <- some (noneOf ['\n'])
     return . Alias $ AliasDefinition{name, arguments, command}

--- a/nix/kore-ghc8107.nix.d/kore.nix
+++ b/nix/kore-ghc8107.nix.d/kore.nix
@@ -582,6 +582,7 @@
             (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
             (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
             (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
+            (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
             ];
           buildable = true;


### PR DESCRIPTION
Fixes current build breakage

### Scope:

Adjusts code that latest `hlint` complains about, fixes `hlint` version to 3.4.1 in the github workflow.

### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
