### PR TITLE
Unify SMT and NoSMT; kill MonadExecute

### DIFF
--- a/kore/app/share/GlobalMain.hs
+++ b/kore/app/share/GlobalMain.hs
@@ -47,9 +47,6 @@ import Control.Lens (
  )
 import Control.Lens qualified as Lens
 import Control.Monad qualified as Monad
-import Control.Monad.Catch (
-    MonadMask,
- )
 import Data.Binary qualified as Binary
 import Data.ByteString.Lazy qualified as ByteString
 import Data.Compact (
@@ -189,11 +186,8 @@ import Paths_kore qualified as MetaData (
  )
 import Prelude.Kore
 import Pretty qualified as KorePretty
-import Prof (
-    MonadProf,
- )
 import SMT (
-    MonadSMT,
+    SMT,
  )
 import SMT qualified
 import System.Clock (
@@ -556,14 +550,6 @@ mainParse parser fileName = do
         Left err -> errorParse err
         Right definition -> return definition
 
-type MonadExecute exe =
-    ( MonadMask exe
-    , MonadIO exe
-    , MonadSMT exe
-    , MonadProf exe
-    , WithLog LogMessage exe
-    )
-
 -- | Run the worker in the context of the main module.
 execute ::
     forall r.
@@ -572,7 +558,7 @@ execute ::
     SmtMetadataTools StepperAttributes ->
     [SentenceAxiom (TermLike VariableName)] ->
     -- | Worker
-    (forall exe. MonadExecute exe => exe r) ->
+    SMT r ->
     Main r
 execute options metadataTools lemmas worker =
     clockSomethingIO "Executing" $

--- a/kore/src/Kore/Rewrite/SMT/Lemma.hs
+++ b/kore/src/Kore/Rewrite/SMT/Lemma.hs
@@ -51,6 +51,8 @@ import SMT (
     MonadSMT (..),
     Result (..),
     SExpr (..),
+    assert,
+    check,
  )
 
 getSMTLemmas ::

--- a/kore/src/Kore/Simplify/Data.hs
+++ b/kore/src/Kore/Simplify/Data.hs
@@ -91,7 +91,7 @@ import Prelude.Kore
 import Pretty qualified
 import Prof
 import SMT (
-    SMT (..),
+    SMT,
  )
 
 -- * Simplifier

--- a/kore/src/SMT.hs
+++ b/kore/src/SMT.hs
@@ -7,11 +7,21 @@ Maintainer  : thomas.tuegel@runtimeverification.com
 -}
 module SMT (
     SMT,
-    getSMT,
+    runNoSMT,
+    runSMT,
     Solver,
     stopSolver,
-    runSMT,
     MonadSMT (..),
+    declare,
+    declareFun,
+    declareSort,
+    declareDatatype,
+    declareDatatypes,
+    assert,
+    check,
+    ackCommand,
+    loadFile,
+    reinit,
     Config (..),
     defaultConfig,
     TimeOut (..),
@@ -30,8 +40,6 @@ module SMT (
     declareFun_,
     setInfo,
     setOption,
-    NoSMT (..),
-    runNoSMT,
     SimpleSMT.SolverException (..),
 
     -- * Expressions
@@ -60,9 +68,6 @@ import Control.Exception (
     SomeException,
  )
 import Control.Lens qualified as Lens
-import Control.Monad (
-    join,
- )
 import Control.Monad qualified as Monad
 import Control.Monad.Catch (
     MonadCatch,
@@ -76,8 +81,7 @@ import Control.Monad.RWS.Strict (
     RWST,
  )
 import Control.Monad.Reader (
-    ReaderT,
-    runReaderT,
+    ReaderT (ReaderT),
  )
 import Control.Monad.Reader qualified as Reader
 import Control.Monad.State.Lazy qualified as State.Lazy
@@ -101,10 +105,8 @@ import Data.Text (
 import GHC.Generics qualified as GHC
 import Kore.Log.WarnRestartSolver (warnRestartSolver)
 import Log (
-    LogAction,
     LoggerT,
     MonadLog (..),
-    SomeEntry,
  )
 import Log qualified
 import Logic (
@@ -149,190 +151,120 @@ class Monad m => MonadSMT m where
     withSolver action = Morph.hoist withSolver action
     {-# INLINE withSolver #-}
 
-    -- | Declares a general SExpr to SMT.
-    declare :: Text -> SExpr -> m SExpr
-    default declare ::
-        (Trans.MonadTrans t, MonadSMT n, m ~ t n) =>
-        Text ->
-        SExpr ->
-        m SExpr
-    declare text = Trans.lift . declare text
-    {-# INLINE declare #-}
+    -- | Lift an SMT action.
+    liftSMT :: SMT a -> m a
+    default liftSMT ::
+        ( MonadTrans t
+        , MonadSMT n
+        , m ~ t n
+        ) =>
+        SMT a ->
+        m a
+    liftSMT = Trans.lift . liftSMT
 
-    -- | Declares a function symbol to SMT.
-    declareFun :: SmtFunctionDeclaration -> m SExpr
-    default declareFun ::
-        (Trans.MonadTrans t, MonadSMT n, m ~ t n) =>
-        SmtFunctionDeclaration ->
-        m SExpr
-    declareFun = Trans.lift . declareFun
-    {-# INLINE declareFun #-}
+-- | Declares a general SExpr to SMT.
+declare :: MonadSMT m => Text -> SExpr -> m SExpr
+declare text = liftSMT . declareSMT text
+{-# INLINE declare #-}
 
-    -- | Declares a sort to SMT.
-    declareSort :: SmtSortDeclaration -> m SExpr
-    default declareSort ::
-        (Trans.MonadTrans t, MonadSMT n, m ~ t n) =>
-        SmtSortDeclaration ->
-        m SExpr
-    declareSort = Trans.lift . declareSort
-    {-# INLINE declareSort #-}
+-- | Declares a function symbol to SMT.
+declareFun :: MonadSMT m => SmtFunctionDeclaration -> m SExpr
+declareFun = liftSMT . declareFunSMT
+{-# INLINE declareFun #-}
 
-    -- | Declares a constructor-based sort to SMT.
-    declareDatatype :: SmtDataTypeDeclaration -> m ()
-    default declareDatatype ::
-        (Trans.MonadTrans t, MonadSMT n, m ~ t n) =>
-        SmtDataTypeDeclaration ->
-        m ()
-    declareDatatype = Trans.lift . declareDatatype
-    {-# INLINE declareDatatype #-}
+-- | Declares a sort to SMT.
+declareSort :: MonadSMT m => SmtSortDeclaration -> m SExpr
+declareSort = liftSMT . declareSortSMT
+{-# INLINE declareSort #-}
 
-    -- | Declares a constructor-based sort to SMT.
-    declareDatatypes :: [SmtDataTypeDeclaration] -> m ()
-    default declareDatatypes ::
-        (Trans.MonadTrans t, MonadSMT n, m ~ t n) =>
-        [SmtDataTypeDeclaration] ->
-        m ()
-    declareDatatypes = Trans.lift . declareDatatypes
-    {-# INLINE declareDatatypes #-}
+-- | Declares a constructor-based sort to SMT.
+declareDatatype :: MonadSMT m => SmtDataTypeDeclaration -> m ()
+declareDatatype = liftSMT . declareDatatypeSMT
+{-# INLINE declareDatatype #-}
 
-    -- | Assume a fact.
-    assert :: SExpr -> m ()
-    default assert ::
-        (Trans.MonadTrans t, MonadSMT n, m ~ t n) =>
-        SExpr ->
-        m ()
-    assert = Trans.lift . assert
-    {-# INLINE assert #-}
+-- | Declares a constructor-based sort to SMT.
+declareDatatypes :: MonadSMT m => [SmtDataTypeDeclaration] -> m ()
+declareDatatypes = liftSMT . declareDatatypesSMT
+{-# INLINE declareDatatypes #-}
 
-    -- | Check if the current set of assertions is satisfiable.
-    check :: m Result
-    default check ::
-        (Trans.MonadTrans t, MonadSMT n, m ~ t n) =>
-        m Result
-    check = Trans.lift check
-    {-# INLINE check #-}
+-- | Assume a fact.
+assert :: MonadSMT m => SExpr -> m ()
+assert = liftSMT . assertSMT
+{-# INLINE assert #-}
 
-    -- | A command with an uninteresting result.
-    ackCommand :: SExpr -> m ()
-    default ackCommand ::
-        (Trans.MonadTrans t, MonadSMT n, m ~ t n) =>
-        SExpr ->
-        m ()
-    ackCommand = Trans.lift . ackCommand
-    {-# INLINE ackCommand #-}
+-- | Check if the current set of assertions is satisfiable.
+check :: MonadSMT m => m Result
+check = liftSMT checkSMT
+{-# INLINE check #-}
 
-    -- | Load a .smt2 file
-    loadFile :: FilePath -> m ()
-    default loadFile ::
-        (Trans.MonadTrans t, MonadSMT n, m ~ t n) =>
-        FilePath ->
-        m ()
-    loadFile = Trans.lift . loadFile
-    {-# INLINE loadFile #-}
+-- | A command with an uninteresting result.
+ackCommand :: MonadSMT m => SExpr -> m ()
+ackCommand = liftSMT . ackCommandSMT
+{-# INLINE ackCommand #-}
 
-    -- | Reinitialize the SMT
-    reinit :: m ()
-    default reinit ::
-        (Trans.MonadTrans t, MonadSMT n, m ~ t n) =>
-        m ()
-    reinit = Trans.lift reinit
-    {-# INLINE reinit #-}
+-- | Load a .smt2 file
+loadFile :: MonadSMT m => FilePath -> m ()
+loadFile = liftSMT . loadFileSMT
+{-# INLINE loadFile #-}
 
--- * Dummy implementation
-
-newtype NoSMT a = NoSMT {getNoSMT :: LoggerT IO a}
-    deriving newtype (Functor, Applicative, Monad, MonadIO)
-    deriving newtype (MonadCatch, MonadThrow, MonadMask)
-
-runNoSMT :: NoSMT a -> LoggerT IO a
-runNoSMT = getNoSMT
-
-instance MonadProf NoSMT where
-    traceEvent name = NoSMT (traceEvent name)
-    {-# INLINE traceEvent #-}
-
-instance MonadLog NoSMT where
-    logEntry entry = NoSMT $ logEntry entry
-    {-# INLINE logEntry #-}
-
-    logWhile entry2 action = NoSMT $ logWhile entry2 $ getNoSMT action
-    {-# INLINE logWhile #-}
-
-instance MonadSMT NoSMT where
-    withSolver = id
-    declare name _ = return (Atom name)
-    declareFun FunctionDeclaration{name} = return name
-    declareSort SortDeclaration{name} = return name
-    declareDatatype _ = return ()
-    declareDatatypes _ = return ()
-    loadFile _ = return ()
-    ackCommand _ = return ()
-    assert _ = return ()
-    check = return Unknown
-    reinit = return ()
+-- | Reinitialize the SMT
+reinit :: MonadSMT m => m ()
+reinit = liftSMT reinitSMT
+{-# INLINE reinit #-}
 
 -- * Implementation
 
 data SolverSetup = SolverSetup
-    { userInit :: !(SMT ())
+    { userInit :: !(SolverSetup -> LoggerT IO ())
     , refSolverHandle :: !(MVar SolverHandle)
     , config :: !Config
     }
     deriving stock (GHC.Generic)
 
-{- | Query an external SMT solver.
+reinitSMT' :: SolverSetup -> LoggerT IO ()
+reinitSMT' sharedSolverSetup =
+    unshareSolverHandle sharedSolverSetup $ \solverSetup -> do
+        withSolver' solverSetup $ \solver -> SimpleSMT.simpleCommand solver ["reset"]
+        initSolver solverSetup
+        modifySolverHandle solverSetup $ Lens.assign (field @"queryCounter") 0
 
-The solver may be shared among multiple threads. Individual commands will
-acquire and release the solver as needed, but sequences of commands from
-different threads may be interleaved; use 'inNewScope' to acquire exclusive
-access to the solver for a sequence of commands.
--}
-newtype SMT a = SMT {getSMT :: ReaderT SolverSetup (LoggerT IO) a}
-    deriving newtype (Applicative, Functor, Monad)
-    deriving newtype (MonadIO, MonadLog)
-    deriving newtype (MonadCatch, MonadThrow, MonadMask)
-
-instance MonadProf SMT where
-    traceEvent name = SMT (traceEvent name)
-    {-# INLINE traceEvent #-}
-
-withSolverHandle :: (SolverHandle -> SMT a) -> SMT a
-withSolverHandle action = do
-    mvar <- SMT (Reader.asks refSolverHandle)
+withSolverHandle :: SolverSetup -> (SolverHandle -> LoggerT IO a) -> LoggerT IO a
+withSolverHandle solverSetup action = do
+    let mvar = refSolverHandle solverSetup
     Exception.bracket
         (Trans.liftIO $ takeMVar mvar)
         (Trans.liftIO . putMVar mvar)
         action
 
-withSolverHandleWithRestart :: (SolverHandle -> SMT a) -> SMT a
-withSolverHandleWithRestart action = do
-    mvar <- SMT (Reader.asks refSolverHandle)
+withSolverHandleWithRestart :: SolverSetup -> (SolverHandle -> LoggerT IO a) -> LoggerT IO a
+withSolverHandleWithRestart solverSetup action = do
     bracketWithExceptions
         (Trans.liftIO $ takeMVar mvar)
         (Trans.liftIO . putMVar mvar)
-        (handleExceptions mvar)
+        handleExceptions
         action
   where
-    handleExceptions mvar originalHandle exception =
+    mvar = refSolverHandle solverSetup
+    Config{executable = exe, arguments = args} = config solverSetup
+
+    handleExceptions originalHandle exception =
         case castToSolverException exception of
             Just solverException -> do
                 warnRestartSolver solverException
-                restartSolverAndRetry mvar
+                restartSolverAndRetry
             Nothing -> do
                 Trans.liftIO $ putMVar mvar originalHandle
                 Exception.throwM exception
 
-    restartSolverAndRetry mvar = do
-        logAction <- askLogAction
-        config@Config{executable = exe, arguments = args} <-
-            askConfig
+    restartSolverAndRetry = do
+        logAction <- Log.askLogAction
         newSolverHandle <-
             Trans.liftIO $
                 Exception.handle handleIOException $
                     SimpleSMT.newSolver exe args logAction
         _ <- Trans.liftIO $ putMVar mvar newSolverHandle
-        initSolver config
-        (action newSolverHandle)
+        initSolver solverSetup
+        action newSolverHandle
 
     handleIOException :: IOException -> IO SolverHandle
     handleIOException e =
@@ -363,29 +295,21 @@ bracketWithExceptions acquire release handleException use =
                 _ <- release resource
                 return v
 
-askLogAction :: SMT (LogAction IO SomeEntry)
-askLogAction = SMT $ Trans.lift Log.askLogAction
-{-# INLINE askLogAction #-}
-
-askConfig :: SMT Config
-askConfig = SMT $ Reader.asks config
-{-# INLINE askConfig #-}
-
-withSolver' :: (Solver -> IO a) -> SMT a
-withSolver' action =
-    withSolverHandle $ \solverHandle -> do
-        logAction <- askLogAction
+withSolver' :: SolverSetup -> (Solver -> IO a) -> LoggerT IO a
+withSolver' solverSetup action =
+    withSolverHandle solverSetup $ \solverHandle -> do
+        logAction <- Log.askLogAction
         Trans.liftIO $ action (Solver solverHandle logAction)
 
-withSolverWithRestart :: (Solver -> IO a) -> SMT a
-withSolverWithRestart action =
-    withSolverHandleWithRestart $ \solverHandle -> do
-        logAction <- askLogAction
+withSolverWithRestart :: SolverSetup -> (Solver -> IO a) -> LoggerT IO a
+withSolverWithRestart solverSetup action =
+    withSolverHandleWithRestart solverSetup $ \solverHandle -> do
+        logAction <- Log.askLogAction
         Trans.liftIO $ action (Solver solverHandle logAction)
 
-modifySolverHandle :: StateT SolverHandle SMT a -> SMT a
-modifySolverHandle action = do
-    mvar <- SMT (Reader.asks refSolverHandle)
+modifySolverHandle :: SolverSetup -> StateT SolverHandle (LoggerT IO) a -> LoggerT IO a
+modifySolverHandle solverSetup action = do
+    let mvar = refSolverHandle solverSetup
     solverHandle <- Trans.liftIO $ takeMVar mvar
     Exception.onException
         ( do
@@ -400,17 +324,14 @@ modifySolverHandle action = do
 @unshareSolverHandle@ works by locking the received 'MVar' and running the
 action with a new 'MVar' that is not shared with any other thread.
 -}
-unshareSolverHandle :: SMT a -> SMT a
-unshareSolverHandle action = do
-    mvarShared <- SMT (Reader.asks refSolverHandle)
+unshareSolverHandle :: SolverSetup -> (SolverSetup -> LoggerT IO a) -> LoggerT IO a
+unshareSolverHandle solverSetup action = do
+    let mvarShared = refSolverHandle solverSetup
     mvarUnshared <- Trans.liftIO $ takeMVar mvarShared >>= newMVar
-    let unshare =
-            SMT
-                . Reader.local (Lens.set (field @"refSolverHandle") mvarUnshared)
-                . getSMT
+    let unshare = Lens.set (field @"refSolverHandle") mvarUnshared
         replaceMVar =
             Trans.liftIO $ takeMVar mvarUnshared >>= putMVar mvarShared
-    Exception.finally (unshare action) replaceMVar
+    Exception.finally (action (unshare solverSetup)) replaceMVar
 
 -- | Increase the 'queryCounter' and indicate if the solver should be reset.
 incrementQueryCounter ::
@@ -422,54 +343,6 @@ incrementQueryCounter (ResetInterval resetInterval) = do
     -- number of runs, specified here. This number can be adjusted based on
     -- experimentation.
     pure (toInteger counter >= resetInterval)
-
-instance MonadSMT SMT where
-    withSolver action =
-        unshareSolverHandle $ do
-            withSolverWithRestart push
-            Exception.finally
-                action
-                ( do
-                    withSolverWithRestart pop
-                    resetInterval' <- extractResetInterval
-                    needReset <-
-                        modifySolverHandle
-                            (incrementQueryCounter resetInterval')
-                    when needReset reinit
-                )
-
-    declare name typ =
-        withSolver' $ \solver -> SimpleSMT.declare solver (Atom name) typ
-
-    declareFun declaration =
-        withSolver' $ \solver -> SimpleSMT.declareFun solver declaration
-
-    declareSort declaration =
-        withSolver' $ \solver -> SimpleSMT.declareSort solver declaration
-
-    declareDatatype declaration =
-        withSolver' $ \solver -> SimpleSMT.declareDatatype solver declaration
-
-    declareDatatypes datatypes =
-        withSolver' $ \solver -> SimpleSMT.declareDatatypes solver datatypes
-
-    assert fact =
-        traceProf ":solver:assert" $
-            withSolver' $ \solver -> SimpleSMT.assert solver fact
-
-    check = traceProf ":solver:check" $ withSolver' SimpleSMT.check
-
-    ackCommand command =
-        withSolver' $ \solver -> SimpleSMT.ackCommand solver command
-
-    loadFile path =
-        withSolver' $ \solver -> SimpleSMT.loadFile solver path
-
-    reinit = unshareSolverHandle $ do
-        withSolver' $ \solver -> SimpleSMT.simpleCommand solver ["reset"]
-        config <- SMT (Reader.asks config)
-        initSolver config
-        modifySolverHandle $ Lens.assign (field @"queryCounter") 0
 
 instance (MonadSMT m, Monoid w) => MonadSMT (AccumT w m) where
     withSolver = mapAccumT withSolver
@@ -544,14 +417,14 @@ defaultConfig =
         , resetInterval = ResetInterval 100
         }
 
-initSolver :: Config -> SMT ()
-initSolver Config{timeOut, rLimit, prelude} = do
-    setTimeOut timeOut
-    setRLimit rLimit
-    traverse_ loadFile preludeFile
-    join $ SMT (Reader.asks userInit)
-  where
-    preludeFile = getPrelude prelude
+initSolver :: SolverSetup -> LoggerT IO ()
+initSolver solverSetup = do
+    let Config{timeOut, rLimit, prelude} = config solverSetup
+        preludeFile = getPrelude prelude
+    runWithSolver (setTimeOut timeOut) solverSetup
+    runWithSolver (setRLimit rLimit) solverSetup
+    runWithSolver (traverse_ loadFile preludeFile) solverSetup
+    userInit solverSetup solverSetup
 
 {- | Initialize a new solverHandle with the given 'Config'.
 
@@ -588,20 +461,6 @@ stopSolver mvar = do
         _ <- SimpleSMT.stop solver
         return ()
 
--- | Run an external SMT solver.
-runSMT :: Config -> SMT () -> SMT a -> LoggerT IO a
-runSMT config userInit smt =
-    Exception.bracket
-        (newSolver config)
-        stopSolver
-        (\mvar -> runSMT' config userInit mvar smt)
-
-runSMT' :: Config -> SMT () -> MVar SolverHandle -> SMT a -> LoggerT IO a
-runSMT' config userInit refSolverHandle SMT{getSMT = smt} =
-    runReaderT
-        (getSMT (initSolver config) >> smt)
-        SolverSetup{userInit, refSolverHandle, config}
-
 -- Need to quote every identifier in SMT between pipes
 -- to escape special chars
 escapeId :: Text -> Text
@@ -621,6 +480,126 @@ setInfo infoFlag expr =
 setOption :: MonadSMT m => Text -> SExpr -> m ()
 setOption infoFlag expr =
     ackCommand $ List (Atom "set-option" : Atom infoFlag : [expr])
+
+{- | Query an external SMT solver (if available).
+
+The solver may be shared among multiple threads. Individual commands will
+acquire and release the solver as needed, but sequences of commands from
+different threads may be interleaved; use 'withSolver' to acquire exclusive
+access to the solver for a sequence of commands.
+-}
+newtype SMT a = SMT (Maybe SolverSetup -> LoggerT IO a)
+    deriving
+        (Applicative, Functor, Monad, MonadIO, MonadLog, MonadProf, MonadCatch, MonadThrow, MonadMask)
+        via ReaderT (Maybe SolverSetup) (LoggerT IO)
+
+runWithSolver :: SMT a -> SolverSetup -> LoggerT IO a
+runWithSolver (SMT action) = action . Just
+
+runNoSMT :: SMT a -> LoggerT IO a
+runNoSMT (SMT action) = action Nothing
+
+-- | Run an external SMT solver.
+runSMT :: Config -> SMT () -> SMT a -> LoggerT IO a
+runSMT config userInit action =
+    Exception.bracket (newSolver config) stopSolver $ \refSolverHandle -> do
+        let solverSetup = SolverSetup{userInit = runWithSolver userInit, refSolverHandle, config}
+        initSolver solverSetup
+        runWithSolver action solverSetup
+
+instance MonadSMT SMT where
+    withSolver (SMT action) =
+        SMT $ \case
+            Nothing -> action Nothing
+            Just sharedSolverSetup -> do
+                unshareSolverHandle sharedSolverSetup $ \solverSetup -> do
+                    withSolverWithRestart solverSetup push
+                    action (Just solverSetup) `Exception.finally` do
+                        withSolverWithRestart solverSetup pop
+                        needReset <-
+                            modifySolverHandle solverSetup $
+                                incrementQueryCounter (resetInterval (config solverSetup))
+                        when needReset (reinitSMT' solverSetup)
+    liftSMT = id
+
+declareSMT :: Text -> SExpr -> SMT SExpr
+declareSMT name typ =
+    SMT $ \case
+        Nothing -> return (Atom name)
+        Just solverSetup ->
+            withSolver' solverSetup $ \solver ->
+                SimpleSMT.declare solver (Atom name) typ
+
+declareFunSMT :: FunctionDeclaration SExpr SExpr -> SMT SExpr
+declareFunSMT declaration@FunctionDeclaration{name} =
+    SMT $ \case
+        Nothing -> return name
+        Just solverSetup ->
+            withSolver' solverSetup $ \solver ->
+                SimpleSMT.declareFun solver declaration
+
+declareSortSMT :: SortDeclaration SExpr -> SMT SExpr
+declareSortSMT declaration@SortDeclaration{name} =
+    SMT $ \case
+        Nothing -> return name
+        Just solverSetup ->
+            withSolver' solverSetup $ \solver ->
+                SimpleSMT.declareSort solver declaration
+
+declareDatatypeSMT :: SmtDataTypeDeclaration -> SMT ()
+declareDatatypeSMT declaration =
+    SMT $ \case
+        Nothing -> return ()
+        Just solverSetup ->
+            withSolver' solverSetup $ \solver ->
+                SimpleSMT.declareDatatype solver declaration
+
+declareDatatypesSMT :: [SmtDataTypeDeclaration] -> SMT ()
+declareDatatypesSMT datatypes =
+    SMT $ \case
+        Nothing -> return ()
+        Just solverSetup ->
+            withSolver' solverSetup $ \solver ->
+                SimpleSMT.declareDatatypes solver datatypes
+
+assertSMT :: SExpr -> SMT ()
+assertSMT fact =
+    SMT $ \case
+        Nothing -> return ()
+        Just solverSetup ->
+            traceProf ":solver:assert" $
+                withSolver' solverSetup $ \solver ->
+                    SimpleSMT.assert solver fact
+
+checkSMT :: SMT Result
+checkSMT =
+    SMT $ \case
+        Nothing -> return Unknown
+        Just solverSetup ->
+            traceProf ":solver:check" $
+                withSolver' solverSetup SimpleSMT.check
+
+ackCommandSMT :: SExpr -> SMT ()
+ackCommandSMT command =
+    SMT $ \case
+        Nothing -> return ()
+        Just solverSetup ->
+            withSolver' solverSetup $ \solver ->
+                SimpleSMT.ackCommand solver command
+
+loadFileSMT :: FilePath -> SMT ()
+loadFileSMT path =
+    SMT $ \case
+        Nothing -> return ()
+        Just solverSetup ->
+            withSolver' solverSetup $ \solver ->
+                SimpleSMT.loadFile solver path
+
+reinitSMT :: SMT ()
+reinitSMT =
+    SMT $ \case
+        Nothing -> return ()
+        Just solverSetup -> reinitSMT' solverSetup
 
 -- --------------------------------
 -- Internal
@@ -642,9 +621,3 @@ setRLimit RLimit{getRLimit} =
             setOption ":rlimit" (SimpleSMT.int rLimit)
         Unlimited ->
             return ()
-
--- | Extract the reset interval value from the configuration.
-extractResetInterval :: SMT ResetInterval
-extractResetInterval =
-    SMT (Reader.asks config)
-        >>= return . resetInterval

--- a/kore/test/Test/Kore/Builtin/Bool.hs
+++ b/kore/test/Test/Kore/Builtin/Bool.hs
@@ -236,7 +236,7 @@ test_unifyBoolOr =
             & lift
             & run
 
-run :: MaybeT (UnifierT (SimplifierT SMT.NoSMT)) a -> IO [Maybe a]
+run :: MaybeT (UnifierT (SimplifierT SMT.SMT)) a -> IO [Maybe a]
 run =
     runNoSMT
         . runSimplifier testEnv
@@ -246,7 +246,7 @@ run =
 termSimplifier ::
     TermLike RewritingVariableName ->
     TermLike RewritingVariableName ->
-    UnifierT (SimplifierT SMT.NoSMT) (Pattern RewritingVariableName)
+    UnifierT (SimplifierT SMT.SMT) (Pattern RewritingVariableName)
 termSimplifier = \term1 term2 ->
     runMaybeT (worker term1 term2 <|> worker term2 term1)
         >>= maybe (fallback term1 term2) return

--- a/kore/test/Test/Kore/Builtin/Builtin.hs
+++ b/kore/test/Test/Kore/Builtin/Builtin.hs
@@ -118,7 +118,7 @@ import Kore.Validate.PatternVerifier qualified as PatternVerifier
 import Logic qualified
 import Prelude.Kore
 import SMT (
-    NoSMT,
+    SMT,
  )
 import Test.Kore.Builtin.Definition
 import Test.Kore.Builtin.External
@@ -150,7 +150,7 @@ testSymbolWithoutSolver ::
     , expanded ~ OrPattern RewritingVariableName
     ) =>
     -- | evaluator function for the builtin
-    (p -> NoSMT expanded) ->
+    (p -> SMT expanded) ->
     -- | test name
     String ->
     -- | symbol being tested
@@ -308,7 +308,7 @@ evaluateExpectTopK termLike = do
 
 evaluateToList ::
     TermLike RewritingVariableName ->
-    NoSMT [Pattern RewritingVariableName]
+    SMT [Pattern RewritingVariableName]
 evaluateToList =
     fmap toList
         . runSimplifier testEnv
@@ -319,7 +319,7 @@ runStep ::
     Pattern RewritingVariableName ->
     -- | axiom
     RewriteRule RewritingVariableName ->
-    NoSMT (OrPattern RewritingVariableName)
+    SMT (OrPattern RewritingVariableName)
 runStep configuration axiom = do
     results <- runStepResult configuration axiom
     return $ Step.gatherResults results
@@ -329,7 +329,7 @@ runStepResult ::
     Pattern RewritingVariableName ->
     -- | axiom
     RewriteRule RewritingVariableName ->
-    NoSMT (Step.Results (RulePattern RewritingVariableName))
+    SMT (Step.Results (RulePattern RewritingVariableName))
 runStepResult configuration axiom =
     Step.applyRewriteRulesParallel
         [axiom]

--- a/kore/test/Test/Kore/Builtin/KEqual.hs
+++ b/kore/test/Test/Kore/Builtin/KEqual.hs
@@ -37,7 +37,7 @@ import Kore.Unification.UnifierT (
  )
 import Prelude.Kore
 import SMT (
-    NoSMT,
+    SMT,
  )
 import Test.Kore (
     testId,
@@ -229,7 +229,7 @@ dvX =
 runKEqualSimplification ::
     TermLike RewritingVariableName ->
     TermLike RewritingVariableName ->
-    NoSMT [Maybe (Pattern RewritingVariableName)]
+    SMT [Maybe (Pattern RewritingVariableName)]
 runKEqualSimplification term1 term2 =
     unify matched
         & runMaybeT

--- a/kore/test/Test/Kore/Builtin/Map.hs
+++ b/kore/test/Test/Kore/Builtin/Map.hs
@@ -103,7 +103,7 @@ import Prelude.Kore hiding (
     concatMap,
  )
 import SMT (
-    NoSMT,
+    SMT,
  )
 import Test.Expect
 import Test.Kore (
@@ -1142,7 +1142,7 @@ unifiesWith ::
     TermLike RewritingVariableName ->
     TermLike RewritingVariableName ->
     Pattern RewritingVariableName ->
-    PropertyT NoSMT ()
+    PropertyT SMT ()
 unifiesWith pat1 pat2 expected =
     unifiesWithMulti pat1 pat2 [expected]
 
@@ -1152,7 +1152,7 @@ unifiesWithMulti ::
     TermLike RewritingVariableName ->
     TermLike RewritingVariableName ->
     [Pattern RewritingVariableName] ->
-    PropertyT NoSMT ()
+    PropertyT SMT ()
 unifiesWithMulti pat1 pat2 expectedResults = do
     actualResults <- lift $ evaluateToList (mkAnd pat1 pat2)
     compareElements (List.sort expectedResults) actualResults

--- a/kore/test/Test/Kore/Builtin/Set.hs
+++ b/kore/test/Test/Kore/Builtin/Set.hs
@@ -1989,7 +1989,7 @@ unifiesWith ::
     TermLike RewritingVariableName ->
     TermLike RewritingVariableName ->
     Pattern RewritingVariableName ->
-    PropertyT NoSMT ()
+    PropertyT SMT ()
 unifiesWith pat1 pat2 expected =
     unifiesWithMulti pat1 pat2 [expected]
 
@@ -1999,7 +1999,7 @@ unifiesWithMulti ::
     TermLike RewritingVariableName ->
     TermLike RewritingVariableName ->
     [Pattern RewritingVariableName] ->
-    PropertyT NoSMT ()
+    PropertyT SMT ()
 unifiesWithMulti pat1 pat2 expectedResults = do
     actualResults <- lift $ evaluateToList (mkAnd pat1 pat2)
     compareElements (List.sort expectedResults) actualResults

--- a/kore/test/Test/Kore/Reachability/MockAllPath.hs
+++ b/kore/test/Test/Kore/Reachability/MockAllPath.hs
@@ -396,16 +396,7 @@ instance MonadLog AllPathIdentity where
 
 instance MonadSMT AllPathIdentity where
     withSolver = undefined
-    declare = undefined
-    declareFun = undefined
-    declareSort = undefined
-    declareDatatype = undefined
-    declareDatatypes = undefined
-    assert = undefined
-    check = undefined
-    ackCommand = undefined
-    loadFile = undefined
-    reinit = undefined
+    liftSMT = undefined
 
 instance MonadThrow AllPathIdentity where
     throwM _ = error "Unimplemented"

--- a/kore/test/Test/Kore/Repl/Interpreter.hs
+++ b/kore/test/Test/Kore/Repl/Interpreter.hs
@@ -747,7 +747,7 @@ runWithState command axioms claims claim stateTransformer = do
     ((c, s), logEntries) <-
         runLogger $
             replInterpreter0
-                @(SimplifierT NoSMT)
+                @(SimplifierT SMT)
                 (modifyAuxOutput output)
                 (modifyKoreOutput output)
                 command
@@ -833,7 +833,7 @@ mkState startTime axioms claims claim =
 
 mkConfig ::
     MVar (Log.LogAction IO Log.ActualEntry) ->
-    Config (SimplifierT NoSMT)
+    Config (SimplifierT SMT)
 mkConfig logger =
     Config
         { stepper = stepper0
@@ -849,7 +849,7 @@ mkConfig logger =
         [Axiom] ->
         ExecutionGraph ->
         ReplNode ->
-        SimplifierT NoSMT ExecutionGraph
+        SimplifierT SMT ExecutionGraph
     stepper0 claims' axioms' graph (ReplNode node) =
         proveClaimStep Nothing EnabledStuckCheck claims' axioms' graph node
 

--- a/kore/test/Test/Kore/Rewrite/Axiom/Matcher.hs
+++ b/kore/test/Test/Kore/Rewrite/Axiom/Matcher.hs
@@ -1355,7 +1355,7 @@ match ::
 match first second =
     runSimplifier Mock.env matchResult
   where
-    matchResult :: SimplifierT NoSMT MatchResult
+    matchResult :: SimplifierT SMT MatchResult
     matchResult = matchIncremental SideCondition.top first second
 
 withMatch ::

--- a/kore/test/Test/Kore/Rewrite/Axiom/Registry.hs
+++ b/kore/test/Test/Kore/Rewrite/Axiom/Registry.hs
@@ -455,7 +455,7 @@ testProcessedAxiomPatterns =
 testMetadataTools :: SmtMetadataTools Attribute.Symbol
 testMetadataTools = MetadataTools.build testIndexedModule
 
-testEnv :: Env (SimplifierT NoSMT)
+testEnv :: Env (SimplifierT SMT)
 testEnv =
     Mock.env
         { metadataTools = testMetadataTools

--- a/kore/test/Test/Kore/Rewrite/Function/Evaluator.hs
+++ b/kore/test/Test/Kore/Rewrite/Function/Evaluator.hs
@@ -119,5 +119,5 @@ simplifierAxioms = Map.fromList [(fId, fEvaluator)]
   where
     fId = Axiom.Identifier.Application (TermLike.symbolConstructor fSymbol)
 
-env :: Test.Env (Test.SimplifierT Test.NoSMT)
+env :: Test.Env (Test.SimplifierT Test.SMT)
 env = Mock.env{Test.simplifierAxioms = simplifierAxioms}

--- a/kore/test/Test/Kore/Rewrite/Function/Integration.hs
+++ b/kore/test/Test/Kore/Rewrite/Function/Integration.hs
@@ -2057,7 +2057,7 @@ testEnv =
         , simplifierXSwitch = DisabledSimplifierX
         }
 
-testEnvUnification :: Env (SimplifierT NoSMT)
+testEnvUnification :: Env (SimplifierT SMT)
 testEnvUnification =
     testEnv
         { simplifierAxioms =

--- a/kore/test/Test/Kore/Rewrite/SMT/Evaluator.hs
+++ b/kore/test/Test/Kore/Rewrite/SMT/Evaluator.hs
@@ -34,9 +34,6 @@ import Kore.Rewrite.RewritingVariable (
 import Kore.Rewrite.SMT.Evaluator qualified as SMT.Evaluator
 import Kore.Simplify.Data qualified as Kore
 import Prelude.Kore
-import SMT (
-    SMT,
- )
 import Test.Kore
 import Test.Kore.Builtin.Bool qualified as Builtin.Bool
 import Test.Kore.Builtin.Builtin (

--- a/kore/test/Test/Kore/Rewrite/SMT/Translate.hs
+++ b/kore/test/Test/Kore/Rewrite/SMT/Translate.hs
@@ -217,14 +217,14 @@ test_translatePredicateWith =
 
 translatePredicate ::
     Predicate VariableName ->
-    Translator VariableName NoSMT SExpr
+    Translator VariableName SMT SExpr
 translatePredicate =
     Evaluator.translatePredicate SideCondition.top Mock.metadataTools
 
 translatePattern ::
     SideCondition VariableName ->
     TermLike VariableName ->
-    Translator VariableName NoSMT SExpr
+    Translator VariableName SMT SExpr
 translatePattern sideCondition =
     SMT.translatePattern
         Mock.metadataTools

--- a/kore/test/Test/Kore/Simplify.hs
+++ b/kore/test/Test/Kore/Simplify.hs
@@ -13,7 +13,7 @@ module Test.Kore.Simplify (
     -- * Re-exports
     Simplifier,
     SimplifierT,
-    NoSMT,
+    SMT,
     Env (..),
     Kore.MonadSimplify,
 ) where
@@ -73,7 +73,7 @@ import Logic (
  )
 import Prelude.Kore
 import SMT (
-    NoSMT,
+    SMT,
  )
 import Test.Kore.Rewrite.MockSymbols qualified as Mock
 import Test.SMT qualified as Test
@@ -83,12 +83,12 @@ runSimplifierSMT env = Test.runSMT userInit . Kore.runSimplifier env
   where
     userInit = declareSortsSymbols Mock.smtDeclarations
 
-runSimplifier :: Env (SimplifierT NoSMT) -> SimplifierT NoSMT a -> IO a
+runSimplifier :: Env (SimplifierT SMT) -> SimplifierT SMT a -> IO a
 runSimplifier env = Test.runNoSMT . Kore.runSimplifier env
 
 runSimplifierBranch ::
-    Env (SimplifierT NoSMT) ->
-    LogicT (SimplifierT NoSMT) a ->
+    Env (SimplifierT SMT) ->
+    LogicT (SimplifierT SMT) a ->
     IO [a]
 runSimplifierBranch env = Test.runNoSMT . Kore.runSimplifierBranch env
 

--- a/kore/test/Test/Kore/Simplify/IntegrationProperty.hs
+++ b/kore/test/Test/Kore/Simplify/IntegrationProperty.hs
@@ -163,18 +163,18 @@ test_regressionGeneratedTerms =
 evaluateT ::
     MonadTrans t =>
     Pattern RewritingVariableName ->
-    t SMT.NoSMT (OrPattern RewritingVariableName)
+    t SMT.SMT (OrPattern RewritingVariableName)
 evaluateT = lift . evaluate
 
 evaluate ::
     Pattern RewritingVariableName ->
-    SMT.NoSMT (OrPattern RewritingVariableName)
+    SMT.SMT (OrPattern RewritingVariableName)
 evaluate = evaluateWithAxioms Map.empty
 
 evaluateWithAxioms ::
     BuiltinAndAxiomSimplifierMap ->
     Pattern RewritingVariableName ->
-    SMT.NoSMT (OrPattern RewritingVariableName)
+    SMT.SMT (OrPattern RewritingVariableName)
 evaluateWithAxioms axioms =
     Simplification.runSimplifier env . Pattern.simplify
   where

--- a/kore/test/Test/Kore/Simplify/Overloading.hs
+++ b/kore/test/Test/Kore/Simplify/Overloading.hs
@@ -517,7 +517,7 @@ match ::
 match termPair = runSimplifier Mock.env $ runExceptT matchResult
   where
     matchResult ::
-        MatchOverloadingResult (SimplifierT NoSMT) RewritingVariableName
+        MatchOverloadingResult (SimplifierT SMT) RewritingVariableName
     matchResult = matchOverloading termPair
 
 withMatching ::

--- a/kore/test/Test/Kore/Simplify/TermLike.hs
+++ b/kore/test/Test/Kore/Simplify/TermLike.hs
@@ -108,7 +108,7 @@ simplifyWithSideCondition
                 . TermLike.simplify sideCondition
                 . mkRewritingTerm
 
-newtype TestSimplifier a = TestSimplifier {getTestSimplifier :: SimplifierT NoSMT a}
+newtype TestSimplifier a = TestSimplifier {getTestSimplifier :: SimplifierT SMT a}
     deriving newtype (Functor, Applicative, Monad)
     deriving newtype (MonadLog, MonadSMT, MonadThrow)
 

--- a/kore/test/Test/SMT.hs
+++ b/kore/test/Test/SMT.hs
@@ -15,7 +15,6 @@ import Log (
  )
 import Prelude.Kore
 import SMT (
-    NoSMT,
     SMT,
  )
 import SMT qualified
@@ -34,12 +33,12 @@ testPropertyWithSolver str =
 testPropertyWithoutSolver ::
     HasCallStack =>
     String ->
-    PropertyT NoSMT () ->
+    PropertyT SMT () ->
     TestTree
 testPropertyWithoutSolver str =
     testProperty str . Hedgehog.property . Morph.hoist runNoSMT
 
-testCaseWithoutSMT :: String -> NoSMT () -> TestTree
+testCaseWithoutSMT :: String -> SMT () -> TestTree
 testCaseWithoutSMT str = testCase str . runNoSMT
 
 assertEqual' ::
@@ -61,5 +60,5 @@ runSMT = runSMTWithConfig SMT.defaultConfig
 runSMTWithConfig :: SMT.Config -> SMT () -> SMT a -> IO a
 runSMTWithConfig config userInit = flip runLoggerT mempty . SMT.runSMT config userInit
 
-runNoSMT :: NoSMT a -> IO a
+runNoSMT :: SMT a -> IO a
 runNoSMT = flip runLoggerT mempty . SMT.runNoSMT


### PR DESCRIPTION
This is the first step towards monomorphisation of the monad transformer stack used in `kore` (for improved performance). Previously there were two separate base monads:

```haskell
newtype NoSMT a = NoSMT {getNoSMT :: LoggerT IO a}
newtype SMT a = SMT {getSMT :: ReaderT SolverSetup (LoggerT IO) a}
```

The choice of the base monad was determined at runtime. Now we have a single base monad:

```haskell
newtype SMT a = SMT (Maybe SolverSetup -> LoggerT IO a)
```

This makes it possible to use a monomorphic monad where previously a polymorphic one was required:

```diff
execute ::
    KoreSolverOptions ->
    SmtMetadataTools StepperAttributes ->
    [SentenceAxiom (TermLike VariableName)] ->
-   (forall exe. MonadExecute exe => exe r) ->
+   SMT r ->
    Main r
```

Note that this change alone is insufficient to improve performance, as the rest of the application still uses an abstract `MonadSMT` context. However, it lifts one of the obstacles towards that goal.