### PR TITLE
Simplifier as a base monad; drop SimplifierT 

### DIFF
--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -36,9 +36,6 @@ import Control.Monad (
     filterM,
     (>=>),
  )
-import Control.Monad.Catch (
-    MonadMask,
- )
 import Control.Monad.Trans.Maybe (runMaybeT)
 import Data.Coerce (
     coerce,
@@ -197,9 +194,6 @@ import Kore.Unparser (
     unparseToText,
     unparseToText2,
  )
-import Log (
-    MonadLog,
- )
 import Log qualified
 import Logic (
     LogicT,
@@ -209,7 +203,6 @@ import Logic qualified
 import Prelude.Kore
 import Prof
 import SMT (
-    MonadSMT,
     SMT,
  )
 import System.Exit (
@@ -239,16 +232,9 @@ data SerializedModule = SerializedModule
     deriving anyclass (NFData)
 
 makeSerializedModule ::
-    forall smt.
-    ( MonadIO smt
-    , MonadLog smt
-    , MonadSMT smt
-    , MonadMask smt
-    , MonadProf smt
-    ) =>
     SimplifierXSwitch ->
     VerifiedModule StepperAttributes ->
-    smt SerializedModule
+    SMT SerializedModule
 makeSerializedModule simplifierx verifiedModule =
     evalSimplifier simplifierx (indexedModuleSyntax verifiedModule') sortGraph overloadGraph metadataTools equations $ do
         rewrites <- initializeAndSimplify verifiedModule
@@ -274,13 +260,6 @@ makeSerializedModule simplifierx verifiedModule =
 
 -- | Symbolic execution
 exec ::
-    forall smt.
-    ( MonadIO smt
-    , MonadLog smt
-    , MonadSMT smt
-    , MonadMask smt
-    , MonadProf smt
-    ) =>
     SimplifierXSwitch ->
     Limit Natural ->
     Limit Natural ->
@@ -289,7 +268,7 @@ exec ::
     ExecutionMode ->
     -- | The input pattern
     TermLike VariableName ->
-    smt (ExitCode, TermLike VariableName)
+    SMT (ExitCode, TermLike VariableName)
 exec
     simplifierx
     depthLimit
@@ -437,12 +416,6 @@ getExitCode
 
 -- | Symbolic search
 search ::
-    ( MonadIO smt
-    , MonadLog smt
-    , MonadSMT smt
-    , MonadMask smt
-    , MonadProf smt
-    ) =>
     SimplifierXSwitch ->
     Limit Natural ->
     Limit Natural ->
@@ -454,7 +427,7 @@ search ::
     Pattern VariableName ->
     -- | The bound on the number of search matches and the search type
     Search.Config ->
-    smt (TermLike VariableName)
+    SMT (TermLike VariableName)
 search
     simplifierx
     depthLimit
@@ -516,13 +489,6 @@ search
 
 -- | Proving a spec given as a module containing rules to be proven
 prove ::
-    forall smt.
-    ( MonadLog smt
-    , MonadMask smt
-    , MonadIO smt
-    , MonadSMT smt
-    , MonadProf smt
-    ) =>
     Maybe MinDepth ->
     StuckCheck ->
     SimplifierXSwitch ->
@@ -537,7 +503,7 @@ prove ::
     VerifiedModule StepperAttributes ->
     -- | The module containing the claims that were proven in a previous run.
     Maybe (VerifiedModule StepperAttributes) ->
-    smt ProveClaimsResult
+    SMT ProveClaimsResult
 prove
     maybeMinDepth
     stuckCheck
@@ -641,12 +607,6 @@ proveWithRepl
 
 -- | Bounded model check a spec given as a module containing rules to be checked
 boundedModelCheck ::
-    ( MonadLog smt
-    , MonadSMT smt
-    , MonadIO smt
-    , MonadMask smt
-    , MonadProf smt
-    ) =>
     SimplifierXSwitch ->
     Limit Natural ->
     Limit Natural ->
@@ -655,7 +615,7 @@ boundedModelCheck ::
     -- | The spec module
     VerifiedModule StepperAttributes ->
     Strategy.GraphSearchOrder ->
-    smt
+    SMT
         ( Bounded.CheckResult
             (TermLike VariableName)
             (ImplicationRule VariableName)
@@ -685,17 +645,11 @@ boundedModelCheck
                 (head claims, depthLimit)
 
 matchDisjunction ::
-    ( MonadLog smt
-    , MonadSMT smt
-    , MonadIO smt
-    , MonadMask smt
-    , MonadProf smt
-    ) =>
     SimplifierXSwitch ->
     VerifiedModule Attribute.Symbol ->
     Pattern RewritingVariableName ->
     [Pattern RewritingVariableName] ->
-    smt (TermLike VariableName)
+    SMT (TermLike VariableName)
 matchDisjunction simplifierx mainModule matchPattern disjunctionPattern =
     evalSimplifierProofs simplifierx mainModule $ do
         results <-
@@ -730,16 +684,10 @@ See 'checkEquation',
 'Kore.Log.ErrorEquationsSameMatch.errorEquationsSameMatch'.
 -}
 checkFunctions ::
-    ( MonadLog smt
-    , MonadSMT smt
-    , MonadIO smt
-    , MonadMask smt
-    , MonadProf smt
-    ) =>
     SimplifierXSwitch ->
     -- | The main module
     VerifiedModule StepperAttributes ->
-    smt ()
+    SMT ()
 checkFunctions simplifierx verifiedModule =
     evalSimplifierProofs simplifierx verifiedModule $ do
         -- check if RHS is function pattern

--- a/kore/src/Kore/Simplify/Data.hs
+++ b/kore/src/Kore/Simplify/Data.hs
@@ -12,8 +12,6 @@ Portability : portable
 module Kore.Simplify.Data (
     Simplifier,
     TermSimplifier,
-    SimplifierT,
-    runSimplifierT,
     Env (..),
     runSimplifier,
     runSimplifierBranch,
@@ -31,7 +29,6 @@ import Control.Monad.Catch (
     MonadMask,
     MonadThrow,
  )
-import Control.Monad.Morph qualified as Morph
 import Control.Monad.Reader
 import Control.Monad.State.Strict
 import Data.Map.Strict (
@@ -85,7 +82,6 @@ import Kore.Simplify.TermLike qualified as TermLike
 import Kore.Syntax.Variable (
     VariableName,
  )
-import Log
 import Logic
 import Prelude.Kore
 import Pretty qualified
@@ -96,11 +92,11 @@ import SMT (
 
 -- * Simplifier
 
-data Env simplifier = Env
+data Env = Env
     { metadataTools :: !(SmtMetadataTools Attribute.Symbol)
-    , simplifierCondition :: !(ConditionSimplifier simplifier)
+    , simplifierCondition :: !(ConditionSimplifier Simplifier)
     , simplifierAxioms :: !BuiltinAndAxiomSimplifierMap
-    , memo :: !(Memo.Self simplifier)
+    , memo :: !(Memo.Self Simplifier)
     , injSimplifier :: !InjSimplifier
     , overloadSimplifier :: !OverloadSimplifier
     , simplifierXSwitch :: !SimplifierXSwitch
@@ -112,26 +108,13 @@ A @Simplifier@ can send constraints to the SMT solver through 'MonadSMT'.
 
 A @Simplifier@ can write to the log through 'HasLog'.
 -}
-newtype SimplifierT smt a = SimplifierT
-    { runSimplifierT :: StateT SimplifierCache (ReaderT (Env (SimplifierT smt)) smt) a
-    }
-    deriving newtype (Functor, Applicative, Monad, MonadSMT)
+newtype Simplifier a
+    = Simplifier (StateT SimplifierCache (ReaderT Env SMT) a)
+    deriving newtype (Functor, Applicative, Monad)
+    deriving newtype (MonadSMT, MonadLog, MonadProf)
     deriving newtype (MonadIO, MonadCatch, MonadThrow, MonadMask)
-    deriving newtype (MonadReader (Env (SimplifierT smt)))
+    deriving newtype (MonadReader Env)
     deriving newtype (MonadState SimplifierCache)
-
-type Simplifier = SimplifierT SMT
-
-instance MonadTrans SimplifierT where
-    lift smt = SimplifierT ((lift . lift) smt)
-    {-# INLINE lift #-}
-
-instance MonadLog log => MonadLog (SimplifierT log) where
-    logWhile entry = mapSimplifierT $ logWhile entry
-
-instance (MonadMask prof, MonadProf prof) => MonadProf (SimplifierT prof) where
-    traceEvent name = lift (traceEvent name)
-    {-# INLINE traceEvent #-}
 
 traceProfSimplify ::
     MonadProf prof =>
@@ -148,10 +131,7 @@ traceProfSimplify (Pattern.toTermLike -> termLike) =
             . Pretty.pretty
             <$> matchAxiomIdentifier termLike
 
-instance
-    (MonadSMT m, MonadLog m, MonadMask m, MonadProf m) =>
-    MonadSimplify (SimplifierT m)
-    where
+instance MonadSimplify Simplifier where
     askMetadataTools = asks metadataTools
     {-# INLINE askMetadataTools #-}
 
@@ -195,11 +175,10 @@ instance
 
 -- | Run a simplification, returning the results along all branches.
 runSimplifierBranch ::
-    Monad smt =>
-    Env (SimplifierT smt) ->
+    Env ->
     -- | simplifier computation
-    LogicT (SimplifierT smt) a ->
-    smt [a]
+    LogicT Simplifier a ->
+    SMT [a]
 runSimplifierBranch env = runSimplifier env . observeAllT
 
 {- | Run a simplification, returning the result of only one branch.
@@ -208,20 +187,18 @@ __Warning__: @runSimplifier@ calls 'error' if the 'Simplifier' does not contain
 exactly one branch. Use 'evalSimplifierBranch' to evaluation simplifications
 that may branch.
 -}
-runSimplifier :: Monad smt => Env (SimplifierT smt) -> SimplifierT smt a -> smt a
-runSimplifier env simplifier =
-    runReaderT (evalStateT (runSimplifierT simplifier) initCache) env
+runSimplifier :: Env -> Simplifier a -> SMT a
+runSimplifier env (Simplifier simplifier) =
+    runReaderT (evalStateT simplifier initCache) env
 
 mkSimplifierEnv ::
-    forall smt.
-    (MonadLog smt, MonadSMT smt, MonadMask smt, MonadProf smt, MonadIO smt) =>
     SimplifierXSwitch ->
     VerifiedModuleSyntax Attribute.Symbol ->
     SortGraph ->
     OverloadGraph ->
     SmtMetadataTools Attribute.Symbol ->
     Map AxiomIdentifier [Equation VariableName] ->
-    smt (Env (SimplifierT smt))
+    SMT Env
 mkSimplifierEnv simplifierXSwitch verifiedModule sortGraph overloadGraph metadataTools rawEquations =
     runSimplifier earlyEnv initialize
   where
@@ -257,7 +234,7 @@ mkSimplifierEnv simplifierXSwitch verifiedModule sortGraph overloadGraph metadat
         {-# SCC "evalSimplifier/overloadSimplifier" #-}
         mkOverloadSimplifier overloadGraph injSimplifier
 
-    initialize :: SimplifierT smt (Env (SimplifierT smt))
+    initialize :: Simplifier Env
     initialize = do
         equations <-
             Equation.simplifyExtractedEquations $
@@ -296,27 +273,23 @@ exactly one branch. Use 'evalSimplifierBranch' to evaluation simplifications
 that may branch.
 -}
 evalSimplifier ::
-    forall smt a.
-    (MonadLog smt, MonadSMT smt, MonadMask smt, MonadProf smt, MonadIO smt) =>
     SimplifierXSwitch ->
     VerifiedModuleSyntax Attribute.Symbol ->
     SortGraph ->
     OverloadGraph ->
     SmtMetadataTools Attribute.Symbol ->
     Map AxiomIdentifier [Equation VariableName] ->
-    SimplifierT smt a ->
-    smt a
+    Simplifier a ->
+    SMT a
 evalSimplifier simplifierXSwitch verifiedModule sortGraph overloadGraph metadataTools rawEquations simplifier = do
     env <- mkSimplifierEnv simplifierXSwitch verifiedModule sortGraph overloadGraph metadataTools rawEquations
     runSimplifier env simplifier
 
 evalSimplifierProofs ::
-    forall smt a.
-    (MonadLog smt, MonadSMT smt, MonadMask smt, MonadProf smt, MonadIO smt) =>
     SimplifierXSwitch ->
     VerifiedModule Attribute.Symbol ->
-    SimplifierT smt a ->
-    smt a
+    Simplifier a ->
+    SMT a
 evalSimplifierProofs simplifierXSwitch verifiedModule simplifier =
     evalSimplifier simplifierXSwitch (indexedModuleSyntax verifiedModule) sortGraph overloadGraph metadataTools rawEquations simplifier
   where
@@ -337,13 +310,3 @@ evalSimplifierProofs simplifierXSwitch verifiedModule simplifier =
         OverloadGraph.fromIndexedModule verifiedModule
     metadataTools = MetadataTools.build verifiedModule'
     rawEquations = Equation.extractEquations verifiedModule'
-
-mapSimplifierT ::
-    forall m b.
-    Monad m =>
-    (forall a. m a -> m a) ->
-    SimplifierT m b ->
-    SimplifierT m b
-mapSimplifierT f simplifierT =
-    SimplifierT . StateT $ \s ->
-        Morph.hoist f (runStateT (runSimplifierT simplifierT) s)

--- a/kore/test/Test/Kore/Builtin/Bool.hs
+++ b/kore/test/Test/Kore/Builtin/Bool.hs
@@ -40,7 +40,7 @@ import Kore.Rewrite.RewritingVariable (
     configElementVariableFromId,
  )
 import Kore.Simplify.Data (
-    SimplifierT,
+    Simplifier,
     runSimplifier,
  )
 import Kore.Simplify.Not qualified as Not
@@ -49,7 +49,6 @@ import Kore.Unification.UnifierT (
     runUnifierT,
  )
 import Prelude.Kore
-import SMT qualified
 import Test.Kore.Builtin.Builtin
 import Test.Kore.Builtin.Definition
 import Test.SMT
@@ -236,7 +235,7 @@ test_unifyBoolOr =
             & lift
             & run
 
-run :: MaybeT (UnifierT (SimplifierT SMT.SMT)) a -> IO [Maybe a]
+run :: MaybeT (UnifierT Simplifier) a -> IO [Maybe a]
 run =
     runNoSMT
         . runSimplifier testEnv
@@ -246,7 +245,7 @@ run =
 termSimplifier ::
     TermLike RewritingVariableName ->
     TermLike RewritingVariableName ->
-    UnifierT (SimplifierT SMT.SMT) (Pattern RewritingVariableName)
+    UnifierT Simplifier (Pattern RewritingVariableName)
 termSimplifier = \term1 term2 ->
     runMaybeT (worker term1 term2 <|> worker term2 term1)
         >>= maybe (fallback term1 term2) return

--- a/kore/test/Test/Kore/Builtin/Builtin.hs
+++ b/kore/test/Test/Kore/Builtin/Builtin.hs
@@ -27,9 +27,6 @@ module Test.Kore.Builtin.Builtin (
 ) where
 
 import Control.Monad ((>=>))
-import Control.Monad.Catch (
-    MonadMask,
- )
 import Control.Monad.Trans.Maybe (runMaybeT)
 import Data.Map.Strict (
     Map,
@@ -243,7 +240,7 @@ testOverloadSimplifier =
 
 -- TODO(Ana): if needed, create copy with experimental simplifier
 -- enabled
-testEnv :: MonadSimplify simplifier => Env simplifier
+testEnv :: Env
 testEnv =
     Env
         { metadataTools = testMetadataTools
@@ -264,17 +261,15 @@ simplify =
         . (simplifyTerm SideCondition.top >=> Logic.scatter)
 
 evaluateTerm ::
-    (MonadSMT smt, MonadLog smt, MonadProf smt, MonadMask smt) =>
     TermLike RewritingVariableName ->
-    smt (OrPattern RewritingVariableName)
+    SMT (OrPattern RewritingVariableName)
 evaluateTerm termLike =
     runSimplifier testEnv $
         Pattern.simplify (Pattern.fromTermLike termLike)
 
 evaluatePredicate ::
-    (MonadSMT smt, MonadLog smt, MonadProf smt, MonadMask smt) =>
     Predicate RewritingVariableName ->
-    smt (OrPattern RewritingVariableName)
+    SMT (OrPattern RewritingVariableName)
 evaluatePredicate predicate =
     runSimplifier testEnv $
         Pattern.simplify
@@ -285,23 +280,20 @@ evaluatePredicate predicate =
 
 evaluateTermT ::
     MonadTrans t =>
-    (MonadSMT smt, MonadLog smt, MonadProf smt, MonadMask smt) =>
     TermLike RewritingVariableName ->
-    t smt (OrPattern RewritingVariableName)
+    t SMT (OrPattern RewritingVariableName)
 evaluateTermT = lift . evaluateTerm
 
 evaluatePredicateT ::
     MonadTrans t =>
-    (MonadSMT smt, MonadLog smt, MonadProf smt, MonadMask smt) =>
     Predicate RewritingVariableName ->
-    t smt (OrPattern RewritingVariableName)
+    t SMT (OrPattern RewritingVariableName)
 evaluatePredicateT = lift . evaluatePredicate
 
 evaluateExpectTopK ::
     HasCallStack =>
-    (MonadSMT smt, MonadLog smt, MonadProf smt, MonadMask smt) =>
     TermLike RewritingVariableName ->
-    Hedgehog.PropertyT smt ()
+    Hedgehog.PropertyT SMT ()
 evaluateExpectTopK termLike = do
     actual <- evaluateTermT termLike
     OrPattern.topOf kSort Hedgehog.=== actual

--- a/kore/test/Test/Kore/Exec.hs
+++ b/kore/test/Test/Kore/Exec.hs
@@ -12,9 +12,6 @@ module Test.Kore.Exec (
 ) where
 
 import Control.Exception as Exception
-import Control.Monad.Catch (
-    MonadMask,
- )
 import Data.Default (
     def,
  )
@@ -89,10 +86,7 @@ import Kore.Rewrite.Search qualified as Search
 import Kore.Rewrite.Strategy (
     LimitExceeded (..),
  )
-import Kore.Simplify.Data (
-    MonadProf,
- )
-import Kore.Simplify.Simplify (MonadSMT, SimplifierXSwitch (..))
+import Kore.Simplify.Simplify (SimplifierXSwitch (..))
 import Kore.Syntax.Definition hiding (
     Alias,
     Symbol,
@@ -107,9 +101,9 @@ import Kore.Validate.DefinitionVerifier (
 import Kore.Verified qualified as Verified
 import Log (
     Entry (..),
-    MonadLog (..),
  )
 import Prelude.Kore
+import SMT (SMT)
 import SMT qualified
 import System.Exit (
     ExitCode (..),
@@ -1032,17 +1026,12 @@ test_execGetExitCode =
 -- disabled; this change should be made when we add the first
 -- experimental feature;
 execTest ::
-    MonadIO smt =>
-    MonadLog smt =>
-    MonadSMT smt =>
-    MonadMask smt =>
-    MonadProf smt =>
     Limit Natural ->
     Limit Natural ->
     VerifiedModule Attribute.StepperAttributes ->
     ExecutionMode ->
     TermLike VariableName ->
-    smt (ExitCode, TermLike VariableName)
+    SMT (ExitCode, TermLike VariableName)
 execTest depthLimit breadthLimit verifiedModule strategy initial = do
     serializedModule <- makeSerializedModule DisabledSimplifierX verifiedModule
     exec
@@ -1054,18 +1043,13 @@ execTest depthLimit breadthLimit verifiedModule strategy initial = do
         initial
 
 searchTest ::
-    MonadIO smt =>
-    MonadLog smt =>
-    MonadSMT smt =>
-    MonadMask smt =>
-    MonadProf smt =>
     Limit Natural ->
     Limit Natural ->
     VerifiedModule Attribute.StepperAttributes ->
     TermLike VariableName ->
     Pattern VariableName ->
     Search.Config ->
-    smt (TermLike VariableName)
+    SMT (TermLike VariableName)
 searchTest depthLimit breadthLimit verifiedModule initial currentSearchPattern config = do
     serializedModule <- makeSerializedModule DisabledSimplifierX verifiedModule
     search
@@ -1078,23 +1062,13 @@ searchTest depthLimit breadthLimit verifiedModule initial currentSearchPattern c
         config
 
 matchDisjunctionTest ::
-    MonadLog smt =>
-    MonadSMT smt =>
-    MonadIO smt =>
-    MonadMask smt =>
-    MonadProf smt =>
     VerifiedModule Attribute.Symbol ->
     Pattern RewritingVariableName ->
     [Pattern RewritingVariableName] ->
-    smt (TermLike VariableName)
+    SMT (TermLike VariableName)
 matchDisjunctionTest = matchDisjunction DisabledSimplifierX
 
 checkFunctionsTest ::
-    MonadLog smt =>
-    MonadSMT smt =>
-    MonadIO smt =>
-    MonadMask smt =>
-    MonadProf smt =>
     VerifiedModule Attribute.StepperAttributes ->
-    smt ()
+    SMT ()
 checkFunctionsTest = checkFunctions DisabledSimplifierX

--- a/kore/test/Test/Kore/Repl/Interpreter.hs
+++ b/kore/test/Test/Kore/Repl/Interpreter.hs
@@ -747,7 +747,7 @@ runWithState command axioms claims claim stateTransformer = do
     ((c, s), logEntries) <-
         runLogger $
             replInterpreter0
-                @(SimplifierT SMT)
+                @Simplifier
                 (modifyAuxOutput output)
                 (modifyKoreOutput output)
                 command
@@ -833,7 +833,7 @@ mkState startTime axioms claims claim =
 
 mkConfig ::
     MVar (Log.LogAction IO Log.ActualEntry) ->
-    Config (SimplifierT SMT)
+    Config Simplifier
 mkConfig logger =
     Config
         { stepper = stepper0
@@ -849,7 +849,7 @@ mkConfig logger =
         [Axiom] ->
         ExecutionGraph ->
         ReplNode ->
-        SimplifierT SMT ExecutionGraph
+        Simplifier ExecutionGraph
     stepper0 claims' axioms' graph (ReplNode node) =
         proveClaimStep Nothing EnabledStuckCheck claims' axioms' graph node
 

--- a/kore/test/Test/Kore/Rewrite.hs
+++ b/kore/test/Test/Kore/Rewrite.hs
@@ -5,9 +5,6 @@ module Test.Kore.Rewrite (
 
 import Control.Exception qualified as Exception
 import Control.Lens qualified as Lens
-import Control.Monad.Catch (
-    MonadThrow,
- )
 import Data.Generics.Product
 import Data.Generics.Wrapped (
     _Unwrapped,
@@ -391,9 +388,7 @@ runStepWorker ::
         ~ Strategy.ExecutionGraph
             (ProgramState (Pattern RewritingVariableName))
             (RewriteRule RewritingVariableName) =>
-    MonadSimplify simplifier =>
-    MonadThrow simplifier =>
-    (Env simplifier -> simplifier result -> IO result) ->
+    (Env -> Simplifier result -> IO result) ->
     -- | depth limit
     Limit Natural ->
     -- | breadth limit

--- a/kore/test/Test/Kore/Rewrite/Axiom/Matcher.hs
+++ b/kore/test/Test/Kore/Rewrite/Axiom/Matcher.hs
@@ -1355,7 +1355,7 @@ match ::
 match first second =
     runSimplifier Mock.env matchResult
   where
-    matchResult :: SimplifierT SMT MatchResult
+    matchResult :: Simplifier MatchResult
     matchResult = matchIncremental SideCondition.top first second
 
 withMatch ::

--- a/kore/test/Test/Kore/Rewrite/Axiom/Registry.hs
+++ b/kore/test/Test/Kore/Rewrite/Axiom/Registry.hs
@@ -455,7 +455,7 @@ testProcessedAxiomPatterns =
 testMetadataTools :: SmtMetadataTools Attribute.Symbol
 testMetadataTools = MetadataTools.build testIndexedModule
 
-testEnv :: Env (SimplifierT SMT)
+testEnv :: Env
 testEnv =
     Mock.env
         { metadataTools = testMetadataTools

--- a/kore/test/Test/Kore/Rewrite/Function/Evaluator.hs
+++ b/kore/test/Test/Kore/Rewrite/Function/Evaluator.hs
@@ -119,5 +119,5 @@ simplifierAxioms = Map.fromList [(fId, fEvaluator)]
   where
     fId = Axiom.Identifier.Application (TermLike.symbolConstructor fSymbol)
 
-env :: Test.Env (Test.SimplifierT Test.SMT)
+env :: Test.Env
 env = Mock.env{Test.simplifierAxioms = simplifierAxioms}

--- a/kore/test/Test/Kore/Rewrite/Function/Integration.hs
+++ b/kore/test/Test/Kore/Rewrite/Function/Integration.hs
@@ -2038,7 +2038,7 @@ testInjSimplifier =
 
 -- TODO(Ana): if needed, create copy with experimental simplifier
 -- enabled
-testEnv :: MonadSimplify simplifier => Env simplifier
+testEnv :: Env
 testEnv =
     Env
         { metadataTools = testMetadataTools
@@ -2057,7 +2057,7 @@ testEnv =
         , simplifierXSwitch = DisabledSimplifierX
         }
 
-testEnvUnification :: Env (SimplifierT SMT)
+testEnvUnification :: Env
 testEnvUnification =
     testEnv
         { simplifierAxioms =

--- a/kore/test/Test/Kore/Rewrite/MockSymbols.hs
+++ b/kore/test/Test/Kore/Rewrite/MockSymbols.hs
@@ -2303,7 +2303,7 @@ overloadSimplifier = mkOverloadSimplifier overloadGraph injSimplifier
 
 -- TODO(Ana): if needed, create copy with experimental simplifier
 -- enabled
-env :: MonadSimplify simplifier => Env simplifier
+env :: Env
 env =
     Env
         { metadataTools = Test.Kore.Rewrite.MockSymbols.metadataTools

--- a/kore/test/Test/Kore/Simplify.hs
+++ b/kore/test/Test/Kore/Simplify.hs
@@ -12,7 +12,6 @@ module Test.Kore.Simplify (
 
     -- * Re-exports
     Simplifier,
-    SimplifierT,
     SMT,
     Env (..),
     Kore.MonadSimplify,
@@ -65,7 +64,6 @@ import Kore.Rewrite.SMT.Declaration (
 import Kore.Simplify.Data (
     Env (..),
     Simplifier,
-    SimplifierT,
  )
 import Kore.Simplify.Data qualified as Kore
 import Logic (
@@ -78,17 +76,17 @@ import SMT (
 import Test.Kore.Rewrite.MockSymbols qualified as Mock
 import Test.SMT qualified as Test
 
-runSimplifierSMT :: Env Simplifier -> Simplifier a -> IO a
+runSimplifierSMT :: Env -> Simplifier a -> IO a
 runSimplifierSMT env = Test.runSMT userInit . Kore.runSimplifier env
   where
     userInit = declareSortsSymbols Mock.smtDeclarations
 
-runSimplifier :: Env (SimplifierT SMT) -> SimplifierT SMT a -> IO a
+runSimplifier :: Env -> Simplifier a -> IO a
 runSimplifier env = Test.runNoSMT . Kore.runSimplifier env
 
 runSimplifierBranch ::
-    Env (SimplifierT SMT) ->
-    LogicT (SimplifierT SMT) a ->
+    Env ->
+    LogicT Simplifier a ->
     IO [a]
 runSimplifierBranch env = Test.runNoSMT . Kore.runSimplifierBranch env
 

--- a/kore/test/Test/Kore/Simplify/Overloading.hs
+++ b/kore/test/Test/Kore/Simplify/Overloading.hs
@@ -516,8 +516,7 @@ match ::
     IO TestMatchResult
 match termPair = runSimplifier Mock.env $ runExceptT matchResult
   where
-    matchResult ::
-        MatchOverloadingResult (SimplifierT SMT) RewritingVariableName
+    matchResult :: MatchOverloadingResult Simplifier RewritingVariableName
     matchResult = matchOverloading termPair
 
 withMatching ::

--- a/kore/test/Test/Kore/Simplify/TermLike.hs
+++ b/kore/test/Test/Kore/Simplify/TermLike.hs
@@ -108,7 +108,7 @@ simplifyWithSideCondition
                 . TermLike.simplify sideCondition
                 . mkRewritingTerm
 
-newtype TestSimplifier a = TestSimplifier {getTestSimplifier :: SimplifierT SMT a}
+newtype TestSimplifier a = TestSimplifier {getTestSimplifier :: Simplifier a}
     deriving newtype (Functor, Applicative, Monad)
     deriving newtype (MonadLog, MonadSMT, MonadThrow)
 

--- a/kore/test/Test/Kore/Unification/Unifier.hs
+++ b/kore/test/Test/Kore/Unification/Unifier.hs
@@ -33,7 +33,6 @@ import Kore.Simplify.Not qualified as Not
 import Kore.Simplify.Pattern qualified as Pattern
 import Kore.Simplify.Simplify (
     BuiltinAndAxiomSimplifierMap,
-    MonadSimplify,
  )
 import Kore.Simplify.SubstitutionSimplifier qualified as SubstitutionSimplifier
 import Kore.Unification.Procedure
@@ -132,7 +131,7 @@ dv2 =
             , domainValueChild = mkStringLiteral "dv2"
             }
 
-testEnv :: MonadSimplify simplifier => Env simplifier
+testEnv :: Env
 testEnv = Mock.env
 
 unificationProblem ::


### PR DESCRIPTION
Previously, `Simplifier` was defined as follows:

```haskell
newtype SimplifierT smt a =
  SimplifierT (StateT SimplifierCache (ReaderT (Env (SimplifierT smt)) smt) a)

type Simplifier = SimplifierT SMT
```

The `smt` type variable was instantiated to either `SMT` or `NoSMT`, depending on whether an external `SMT` solver was available. Now that `SMT` and `NoSMT` have been unified, we can define `Simplifier` as a base monad rather than a transformer:

```haskell
newtype Simplifier a =
  Simplifier (StateT SimplifierCache (ReaderT Env SMT) a)
```

This definition is simpler and allows us to remove parameterization from `Env`.

As a knock-on effect, this forces us to remove some of the unnecessary polymorphism over `MonadSMT` in the following functions:

* `makeSerializedModule`
* `exec`
* `search`
* `prove`
* `boundedModelCheck`
* `matchDisjunction`
* `checkFunctions`
* `mkSimplifierEnv`
* `evalSimplifier`
* `evalSimplifierProofs`
* `evaluateTerm`
* `evaluatePredicate`