### PR TITLE
Implement --smt-retry-limit option

### DIFF
--- a/kore/src/Kore/Rewrite/SMT/Evaluator.hs
+++ b/kore/src/Kore/Rewrite/SMT/Evaluator.hs
@@ -190,8 +190,8 @@ decidePredicate sideCondition predicates =
         -- Use the same timeout for the first retry, since sometimes z3
         -- decides it doesn't want to work today and all we need is to
         -- retry it once.
-        let timeoutScales = takeWithin limit [1..]
-        let retryActions = map retryOnceWithScaledTimeout timeoutScales 
+        let timeoutScales = takeWithin limit [1 ..]
+        let retryActions = map retryOnceWithScaledTimeout timeoutScales
         let combineRetries r1 r2 = r1 >>= whenUnknown r2
         -- This works even if 'retryActions' is infinite, because the second
         -- argument to 'whenUnknown' will be the 'combineRetries' of all of
@@ -200,13 +200,13 @@ decidePredicate sideCondition predicates =
         foldr combineRetries (pure Unknown) retryActions
 
     retryOnceWithScaledTimeout :: Integer -> MaybeT simplifier Result
-    retryOnceWithScaledTimeout scale = 
+    retryOnceWithScaledTimeout scale =
         -- scale the timeout _inside_ 'retryOnce' so that we override the
         -- call to 'SMT.reinit'.
         retryOnce $ SMT.localTimeOut (scaleTimeOut scale) query
 
     scaleTimeOut _ (SMT.TimeOut Unlimited) = SMT.TimeOut Unlimited
-    scaleTimeOut n (SMT.TimeOut (Limit r)) = SMT.TimeOut (Limit (n*r)) 
+    scaleTimeOut n (SMT.TimeOut (Limit r)) = SMT.TimeOut (Limit (n * r))
 
     retryOnce actionToRetry = do
         SMT.reinit

--- a/kore/src/Options/SMT.hs
+++ b/kore/src/Options/SMT.hs
@@ -77,7 +77,7 @@ parseKoreSolverOptions =
                 <> help "Timeout for calls to the SMT solver, in milliseconds"
                 <> value defaultTimeOut
             )
-    
+
     parseRetryLimit =
         option
             readRetryLimit

--- a/kore/src/SMT.hs
+++ b/kore/src/SMT.hs
@@ -620,23 +620,28 @@ reinitSMT =
         Nothing -> return ()
         Just solverSetup -> reinitSMT' solverSetup
 
--- | Run a solver action with an adjusted timeout,
--- and reset the timeout when it's done.
+{- | Run a solver action with an adjusted timeout,
+ and reset the timeout when it's done.
+-}
 localTimeOut :: MonadSMT m => (TimeOut -> TimeOut) -> m a -> m a
 localTimeOut adjust isolated = do
     originalTimeOut <- liftSMT extractTimeOut
     setTimeOut $ adjust originalTimeOut
     isolated <* setTimeOut originalTimeOut
-    where
-        extractTimeOut = SMT $ pure . \case
-            Nothing -> TimeOut Unlimited
-            Just setup -> timeOut $ config setup
+  where
+    extractTimeOut =
+        SMT $
+            pure . \case
+                Nothing -> TimeOut Unlimited
+                Just setup -> timeOut $ config setup
 
 -- | Get the retry limit for SMT queries.
 askRetryLimitSMT :: SMT RetryLimit
-askRetryLimitSMT = SMT $ pure . \case
-    Nothing -> RetryLimit (Limit 0)
-    Just setup -> retryLimit $ config setup
+askRetryLimitSMT =
+    SMT $
+        pure . \case
+            Nothing -> RetryLimit (Limit 0)
+            Just setup -> retryLimit $ config setup
 
 -- --------------------------------
 -- Internal


### PR DESCRIPTION
Fixes #3162

### Scope:

Add a new option, `--smt-retry-limit`, which controls how many times we will retry an SMT query that returned `Unknown`. Previously, we would always retry once.

### Estimate:

I think it's done already, but it's unclear where tests for this feature should go (or even if there should be any, as retries were previously untested anyway).

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [x] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [x] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [x] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
