### PR TITLE
Specialize Kore.Exec and Kore.Repl to Simplifier

### DIFF
--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -66,7 +66,7 @@ import Kore.Repl.Parser
 import Kore.Repl.State
 import Kore.Rewrite.Strategy qualified as Strategy
 import Kore.Simplify.Data (
-    MonadSimplify,
+    Simplifier,
  )
 import Kore.Syntax.Module (
     ModuleName (..),
@@ -79,9 +79,6 @@ import Kore.Unparser (
     unparseToString,
  )
 import Prelude.Kore
-import Prof (
-    MonadProf,
- )
 import System.Clock (
     Clock (Monotonic),
     TimeSpec,
@@ -107,11 +104,6 @@ import Text.Megaparsec (
  execution of proofs. Currently works via stdin/stdout interaction.
 -}
 runRepl ::
-    forall m.
-    MonadSimplify m =>
-    MonadIO m =>
-    MonadProf m =>
-    MonadMask m =>
     Maybe MinDepth ->
     StuckCheck ->
     -- | list of axioms to used in the proof
@@ -130,7 +122,7 @@ runRepl ::
     ModuleName ->
     Log.KoreLogOptions ->
     KFileLocations ->
-    m ()
+    Simplifier ()
 runRepl _ _ _ [] _ _ _ _ outputFile _ _ _ =
     let printTerm = maybe putStrLn writeFile (unOutputFile outputFile)
      in liftIO . printTerm . unparseToString $ topTerm
@@ -165,7 +157,7 @@ runRepl
                 RunScript ->
                     runReplCommand Exit newState
       where
-        runReplCommand :: ReplCommand -> ReplState -> m ()
+        runReplCommand :: ReplCommand -> ReplState -> Simplifier ()
         runReplCommand cmd st =
             void $
                 flip evalStateT st $
@@ -176,14 +168,14 @@ runRepl
         evaluateScript ::
             ReplScript ->
             ScriptModeOutput ->
-            RWST (Config m) String ReplState m ()
+            RWST Config String ReplState Simplifier ()
         evaluateScript script outputFlag =
             maybe
                 (pure ())
                 (flip parseEvalScript outputFlag)
                 (unReplScript script)
 
-        repl0 :: InputT (ReaderT (Config m) (StateT ReplState m)) ()
+        repl0 :: InputT (ReaderT Config (StateT ReplState Simplifier)) ()
         repl0 = do
             str <- prompt
             let command =
@@ -215,7 +207,7 @@ runRepl
                         }
                 }
 
-        config :: Config m
+        config :: Config
         config =
             Config
                 { stepper = stepper0
@@ -268,7 +260,7 @@ runRepl
             [Axiom] ->
             ExecutionGraph ->
             ReplNode ->
-            m ExecutionGraph
+            Simplifier ExecutionGraph
         stepper0 claims axioms graph rnode = do
             let node = unReplNode rnode
             if Graph.outdeg (Strategy.graph graph) node == 0
@@ -278,7 +270,7 @@ runRepl
                         & Exception.handle (someExceptionHandler graph)
                 else pure graph
 
-        withConfigurationHandler :: a -> Claim.WithConfiguration -> m a
+        withConfigurationHandler :: a -> Claim.WithConfiguration -> Simplifier a
         withConfigurationHandler
             _
             (Claim.WithConfiguration lastConfiguration someException) =
@@ -289,7 +281,7 @@ runRepl
                             ("// Last configuration:\n" <> unparseToString lastConfiguration)
                     Exception.throwM someException
 
-        someExceptionHandler :: a -> Exception.SomeException -> m a
+        someExceptionHandler :: a -> Exception.SomeException -> Simplifier a
         someExceptionHandler a someException = do
             case Exception.fromException someException of
                 Just (Log.SomeEntry entry) ->
@@ -298,7 +290,7 @@ runRepl
                     errorException someException
             pure a
 
-        replGreeting :: m ()
+        replGreeting :: Simplifier ()
         replGreeting =
             liftIO $
                 putStrLn "Welcome to the Kore Repl! Use 'help' to get started.\n"

--- a/kore/src/Kore/Repl/Data.hs
+++ b/kore/src/Kore/Repl/Data.hs
@@ -95,7 +95,7 @@ import Kore.Rewrite.RewritingVariable (
  )
 import Kore.Rewrite.Strategy qualified as Strategy
 import Kore.Simplify.Data (
-    MonadSimplify (..),
+    Simplifier,
  )
 import Kore.Simplify.Not qualified as Not
 import Kore.Syntax.Module (
@@ -574,14 +574,14 @@ data ReplState = ReplState
     deriving stock (GHC.Generic)
 
 -- | Configuration environment for the repl.
-data Config m = Config
+data Config = Config
     { -- | Stepper function
       stepper ::
         [SomeClaim] ->
         [Axiom] ->
         ExecutionGraph ->
         ReplNode ->
-        m ExecutionGraph
+        Simplifier ExecutionGraph
     , -- | Unifier function, it is a partially applied 'unificationProcedure'
       --   where we discard the result since we are looking for unification
       --   failures
@@ -589,7 +589,7 @@ data Config m = Config
         SideCondition RewritingVariableName ->
         TermLike RewritingVariableName ->
         TermLike RewritingVariableName ->
-        UnifierT m (Condition RewritingVariableName)
+        UnifierT Simplifier (Condition RewritingVariableName)
     , -- | Logger function, see 'logging'.
       logger :: MVar (LogAction IO ActualEntry)
     , -- | Output resulting pattern to this file.
@@ -633,14 +633,13 @@ makeKoreReplOutput str =
     ReplOutput . return . KoreOut $ str <> "\n"
 
 runUnifierWithoutExplanation ::
-    forall m a.
-    MonadSimplify m =>
-    UnifierT m a ->
-    m (Maybe (NonEmpty a))
+    forall a.
+    UnifierT Simplifier a ->
+    Simplifier (Maybe (NonEmpty a))
 runUnifierWithoutExplanation unifier =
     failEmptyList <$> unificationResults
   where
-    unificationResults :: m [a]
+    unificationResults :: Simplifier [a]
     unificationResults = Monad.Unify.runUnifierT Not.notSimplifier unifier
     failEmptyList :: [a] -> Maybe (NonEmpty a)
     failEmptyList results =

--- a/kore/src/Kore/Repl/Interpreter.hs
+++ b/kore/src/Kore/Repl/Interpreter.hs
@@ -37,9 +37,6 @@ import Control.Lens qualified as Lens
 import Control.Monad (
     (<=<),
  )
-import Control.Monad.Catch (
-    MonadMask,
- )
 import Control.Monad.Extra (
     ifM,
     loop,
@@ -185,7 +182,7 @@ import Kore.Rewrite.RewritingVariable (
 import Kore.Rewrite.RulePattern qualified as RulePattern
 import Kore.Rewrite.Strategy qualified as Strategy
 import Kore.Simplify.Data (
-    MonadSimplify,
+    Simplifier,
  )
 import Kore.Syntax.Application
 import Kore.Syntax.Id qualified as Id (
@@ -249,20 +246,16 @@ import Text.Megaparsec (
  rid of the WriterT part of the stack. This happens in the implementation of
  'replInterpreter'.
 -}
-type ReplM m a = RWST (Config m) ReplOutput ReplState m a
+type ReplM a = RWST Config ReplOutput ReplState Simplifier a
 
 data ReplStatus = Continue | SuccessStop | FailStop
     deriving stock (Eq, Show)
 
 -- | Interprets a REPL command in a stateful Simplifier context.
 replInterpreter ::
-    forall m.
-    MonadSimplify m =>
-    MonadIO m =>
-    MonadMask m =>
     (forall n. MonadIO n => String -> InputT n ()) ->
     ReplCommand ->
-    InputT (ReaderT (Config m) (StateT ReplState m)) ReplStatus
+    InputT (ReaderT Config (StateT ReplState Simplifier)) ReplStatus
 replInterpreter fn cmd =
     replInterpreter0
         (PrintAuxOutput fn)
@@ -270,14 +263,10 @@ replInterpreter fn cmd =
         cmd
 
 replInterpreter0 ::
-    forall m.
-    MonadSimplify m =>
-    MonadIO m =>
-    MonadMask m =>
     PrintAuxOutput ->
     PrintKoreOutput ->
     ReplCommand ->
-    InputT (ReaderT (Config m) (StateT ReplState m)) ReplStatus
+    InputT (ReaderT Config (StateT ReplState Simplifier)) ReplStatus
 replInterpreter0 printAux printKore replCmd = do
     let command = case replCmd of
             ShowUsage -> showUsage $> Continue
@@ -350,8 +339,8 @@ replInterpreter0 printAux printKore replCmd = do
     -- and updates the state, returning the writer output along with the
     -- monadic result.
     evaluateCommand ::
-        ReplM m ReplStatus ->
-        ReaderT (Config m) (StateT ReplState m) (ReplOutput, ReplStatus)
+        ReplM ReplStatus ->
+        ReaderT Config (StateT ReplState Simplifier) (ReplOutput, ReplStatus)
     evaluateCommand c = do
         st <- get
         config <- Reader.ask
@@ -381,9 +370,7 @@ showStepStoppedMessage n sr =
 showUsage :: MonadWriter ReplOutput m => m ()
 showUsage = putStrLn' showUsageMessage
 
-exit ::
-    MonadIO m =>
-    ReplM m ReplStatus
+exit :: ReplM ReplStatus
 exit = do
     proofs <- allProofs
     ofile <- Lens.view (field @"outputFile")
@@ -521,11 +508,9 @@ showGraph view mfile out = do
 
 -- | Executes 'n' prove steps, or until branching occurs.
 proveSteps ::
-    MonadSimplify m =>
-    MonadIO m =>
     -- | maximum number of steps to perform
     Natural ->
-    ReplM m ()
+    ReplM ()
 proveSteps n = do
     let node = ReplNode . fromEnum $ n
     result <- loopM performStepNoBranching (n, SingleResult node)
@@ -538,11 +523,9 @@ proveSteps n = do
 than 'n' steps if the proof is stuck or completed in less than 'n' steps.
 -}
 proveStepsF ::
-    MonadSimplify m =>
-    MonadIO m =>
     -- | maximum number of steps to perform
     Natural ->
-    ReplM m ()
+    ReplM ()
 proveStepsF n = do
     node <- Lens.use (field @"node")
     recursiveForcedStep n node
@@ -554,13 +537,9 @@ proveStepsF n = do
 
 -- | Loads a script from a file.
 loadScript ::
-    forall m.
-    MonadSimplify m =>
-    MonadIO m =>
-    MonadMask m =>
     -- | path to file
     FilePath ->
-    ReplM m ()
+    ReplM ()
 loadScript file = parseEvalScript file DisableOutput
 
 -- | Change the general log settings.
@@ -618,31 +597,28 @@ selectNode rnode = do
 
 -- | Shows configuration at node 'n', or current node if 'Nothing' is passed.
 showConfig ::
-    Monad m =>
     -- | 'Nothing' for current node, or @Just n@ for a specific node identifier
     Maybe ReplNode ->
-    ReplM m ()
+    ReplM ()
 showConfig =
     showClaimStateComponent "Config" (from @_ @(OrPattern _) . getConfiguration)
 
 -- | Shows destination at node 'n', or current node if 'Nothing' is passed.
 showDest ::
-    Monad m =>
     -- | 'Nothing' for current node, or @Just n@ for a specific node identifier
     Maybe ReplNode ->
-    ReplM m ()
+    ReplM ()
 showDest =
     showClaimStateComponent
         "Destination"
         getDestination
 
 showClaimStateComponent ::
-    Monad m =>
     -- | component name
     String ->
     (SomeClaim -> OrPattern RewritingVariableName) ->
     Maybe ReplNode ->
-    ReplM m ()
+    ReplM ()
 showClaimStateComponent name transformer maybeNode = do
     maybeClaimState <- getClaimStateAt maybeNode
     case maybeClaimState of
@@ -660,24 +636,22 @@ showClaimStateComponent name transformer maybeNode = do
  depending on whether the string already exists in the list or not.
 -}
 omitCell ::
-    forall m.
-    Monad m =>
     -- | Nothing to show current list, @Just str@ to add/remove to list
     Maybe String ->
-    ReplM m ()
+    ReplM ()
 omitCell =
     \case
         Nothing -> showCells
         Just str -> addOrRemove str
   where
-    showCells :: ReplM m ()
+    showCells :: ReplM ()
     showCells = do
         omit <- Lens.use (field @"omit")
         if Set.null omit
             then putStrLn' "Omit list is currently empty."
             else traverse_ putStrLn' omit
 
-    addOrRemove :: String -> ReplM m ()
+    addOrRemove :: String -> ReplM ()
     addOrRemove str = field @"omit" %= toggle str
 
     toggle :: String -> Set String -> Set String
@@ -688,7 +662,7 @@ omitCell =
 {- | Shows all leaf nodes identifiers which are either stuck or can be
  evaluated further.
 -}
-showLeafs :: forall m. Monad m => ReplM m ()
+showLeafs :: ReplM ()
 showLeafs = do
     leafsByType <- sortLeafsByType <$> getInnerGraph
     case Map.foldMapWithKey showPair leafsByType of
@@ -698,15 +672,12 @@ showLeafs = do
     showPair :: NodeState -> [Graph.Node] -> String
     showPair ns xs = show ns <> ": " <> show xs
 
-proofStatus :: forall m. Monad m => ReplM m ()
+proofStatus :: ReplM ()
 proofStatus = do
     proofs <- allProofs
     putStrLn' . showProofStatus $ proofs
 
-allProofs ::
-    forall m.
-    Monad m =>
-    ReplM m (Map.Map ClaimIndex GraphProofStatus)
+allProofs :: ReplM (Map.Map ClaimIndex GraphProofStatus)
 allProofs = do
     graphs <- Lens.use (field @"graphs")
     claims <- Lens.use (field @"claims")
@@ -760,9 +731,8 @@ showRule configNode = do
             putStrLn' $ showRuleIdentifier rule
 
 showRules ::
-    Monad m =>
     (ReplNode, ReplNode) ->
-    ReplM m ()
+    ReplM ()
 showRules (ReplNode node1, ReplNode node2) = do
     graph <- getInnerGraph
     let path =
@@ -808,10 +778,9 @@ showRuleIdentifier rule =
 
 -- | Shows the previous branching point.
 showPrecBranch ::
-    Monad m =>
     -- | 'Nothing' for current node, or @Just n@ for a specific node identifier
     Maybe ReplNode ->
-    ReplM m ()
+    ReplM ()
 showPrecBranch maybeNode = do
     graph <- getInnerGraph
     node' <- getTargetNode maybeNode
@@ -830,10 +799,9 @@ showPrecBranch maybeNode = do
 
 -- | Shows the next node(s) for the selected node.
 showChildren ::
-    Monad m =>
     -- | 'Nothing' for current node, or @Just n@ for a specific node identifier
     Maybe ReplNode ->
-    ReplM m ()
+    ReplM ()
 showChildren maybeNode = do
     graph <- getInnerGraph
     node' <- getTargetNode maybeNode
@@ -906,29 +874,21 @@ labelDel lbl = do
 
 -- | Redirect command to specified file.
 redirect ::
-    forall m.
-    MonadSimplify m =>
-    MonadIO m =>
-    MonadMask m =>
     -- | command to redirect
     ReplCommand ->
     -- | file path
     FilePath ->
-    ReplM m ()
+    ReplM ()
 redirect cmd file = do
     liftIO $ withExistingDirectory file (`writeFile` "")
     appendCommand cmd file
 
 runInterpreterWithOutput ::
-    forall m.
-    MonadSimplify m =>
-    MonadIO m =>
-    MonadMask m =>
     PrintAuxOutput ->
     PrintKoreOutput ->
     ReplCommand ->
-    Config m ->
-    ReplM m ()
+    Config ->
+    ReplM ()
 runInterpreterWithOutput printAux printKore cmd config =
     get
         >>= ( \st ->
@@ -945,32 +905,23 @@ data AlsoApplyRule = Never | IfPossible
  current node.
 -}
 tryAxiomClaim ::
-    forall m.
-    MonadSimplify m =>
-    MonadIO m =>
     -- | tagged index in the axioms or claims list
     RuleReference ->
-    ReplM m ()
+    ReplM ()
 tryAxiomClaim = tryAxiomClaimWorker Never
 
 -- | Attempt to use a specific axiom or claim to progress the current proof.
 tryFAxiomClaim ::
-    forall m.
-    MonadSimplify m =>
-    MonadIO m =>
     -- | tagged index in the axioms or claims list
     RuleReference ->
-    ReplM m ()
+    ReplM ()
 tryFAxiomClaim = tryAxiomClaimWorker IfPossible
 
 tryAxiomClaimWorker ::
-    forall m.
-    MonadSimplify m =>
-    MonadIO m =>
     AlsoApplyRule ->
     -- | tagged index in the axioms or claims list
     RuleReference ->
-    ReplM m ()
+    ReplM ()
 tryAxiomClaimWorker mode ref = do
     maybeAxiomOrClaim <-
         ruleReference
@@ -1020,7 +971,7 @@ tryAxiomClaimWorker mode ref = do
     showUnificationFailure ::
         Either Axiom SomeClaim ->
         ReplNode ->
-        ReplM m ()
+        ReplM ()
     showUnificationFailure axiomOrClaim' node = do
         let first = extractLeftPattern axiomOrClaim'
         maybeSecond <- getClaimStateAt (Just node)
@@ -1037,7 +988,7 @@ tryAxiomClaimWorker mode ref = do
                         }
                     (getConfiguration <$> second)
               where
-                patternUnifier :: Pattern RewritingVariableName -> ReplM m ()
+                patternUnifier :: Pattern RewritingVariableName -> ReplM ()
                 patternUnifier
                     (Pattern.splitTerm -> (secondTerm, secondCondition)) =
                         runUnifier' sideCondition first secondTerm
@@ -1049,7 +1000,7 @@ tryAxiomClaimWorker mode ref = do
     tryForceAxiomOrClaim ::
         Either Axiom SomeClaim ->
         ReplNode ->
-        ReplM m ()
+        ReplM ()
     tryForceAxiomOrClaim axiomOrClaim node = do
         (graph, result) <-
             tryApplyAxiomOrClaim axiomOrClaim node
@@ -1070,7 +1021,7 @@ tryAxiomClaimWorker mode ref = do
         SideCondition RewritingVariableName ->
         TermLike RewritingVariableName ->
         TermLike RewritingVariableName ->
-        ReplM m ()
+        ReplM ()
     runUnifier' sideCondition first second =
         runUnifier sideCondition first' second
             >>= tell . formatUnificationMessage
@@ -1161,11 +1112,9 @@ saveSessionWithMessage notifySuccess path =
     seqUnlines = unlines . toList
 
 savePartialProof ::
-    forall m.
-    MonadIO m =>
     Maybe Natural ->
     FilePath ->
-    ReplM m ()
+    ReplM ()
 savePartialProof maybeNatural file = do
     currentIndex <- Lens.use (field @"claimIndex")
     claims <- Lens.use (field @"claims")
@@ -1188,7 +1137,7 @@ savePartialProof maybeNatural file = do
   where
     saveUnparsedDefinitionToFile ::
         Pretty.Doc ann ->
-        ReplM m ()
+        ReplM ()
     saveUnparsedDefinitionToFile definition =
         liftIO $
             withFile
@@ -1222,17 +1171,13 @@ output. AuxOut will not be piped, instead it will be sent directly to the repl's
 output.
 -}
 pipe ::
-    forall m.
-    MonadIO m =>
-    MonadMask m =>
-    MonadSimplify m =>
     -- | command to pipe
     ReplCommand ->
     -- | path to the program that will receive the command's output
     String ->
     -- | additional arguments to be passed to the program
     [String] ->
-    ReplM m ()
+    ReplM ()
 pipe cmd file args = do
     exists <- liftIO $ findExecutable file
     case exists of
@@ -1267,26 +1212,18 @@ pipe cmd file args = do
 
 -- | Appends output of a command to a file.
 appendTo ::
-    forall m.
-    MonadSimplify m =>
-    MonadIO m =>
-    MonadMask m =>
     -- | command
     ReplCommand ->
     -- | file to append to
     FilePath ->
-    ReplM m ()
+    ReplM ()
 appendTo cmd file =
     withExistingDirectory file (appendCommand cmd)
 
 appendCommand ::
-    forall m.
-    MonadSimplify m =>
-    MonadIO m =>
-    MonadMask m =>
     ReplCommand ->
     FilePath ->
-    ReplM m ()
+    ReplM ()
 appendCommand cmd file = do
     config <- ask
     runInterpreterWithOutput
@@ -1309,14 +1246,10 @@ alias a = do
         Right _ -> pure ()
 
 tryAlias ::
-    forall m.
-    MonadSimplify m =>
-    MonadIO m =>
-    MonadMask m =>
     ReplAlias ->
     PrintAuxOutput ->
     PrintKoreOutput ->
-    ReplM m ReplStatus
+    ReplM ReplStatus
 tryAlias replAlias@ReplAlias{name} printAux printKore = do
     res <- findAlias name
     case res of
@@ -1334,9 +1267,9 @@ tryAlias replAlias@ReplAlias{name} printAux printKore = do
   where
     runInterpreter ::
         ReplCommand ->
-        Config m ->
+        Config ->
         ReplState ->
-        ReplM m (ReplStatus, ReplState)
+        ReplM (ReplStatus, ReplState)
     runInterpreter cmd config st =
         lift $
             (`runStateT` st) $
@@ -1351,12 +1284,9 @@ tryAlias replAlias@ReplAlias{name} printAux printKore = do
  See 'loopM' for details.
 -}
 performStepNoBranching ::
-    forall m.
-    MonadSimplify m =>
-    MonadIO m =>
     -- | (current step, last result)
     (Natural, StepResult) ->
-    ReplM m (Either (Natural, StepResult) (Natural, StepResult))
+    ReplM (Either (Natural, StepResult) (Natural, StepResult))
 performStepNoBranching =
     \case
         -- Termination branch
@@ -1371,11 +1301,9 @@ performStepNoBranching =
 -- TODO(Vladimir): It would be ideal for this to be implemented in terms of
 -- 'performStepNoBranching'.
 recursiveForcedStep ::
-    MonadSimplify m =>
-    MonadIO m =>
     Natural ->
     ReplNode ->
-    ReplM m ()
+    ReplM ()
 recursiveForcedStep n node
     | n == 0 = pure ()
     | otherwise = do
@@ -1600,16 +1528,13 @@ instance ShowErrorComponent ReplScriptParseError where
     showErrorComponent (ReplScriptParseError err) = err
 
 parseEvalScript ::
-    forall t m.
-    MonadSimplify m =>
-    MonadIO m =>
-    MonadMask m =>
-    MonadState ReplState (t m) =>
-    MonadReader (Config m) (t m) =>
+    forall t.
+    MonadState ReplState (t Simplifier) =>
+    MonadReader Config (t Simplifier) =>
     Monad.Trans.MonadTrans t =>
     FilePath ->
     ScriptModeOutput ->
-    t m ()
+    t Simplifier ()
 parseEvalScript file scriptModeOutput = do
     exists <- lift . liftIO . doesFileExist $ file
     if exists
@@ -1634,7 +1559,7 @@ parseEvalScript file scriptModeOutput = do
 
     executeScript ::
         [ReplCommand] ->
-        t m ()
+        t Simplifier ()
     executeScript cmds = do
         config <- ask
         get >>= executeCommands config >>= put
@@ -1649,7 +1574,7 @@ parseEvalScript file scriptModeOutput = do
 
         executeCommand ::
             ReplCommand ->
-            ReaderT (Config m) (StateT ReplState m) ReplStatus
+            ReaderT Config (StateT ReplState Simplifier) ReplStatus
         executeCommand command =
             runInputT defaultSettings $
                 replInterpreter0
@@ -1659,7 +1584,7 @@ parseEvalScript file scriptModeOutput = do
 
         executeCommandWithOutput ::
             ReplCommand ->
-            ReaderT (Config m) (StateT ReplState m) ReplStatus
+            ReaderT Config (StateT ReplState Simplifier) ReplStatus
         executeCommandWithOutput command = do
             node <- Lens.use (field @"node")
             liftIO $ putStr $ "Kore (" <> show (unReplNode node) <> ")> "

--- a/kore/test/Test/Kore/Repl/Interpreter.hs
+++ b/kore/test/Test/Kore/Repl/Interpreter.hs
@@ -747,7 +747,6 @@ runWithState command axioms claims claim stateTransformer = do
     ((c, s), logEntries) <-
         runLogger $
             replInterpreter0
-                @Simplifier
                 (modifyAuxOutput output)
                 (modifyKoreOutput output)
                 command
@@ -833,7 +832,7 @@ mkState startTime axioms claims claim =
 
 mkConfig ::
     MVar (Log.LogAction IO Log.ActualEntry) ->
-    Config Simplifier
+    Config
 mkConfig logger =
     Config
         { stepper = stepper0


### PR DESCRIPTION
In those modules the abstract monad was never instantiated to anything but `Simplifier`, so it was straightforward to specialize it.