### PR TITLE
[nix] Rematerialize GHC9 in the CI

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -27,22 +27,26 @@ jobs:
           ref: ${{ steps.config.outputs.ref }}
           submodules: recursive
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v14.1
+      - name: 'Install Nix'
+        uses: cachix/install-nix-action@v15
         with:
           extra_nix_config: |
-            substituters = http://cache.nixos.org https://hydra.iohk.io
+            substituters = http://cache.nixos.org https://cache.iog.io
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
-          install_url: "https://releases.nixos.org/nix/nix-2.3.16/install"
 
-      - name: Install Cachix
+      - name: 'Install Cachix'
         uses: cachix/cachix-action@v10
         with:
           name: runtimeverification
+          extraPullNames: kore
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
 
+
       - name: Materialize
-        run: ./nix/rematerialize.sh
+        run: GC_DONT_GC=1 nix run .#update-cabal
+
+      - name: Materialize GHC 9
+        run: GC_DONT_GC=1 nix run .#update-cabal-ghc9
 
       - name: Update branch
         env:

--- a/flake.lock
+++ b/flake.lock
@@ -98,6 +98,21 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "ghc-8.6.5-iohk": {
       "flake": false,
       "locked": {
@@ -221,6 +236,26 @@
       "original": {
         "owner": "kristapsdz",
         "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "mach-nix": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2",
+        "pypi-deps-db": "pypi-deps-db"
+      },
+      "locked": {
+        "lastModified": 1657089034,
+        "narHash": "sha256-qSjk1iOi14ijAOP6QuGfE3fvy08aVxsgus+ArwgiyuU=",
+        "owner": "DavHau",
+        "repo": "mach-nix",
+        "rev": "51caf584f26acdfaa51bbf7ee1ffa365aea7bc64",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DavHau",
+        "repo": "mach-nix",
         "type": "github"
       }
     },
@@ -355,6 +390,21 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1643805626,
+        "narHash": "sha256-AXLDVMG+UaAGsGSpOtQHPIKB+IZ0KSd9WS77aanGzgc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "554d2d8aa25b6e583575459c297ec23750adb6cb",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
     "old-ghc-nix": {
       "flake": false,
       "locked": {
@@ -372,9 +422,26 @@
         "type": "github"
       }
     },
+    "pypi-deps-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1643877077,
+        "narHash": "sha256-jv8pIvRFTP919GybOxXE5TfOkrjTbdo9QiCO1TD3ZaY=",
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "rev": "da53397f0b782b0b18deb72ef8e0fb5aa7c98aa3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "haskell-nix": "haskell-nix",
+        "mach-nix": "mach-nix",
         "nixpkgs": [
           "haskell-nix",
           "nixpkgs-unstable"

--- a/flake.nix
+++ b/flake.nix
@@ -104,6 +104,7 @@
             "rematerialize-kore-nix-${compiler-nix-name}" ''
               #!/bin/sh
               ${self.stack-nix.passthru.generateMaterialized} ./nix/kore-${compiler-nix-name}.nix.d
+              ${pkgs.nixfmt}/bin/nixfmt ./nix/kore-${compiler-nix-name}.nix.d/*.nix
             '';
         };
 

--- a/nix/kore-ghc8107.nix.d/default.nix
+++ b/nix/kore-ghc8107.nix.d/default.nix
@@ -1,32 +1,34 @@
 {
-  extras = hackage:
-    {
-      packages = {
-        "ghc-trace-events" = (((hackage.ghc-trace-events)."0.1.2.1").revisions).default;
-        "monoidal-containers" = (((hackage.monoidal-containers)."0.6.0.1").revisions).default;
-        "newtype" = (((hackage.newtype)."0.2.2.0").revisions).default;
-        "sqlite-simple" = (((hackage.sqlite-simple)."0.4.18.0").revisions).default;
-        "direct-sqlite" = (((hackage.direct-sqlite)."2.3.26").revisions).default;
-        "witherable" = (((hackage.witherable)."0.3.5").revisions).default;
-        "witherable-class" = (((hackage.witherable-class)."0").revisions).default;
-        "co-log" = (((hackage.co-log)."0.4.0.1").revisions).default;
-        "tasty-test-reporter" = (((hackage.tasty-test-reporter)."0.1.1.4").revisions).default;
-        "junit-xml" = (((hackage.junit-xml)."0.1.0.0").revisions).default;
-        "compact" = (((hackage.compact)."0.2.0.0").revisions).default;
-        "decision-diagrams" = (((hackage.decision-diagrams)."0.2.0.0").revisions).default;
-        "ghc-events" = (((hackage.ghc-events)."0.13.0").revisions).default;
-        kore = ./kore.nix;
-        eventlog2speedscope = ./.stack-to-nix.cache.0;
-        pipes-ghc-events = ./.stack-to-nix.cache.1;
-        pipes-sqlite-simple = ./.stack-to-nix.cache.2;
-        };
-      };
+  extras = hackage: {
+    packages = {
+      "ghc-trace-events" =
+        (((hackage.ghc-trace-events)."0.1.2.1").revisions).default;
+      "monoidal-containers" =
+        (((hackage.monoidal-containers)."0.6.0.1").revisions).default;
+      "newtype" = (((hackage.newtype)."0.2.2.0").revisions).default;
+      "sqlite-simple" =
+        (((hackage.sqlite-simple)."0.4.18.0").revisions).default;
+      "direct-sqlite" = (((hackage.direct-sqlite)."2.3.26").revisions).default;
+      "witherable" = (((hackage.witherable)."0.3.5").revisions).default;
+      "witherable-class" = (((hackage.witherable-class)."0").revisions).default;
+      "co-log" = (((hackage.co-log)."0.4.0.1").revisions).default;
+      "tasty-test-reporter" =
+        (((hackage.tasty-test-reporter)."0.1.1.4").revisions).default;
+      "junit-xml" = (((hackage.junit-xml)."0.1.0.0").revisions).default;
+      "compact" = (((hackage.compact)."0.2.0.0").revisions).default;
+      "decision-diagrams" =
+        (((hackage.decision-diagrams)."0.2.0.0").revisions).default;
+      "ghc-events" = (((hackage.ghc-events)."0.13.0").revisions).default;
+      kore = ./kore.nix;
+      eventlog2speedscope = ./.stack-to-nix.cache.0;
+      pipes-ghc-events = ./.stack-to-nix.cache.1;
+      pipes-sqlite-simple = ./.stack-to-nix.cache.2;
+    };
+  };
   resolver = "lts-18.18";
   modules = [
-    ({ lib, ... }:
-      { packages = {}; })
+    ({ lib, ... }: { packages = { }; })
     { packages = { "$everything" = { ghcOptions = [ "-haddock" ]; }; }; }
-    ({ lib, ... }:
-      { planned = lib.mkOverride 900 true; })
-    ];
-  }
+    ({ lib, ... }: { planned = lib.mkOverride 900 true; })
+  ];
+}

--- a/nix/kore-ghc8107.nix.d/kore.nix
+++ b/nix/kore-ghc8107.nix.d/kore.nix
@@ -1,37 +1,673 @@
-{ system
-  , compiler
-  , flags
-  , pkgs
-  , hsPkgs
-  , pkgconfPkgs
-  , errorHandler
-  , config
-  , ... }:
-  {
-    flags = { threaded = true; };
-    package = {
-      specVersion = "2.2";
-      identifier = { name = "kore"; version = "0.60.0.0"; };
-      license = "BSD-3-Clause";
-      copyright = "2018-2021 Runtime Verification Inc";
-      maintainer = "ana.pantilie@runtimeverification.com";
-      author = "Runtime Verification Inc";
-      homepage = "https://github.com/runtimeverification/haskell-backend#readme";
-      url = "";
-      synopsis = "";
-      description = "Please see the [README](README.md) file.";
-      buildType = "Simple";
-      isLocal = true;
-      detailLevel = "FullDetails";
-      licenseFiles = [ "LICENSE" ];
-      dataDir = ".";
-      dataFiles = [];
-      extraSrcFiles = [ "README.md" "CHANGELOG.md" ];
-      extraTmpFiles = [];
-      extraDocFiles = [];
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, errorHandler, config, ...
+}:
+{
+  flags = { threaded = true; };
+  package = {
+    specVersion = "2.2";
+    identifier = {
+      name = "kore";
+      version = "0.60.0.0";
+    };
+    license = "BSD-3-Clause";
+    copyright = "2018-2021 Runtime Verification Inc";
+    maintainer = "ana.pantilie@runtimeverification.com";
+    author = "Runtime Verification Inc";
+    homepage = "https://github.com/runtimeverification/haskell-backend#readme";
+    url = "";
+    synopsis = "";
+    description = "Please see the [README](README.md) file.";
+    buildType = "Simple";
+    isLocal = true;
+    detailLevel = "FullDetails";
+    licenseFiles = [ "LICENSE" ];
+    dataDir = ".";
+    dataFiles = [ ];
+    extraSrcFiles = [ "README.md" "CHANGELOG.md" ];
+    extraTmpFiles = [ ];
+    extraDocFiles = [ ];
+  };
+  components = {
+    "library" = {
+      depends = [
+        (hsPkgs."base" or (errorHandler.buildDepError "base"))
+        (hsPkgs."adjunctions" or (errorHandler.buildDepError "adjunctions"))
+        (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+        (hsPkgs."aeson-pretty" or (errorHandler.buildDepError "aeson-pretty"))
+        (hsPkgs."array" or (errorHandler.buildDepError "array"))
+        (hsPkgs."async" or (errorHandler.buildDepError "async"))
+        (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
+        (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+        (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
+        (hsPkgs."co-log" or (errorHandler.buildDepError "co-log"))
+        (hsPkgs."comonad" or (errorHandler.buildDepError "comonad"))
+        (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
+        (hsPkgs."conduit-extra" or (errorHandler.buildDepError "conduit-extra"))
+        (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+        (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
+        (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+        (hsPkgs."decision-diagrams" or (errorHandler.buildDepError
+          "decision-diagrams"))
+        (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+        (hsPkgs."deriving-aeson" or (errorHandler.buildDepError
+          "deriving-aeson"))
+        (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+        (hsPkgs."distributive" or (errorHandler.buildDepError "distributive"))
+        (hsPkgs."errors" or (errorHandler.buildDepError "errors"))
+        (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
+        (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+        (hsPkgs."fgl" or (errorHandler.buildDepError "fgl"))
+        (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+        (hsPkgs."free" or (errorHandler.buildDepError "free"))
+        (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
+        (hsPkgs."generics-sop" or (errorHandler.buildDepError "generics-sop"))
+        (hsPkgs."ghc-trace-events" or (errorHandler.buildDepError
+          "ghc-trace-events"))
+        (hsPkgs."gitrev" or (errorHandler.buildDepError "gitrev"))
+        (hsPkgs."graphviz" or (errorHandler.buildDepError "graphviz"))
+        (hsPkgs."hashable" or (errorHandler.buildDepError "hashable"))
+        (hsPkgs."haskeline" or (errorHandler.buildDepError "haskeline"))
+        (hsPkgs."integer-gmp" or (errorHandler.buildDepError "integer-gmp"))
+        (hsPkgs."json-rpc" or (errorHandler.buildDepError "json-rpc"))
+        (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+        (hsPkgs."logict" or (errorHandler.buildDepError "logict"))
+        (hsPkgs."matrix" or (errorHandler.buildDepError "matrix"))
+        (hsPkgs."megaparsec" or (errorHandler.buildDepError "megaparsec"))
+        (hsPkgs."mmorph" or (errorHandler.buildDepError "mmorph"))
+        (hsPkgs."monad-logger" or (errorHandler.buildDepError "monad-logger"))
+        (hsPkgs."mono-traversable" or (errorHandler.buildDepError
+          "mono-traversable"))
+        (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
+        (hsPkgs."multiset" or (errorHandler.buildDepError "multiset"))
+        (hsPkgs."optparse-applicative" or (errorHandler.buildDepError
+          "optparse-applicative"))
+        (hsPkgs."parser-combinators" or (errorHandler.buildDepError
+          "parser-combinators"))
+        (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
+        (hsPkgs."process" or (errorHandler.buildDepError "process"))
+        (hsPkgs."profunctors" or (errorHandler.buildDepError "profunctors"))
+        (hsPkgs."recursion-schemes" or (errorHandler.buildDepError
+          "recursion-schemes"))
+        (hsPkgs."semialign" or (errorHandler.buildDepError "semialign"))
+        (hsPkgs."sqlite-simple" or (errorHandler.buildDepError "sqlite-simple"))
+        (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+        (hsPkgs."streams" or (errorHandler.buildDepError "streams"))
+        (hsPkgs."tar" or (errorHandler.buildDepError "tar"))
+        (hsPkgs."template-haskell" or (errorHandler.buildDepError
+          "template-haskell"))
+        (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
+        (hsPkgs."text" or (errorHandler.buildDepError "text"))
+        (hsPkgs."these" or (errorHandler.buildDepError "these"))
+        (hsPkgs."time" or (errorHandler.buildDepError "time"))
+        (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+        (hsPkgs."unordered-containers" or (errorHandler.buildDepError
+          "unordered-containers"))
+        (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
+        (hsPkgs."witherable" or (errorHandler.buildDepError "witherable"))
+        (hsPkgs."zlib" or (errorHandler.buildDepError "zlib"))
+      ];
+      build-tools = [
+        (hsPkgs.buildPackages.happy.components.exes.happy or (pkgs.buildPackages.happy or (errorHandler.buildToolDepError
+          "happy:happy")))
+        (hsPkgs.buildPackages.alex.components.exes.alex or (pkgs.buildPackages.alex or (errorHandler.buildToolDepError
+          "alex:alex")))
+      ];
+      buildable = true;
+      modules = [
+        "Changed"
+        "Control/Monad/Counter"
+        "Data/Graph/TopologicalSort"
+        "Data/Limit"
+        "Data/Sup"
+        "Debug"
+        "ErrorContext"
+        "From"
+        "GlobalMain"
+        "Injection"
+        "Kore/AST/ApplicativeKore"
+        "Kore/AST/AstWithLocation"
+        "Kore/AST/Common"
+        "Kore/AST/Error"
+        "Kore/Attribute/Assoc"
+        "Kore/Attribute/Attributes"
+        "Kore/Attribute/Axiom"
+        "Kore/Attribute/Axiom/Concrete"
+        "Kore/Attribute/Axiom/Constructor"
+        "Kore/Attribute/Axiom/NonExecutable"
+        "Kore/Attribute/Axiom/Symbolic"
+        "Kore/Attribute/Axiom/Unit"
+        "Kore/Attribute/Comm"
+        "Kore/Attribute/Constructor"
+        "Kore/Attribute/Definition"
+        "Kore/Attribute/Function"
+        "Kore/Attribute/Functional"
+        "Kore/Attribute/Hook"
+        "Kore/Attribute/Idem"
+        "Kore/Attribute/Injective"
+        "Kore/Attribute/Label"
+        "Kore/Attribute/Location"
+        "Kore/Attribute/Null"
+        "Kore/Attribute/Overload"
+        "Kore/Attribute/Owise"
+        "Kore/Attribute/Parser"
+        "Kore/Attribute/Pattern/ConstructorLike"
+        "Kore/Attribute/Pattern/Created"
+        "Kore/Attribute/Pattern/Defined"
+        "Kore/Attribute/Pattern/FreeVariables"
+        "Kore/Attribute/Pattern/Function"
+        "Kore/Attribute/Pattern/Functional"
+        "Kore/Attribute/Pattern/Simplified"
+        "Kore/Attribute/PredicatePattern"
+        "Kore/Attribute/Priority"
+        "Kore/Attribute/ProductionID"
+        "Kore/Attribute/RuleIndex"
+        "Kore/Attribute/Simplification"
+        "Kore/Attribute/Smthook"
+        "Kore/Attribute/SmtLemma"
+        "Kore/Attribute/Smtlib"
+        "Kore/Attribute/Smtlib/Smthook"
+        "Kore/Attribute/Smtlib/Smtlib"
+        "Kore/Attribute/Sort"
+        "Kore/Attribute/Sort/Concat"
+        "Kore/Attribute/Sort/Constructors"
+        "Kore/Attribute/Sort/ConstructorsBuilder"
+        "Kore/Attribute/Sort/Element"
+        "Kore/Attribute/Sort/HasDomainValues"
+        "Kore/Attribute/Sort/Unit"
+        "Kore/Attribute/SortInjection"
+        "Kore/Attribute/Source"
+        "Kore/Attribute/SourceLocation"
+        "Kore/Attribute/Subsort"
+        "Kore/Attribute/Symbol"
+        "Kore/Attribute/Symbol/Anywhere"
+        "Kore/Attribute/Symbol/Klabel"
+        "Kore/Attribute/Symbol/Memo"
+        "Kore/Attribute/Symbol/NoEvaluators"
+        "Kore/Attribute/Symbol/SymbolKywd"
+        "Kore/Attribute/Synthetic"
+        "Kore/Attribute/Trusted"
+        "Kore/Attribute/UniqueId"
+        "Kore/BugReport"
+        "Kore/Builtin"
+        "Kore/Builtin/AssocComm/AssocComm"
+        "Kore/Builtin/AssocComm/CeilSimplifier"
+        "Kore/Builtin/AssociativeCommutative"
+        "Kore/Builtin/Attributes"
+        "Kore/Builtin/Bool"
+        "Kore/Builtin/Bool/Bool"
+        "Kore/Builtin/Builtin"
+        "Kore/Builtin/Encoding"
+        "Kore/Builtin/Endianness"
+        "Kore/Builtin/Endianness/Endianness"
+        "Kore/Builtin/EqTerm"
+        "Kore/Builtin/Error"
+        "Kore/Builtin/Inj"
+        "Kore/Builtin/Int"
+        "Kore/Builtin/Int/Int"
+        "Kore/Builtin/InternalBytes"
+        "Kore/Builtin/InternalBytes/InternalBytes"
+        "Kore/Builtin/KEqual"
+        "Kore/Builtin/Kreflection"
+        "Kore/Builtin/Krypto"
+        "Kore/Builtin/List"
+        "Kore/Builtin/List/List"
+        "Kore/Builtin/Map"
+        "Kore/Builtin/Map/Map"
+        "Kore/Builtin/Set"
+        "Kore/Builtin/Set/Set"
+        "Kore/Builtin/Signedness"
+        "Kore/Builtin/Signedness/Signedness"
+        "Kore/Builtin/String"
+        "Kore/Builtin/String/String"
+        "Kore/Builtin/Symbols"
+        "Kore/Builtin/Verifiers"
+        "Kore/Debug"
+        "Kore/Equation"
+        "Kore/Equation/Application"
+        "Kore/Equation/DebugEquation"
+        "Kore/Equation/Equation"
+        "Kore/Equation/Registry"
+        "Kore/Equation/Sentence"
+        "Kore/Equation/Simplification"
+        "Kore/Equation/Validate"
+        "Kore/Error"
+        "Kore/Exec"
+        "Kore/IndexedModule/Error"
+        "Kore/IndexedModule/IndexedModule"
+        "Kore/IndexedModule/MetadataTools"
+        "Kore/IndexedModule/MetadataToolsBuilder"
+        "Kore/IndexedModule/OverloadGraph"
+        "Kore/IndexedModule/Resolvers"
+        "Kore/IndexedModule/SortGraph"
+        "Kore/Internal/Alias"
+        "Kore/Internal/ApplicationSorts"
+        "Kore/Internal/Condition"
+        "Kore/Internal/Conditional"
+        "Kore/Internal/From"
+        "Kore/Internal/Inj"
+        "Kore/Internal/InternalBool"
+        "Kore/Internal/InternalBytes"
+        "Kore/Internal/InternalInt"
+        "Kore/Internal/InternalList"
+        "Kore/Internal/InternalMap"
+        "Kore/Internal/InternalSet"
+        "Kore/Internal/InternalString"
+        "Kore/Internal/Key"
+        "Kore/Internal/MultiAnd"
+        "Kore/Internal/MultiExists"
+        "Kore/Internal/MultiOr"
+        "Kore/Internal/NormalizedAc"
+        "Kore/Internal/OrCondition"
+        "Kore/Internal/OrPattern"
+        "Kore/Internal/Pattern"
+        "Kore/Internal/Predicate"
+        "Kore/Internal/SideCondition"
+        "Kore/Internal/SideCondition/SideCondition"
+        "Kore/Internal/Substitution"
+        "Kore/Internal/Symbol"
+        "Kore/Internal/TermLike"
+        "Kore/Internal/TermLike/Renaming"
+        "Kore/Internal/TermLike/TermLike"
+        "Kore/Internal/Variable"
+        "Kore/JsonRpc"
+        "Kore/Log"
+        "Kore/Log/DebugAppliedRewriteRules"
+        "Kore/Log/DebugAttemptedRewriteRules"
+        "Kore/Log/DebugBeginClaim"
+        "Kore/Log/DebugCreatedSubstitution"
+        "Kore/Log/DebugEvaluateCondition"
+        "Kore/Log/DebugProven"
+        "Kore/Log/DebugRetrySolverQuery"
+        "Kore/Log/DebugSolver"
+        "Kore/Log/DebugSubstitutionSimplifier"
+        "Kore/Log/DebugTransition"
+        "Kore/Log/DebugUnification"
+        "Kore/Log/DebugUnifyBottom"
+        "Kore/Log/ErrorBottomTotalFunction"
+        "Kore/Log/ErrorDecidePredicateUnknown"
+        "Kore/Log/ErrorEquationRightFunction"
+        "Kore/Log/ErrorEquationsSameMatch"
+        "Kore/Log/ErrorException"
+        "Kore/Log/ErrorOutOfDate"
+        "Kore/Log/ErrorParse"
+        "Kore/Log/ErrorRewriteLoop"
+        "Kore/Log/ErrorRewritesInstantiation"
+        "Kore/Log/ErrorVerify"
+        "Kore/Log/InfoAttemptUnification"
+        "Kore/Log/JsonRpc"
+        "Kore/Log/InfoExecBreadth"
+        "Kore/Log/InfoExecDepth"
+        "Kore/Log/InfoProofDepth"
+        "Kore/Log/InfoReachability"
+        "Kore/Log/KoreLogOptions"
+        "Kore/Log/Registry"
+        "Kore/Log/SQLite"
+        "Kore/Log/WarnBoundedModelChecker"
+        "Kore/Log/WarnClaimRHSIsBottom"
+        "Kore/Log/WarnDepthLimitExceeded"
+        "Kore/Log/WarnFunctionWithoutEvaluators"
+        "Kore/Log/WarnIfLowProductivity"
+        "Kore/Log/WarnNotImplemented"
+        "Kore/Log/WarnRestartSolver"
+        "Kore/Log/WarnStuckClaimState"
+        "Kore/Log/WarnSymbolSMTRepresentation"
+        "Kore/Log/WarnTrivialClaim"
+        "Kore/Log/WarnUnsimplified"
+        "Kore/ModelChecker/Bounded"
+        "Kore/ModelChecker/Simplification"
+        "Kore/ModelChecker/Step"
+        "Kore/Options"
+        "Kore/Parser"
+        "Kore/Parser/CString"
+        "Kore/Parser/Lexer"
+        "Kore/Parser/LexerWrapper"
+        "Kore/Parser/Parser"
+        "Kore/Parser/ParserUtils"
+        "Kore/Reachability"
+        "Kore/Reachability/AllPathClaim"
+        "Kore/Reachability/Claim"
+        "Kore/Reachability/ClaimState"
+        "Kore/Reachability/OnePathClaim"
+        "Kore/Reachability/Prim"
+        "Kore/Reachability/Prove"
+        "Kore/Reachability/SomeClaim"
+        "Kore/Repl"
+        "Kore/Repl/Data"
+        "Kore/Repl/Interpreter"
+        "Kore/Repl/Parser"
+        "Kore/Repl/State"
+        "Kore/Rewrite"
+        "Kore/Rewrite/AntiLeft"
+        "Kore/Rewrite/Axiom/EvaluationStrategy"
+        "Kore/Rewrite/Axiom/Identifier"
+        "Kore/Rewrite/Axiom/Matcher"
+        "Kore/Rewrite/Axiom/MatcherData"
+        "Kore/Rewrite/Axiom/Registry"
+        "Kore/Rewrite/AxiomPattern"
+        "Kore/Rewrite/ClaimPattern"
+        "Kore/Rewrite/Function/Evaluator"
+        "Kore/Rewrite/Function/Memo"
+        "Kore/Rewrite/Implication"
+        "Kore/Rewrite/Remainder"
+        "Kore/Rewrite/Result"
+        "Kore/Rewrite/RewriteStep"
+        "Kore/Rewrite/Rule"
+        "Kore/Rewrite/Rule/Expand"
+        "Kore/Rewrite/Rule/Simplify"
+        "Kore/Rewrite/RulePattern"
+        "Kore/Rewrite/Search"
+        "Kore/Rewrite/SMT/AST"
+        "Kore/Rewrite/SMT/Declaration"
+        "Kore/Rewrite/SMT/Encoder"
+        "Kore/Rewrite/SMT/Evaluator"
+        "Kore/Rewrite/SMT/Lemma"
+        "Kore/Rewrite/SMT/Representation/All"
+        "Kore/Rewrite/SMT/Representation/Resolve"
+        "Kore/Rewrite/SMT/Representation/Sorts"
+        "Kore/Rewrite/SMT/Representation/Symbols"
+        "Kore/Rewrite/SMT/Resolvers"
+        "Kore/Rewrite/SMT/Translate"
+        "Kore/Rewrite/Step"
+        "Kore/Rewrite/Strategy"
+        "Kore/Rewrite/Substitution"
+        "Kore/Rewrite/Transition"
+        "Kore/Rewrite/RewritingVariable"
+        "Kore/Rewrite/UnifyingRule"
+        "Kore/Simplify/And"
+        "Kore/Simplify/AndPredicates"
+        "Kore/Simplify/AndTerms"
+        "Kore/Simplify/API"
+        "Kore/Simplify/Application"
+        "Kore/Simplify/Bottom"
+        "Kore/Simplify/Ceil"
+        "Kore/Simplify/CeilSimplifier"
+        "Kore/Simplify/Condition"
+        "Kore/Simplify/DomainValue"
+        "Kore/Simplify/Equals"
+        "Kore/Simplify/Exists"
+        "Kore/Simplify/ExpandAlias"
+        "Kore/Simplify/Floor"
+        "Kore/Simplify/Forall"
+        "Kore/Simplify/Iff"
+        "Kore/Simplify/Implies"
+        "Kore/Simplify/In"
+        "Kore/Simplify/Inhabitant"
+        "Kore/Simplify/Inj"
+        "Kore/Simplify/InjSimplifier"
+        "Kore/Simplify/InternalBool"
+        "Kore/Simplify/InternalBytes"
+        "Kore/Simplify/InternalInt"
+        "Kore/Simplify/InternalList"
+        "Kore/Simplify/InternalMap"
+        "Kore/Simplify/InternalSet"
+        "Kore/Simplify/InternalString"
+        "Kore/Simplify/Mu"
+        "Kore/Simplify/Next"
+        "Kore/Simplify/NoConfusion"
+        "Kore/Simplify/Not"
+        "Kore/Simplify/NotSimplifier"
+        "Kore/Simplify/Nu"
+        "Kore/Simplify/Or"
+        "Kore/Simplify/OrPattern"
+        "Kore/Simplify/Overloading"
+        "Kore/Simplify/OverloadSimplifier"
+        "Kore/Simplify/Pattern"
+        "Kore/Simplify/Predicate"
+        "Kore/Simplify/SetVariable"
+        "Kore/Simplify/SimplificationType"
+        "Kore/Simplify/Simplify"
+        "Kore/Simplify/StringLiteral"
+        "Kore/Simplify/SubstitutionSimplifier"
+        "Kore/Simplify/TermLike"
+        "Kore/Simplify/Top"
+        "Kore/Simplify/Variable"
+        "Kore/Sort"
+        "Kore/Substitute"
+        "Kore/Syntax"
+        "Kore/Syntax/And"
+        "Kore/Syntax/Application"
+        "Kore/Syntax/Bottom"
+        "Kore/Syntax/Ceil"
+        "Kore/Syntax/Definition"
+        "Kore/Syntax/DomainValue"
+        "Kore/Syntax/Equals"
+        "Kore/Syntax/Exists"
+        "Kore/Syntax/Floor"
+        "Kore/Syntax/Forall"
+        "Kore/Syntax/Id"
+        "Kore/Syntax/Iff"
+        "Kore/Syntax/Implies"
+        "Kore/Syntax/In"
+        "Kore/Syntax/Inhabitant"
+        "Kore/Syntax/Json"
+        "Kore/Syntax/Json/Internal"
+        "Kore/Syntax/Module"
+        "Kore/Syntax/Mu"
+        "Kore/Syntax/Next"
+        "Kore/Syntax/Not"
+        "Kore/Syntax/Nu"
+        "Kore/Syntax/Or"
+        "Kore/Syntax/Pattern"
+        "Kore/Syntax/PatternF"
+        "Kore/Syntax/Rewrites"
+        "Kore/Syntax/Sentence"
+        "Kore/Syntax/StringLiteral"
+        "Kore/Syntax/Top"
+        "Kore/Syntax/Variable"
+        "Kore/TopBottom"
+        "Kore/Unification/Procedure"
+        "Kore/Unification/SubstitutionNormalization"
+        "Kore/Unification/SubstitutionSimplifier"
+        "Kore/Unification/UnifierT"
+        "Kore/Unification/Unify"
+        "Kore/Unification/NewUnifier"
+        "Kore/Unparser"
+        "Kore/Validate/AliasVerifier"
+        "Kore/Validate/AttributesVerifier"
+        "Kore/Validate/DefinitionVerifier"
+        "Kore/Validate/Error"
+        "Kore/Validate/ModuleVerifier"
+        "Kore/Validate/PatternVerifier"
+        "Kore/Validate/PatternVerifier/PatternVerifier"
+        "Kore/Validate/SentenceVerifier"
+        "Kore/Validate/SortVerifier"
+        "Kore/Validate/Verifier"
+        "Kore/Variables/Binding"
+        "Kore/Variables/Free"
+        "Kore/Variables/Fresh"
+        "Kore/Variables/Target"
+        "Kore/Verified"
+        "Kore/VersionInfo"
+        "Log"
+        "Log/Entry"
+        "Logic"
+        "Options/SMT"
+        "Pair"
+        "Partial"
+        "Paths_kore"
+        "Prelude/Kore"
+        "Pretty"
+        "Prof"
+        "SMT"
+        "SMT/AST"
+        "SMT/SimpleSMT"
+        "SQL"
+        "SQL/ColumnDef"
+        "SQL/Key"
+        "SQL/Query"
+        "SQL/SOP"
+        "SQL/SQL"
+        "Stats"
+      ];
+      hsSourceDirs = [ "src" "app/share" ];
+    };
+    exes = {
+      "kore-exec" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
+          (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
+          (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+          (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+          (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
+          (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+          (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+          (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
+          (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError
+            "optparse-applicative"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."time" or (errorHandler.buildDepError "time"))
+        ];
+        buildable = true;
+        hsSourceDirs = [ "app/exec" ];
+        mainPath = (([ "Main.hs" ]
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4")
+          "")
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8")
+          "") ++ [ "" ];
       };
-    components = {
-      "library" = {
+      "kore-rpc" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
+          (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
+          (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+          (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
+          (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError
+            "optparse-applicative"))
+          (hsPkgs."time" or (errorHandler.buildDepError "time"))
+        ];
+        buildable = true;
+        hsSourceDirs = [ "app/rpc" ];
+        mainPath = (([ "Main.hs" ]
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4")
+          "")
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8")
+          "") ++ [ "" ];
+      };
+      "kore-format" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError
+            "optparse-applicative"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+        ];
+        buildable = true;
+        hsSourceDirs = [ "app/format" ];
+        mainPath = (([ "Main.hs" ]
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4")
+          "")
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8")
+          "") ++ [ "" ];
+      };
+      "kore-parser" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
+        ];
+        buildable = true;
+        hsSourceDirs = [ "app/parser" ];
+        mainPath = (([ "Main.hs" ]
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4")
+          "")
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8")
+          "") ++ [ "" ];
+      };
+      "kore-prof" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
+          (hsPkgs."eventlog2speedscope" or (errorHandler.buildDepError
+            "eventlog2speedscope"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError
+            "optparse-applicative"))
+        ];
+        buildable = true;
+        hsSourceDirs = [ "app/prof" ];
+        mainPath = (([ "Main.hs" ]
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4")
+          "")
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8")
+          "") ++ [ "" ];
+      };
+      "kore-repl" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
+          (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
+          (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
+          (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError
+            "optparse-applicative"))
+        ];
+        buildable = true;
+        hsSourceDirs = [ "app/repl" ];
+        mainPath = (([ "Main.hs" ]
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4")
+          "")
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8")
+          "") ++ [ "" ];
+      };
+      "kore-match-disjunction" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
+          (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError
+            "optparse-applicative"))
+          (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+        ];
+        buildable = true;
+        hsSourceDirs = [ "app/match-disjunction" ];
+        mainPath = (([ "Main.hs" ]
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4")
+          "")
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8")
+          "") ++ [ "" ];
+      };
+      "kore-check-functions" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
+          (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
+          (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
+        ];
+        buildable = true;
+        hsSourceDirs = [ "app/check-functions" ];
+        mainPath = (([ "Main.hs" ]
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4")
+          "")
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8")
+          "") ++ [ "" ];
+      };
+      "kore-simplify" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
+          (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError
+            "optparse-applicative"))
+        ];
+        buildable = true;
+        hsSourceDirs = [ "app/simplify" ];
+        mainPath = (([ "Main.hs" ]
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4")
+          "")
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8")
+          "") ++ [ "" ];
+      };
+    };
+    tests = {
+      "kore-test" = {
         depends = [
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."adjunctions" or (errorHandler.buildDepError "adjunctions"))
@@ -45,13 +681,16 @@
           (hsPkgs."co-log" or (errorHandler.buildDepError "co-log"))
           (hsPkgs."comonad" or (errorHandler.buildDepError "comonad"))
           (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
-          (hsPkgs."conduit-extra" or (errorHandler.buildDepError "conduit-extra"))
+          (hsPkgs."conduit-extra" or (errorHandler.buildDepError
+            "conduit-extra"))
           (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
           (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
           (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
-          (hsPkgs."decision-diagrams" or (errorHandler.buildDepError "decision-diagrams"))
+          (hsPkgs."decision-diagrams" or (errorHandler.buildDepError
+            "decision-diagrams"))
           (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
-          (hsPkgs."deriving-aeson" or (errorHandler.buildDepError "deriving-aeson"))
+          (hsPkgs."deriving-aeson" or (errorHandler.buildDepError
+            "deriving-aeson"))
           (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
           (hsPkgs."distributive" or (errorHandler.buildDepError "distributive"))
           (hsPkgs."errors" or (errorHandler.buildDepError "errors"))
@@ -62,7 +701,8 @@
           (hsPkgs."free" or (errorHandler.buildDepError "free"))
           (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
           (hsPkgs."generics-sop" or (errorHandler.buildDepError "generics-sop"))
-          (hsPkgs."ghc-trace-events" or (errorHandler.buildDepError "ghc-trace-events"))
+          (hsPkgs."ghc-trace-events" or (errorHandler.buildDepError
+            "ghc-trace-events"))
           (hsPkgs."gitrev" or (errorHandler.buildDepError "gitrev"))
           (hsPkgs."graphviz" or (errorHandler.buildDepError "graphviz"))
           (hsPkgs."hashable" or (errorHandler.buildDepError "hashable"))
@@ -75,877 +715,273 @@
           (hsPkgs."megaparsec" or (errorHandler.buildDepError "megaparsec"))
           (hsPkgs."mmorph" or (errorHandler.buildDepError "mmorph"))
           (hsPkgs."monad-logger" or (errorHandler.buildDepError "monad-logger"))
-          (hsPkgs."mono-traversable" or (errorHandler.buildDepError "mono-traversable"))
+          (hsPkgs."mono-traversable" or (errorHandler.buildDepError
+            "mono-traversable"))
           (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
           (hsPkgs."multiset" or (errorHandler.buildDepError "multiset"))
-          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-          (hsPkgs."parser-combinators" or (errorHandler.buildDepError "parser-combinators"))
-          (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError
+            "optparse-applicative"))
+          (hsPkgs."parser-combinators" or (errorHandler.buildDepError
+            "parser-combinators"))
+          (hsPkgs."prettyprinter" or (errorHandler.buildDepError
+            "prettyprinter"))
           (hsPkgs."process" or (errorHandler.buildDepError "process"))
           (hsPkgs."profunctors" or (errorHandler.buildDepError "profunctors"))
-          (hsPkgs."recursion-schemes" or (errorHandler.buildDepError "recursion-schemes"))
+          (hsPkgs."recursion-schemes" or (errorHandler.buildDepError
+            "recursion-schemes"))
           (hsPkgs."semialign" or (errorHandler.buildDepError "semialign"))
-          (hsPkgs."sqlite-simple" or (errorHandler.buildDepError "sqlite-simple"))
+          (hsPkgs."sqlite-simple" or (errorHandler.buildDepError
+            "sqlite-simple"))
           (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
           (hsPkgs."streams" or (errorHandler.buildDepError "streams"))
           (hsPkgs."tar" or (errorHandler.buildDepError "tar"))
-          (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+          (hsPkgs."template-haskell" or (errorHandler.buildDepError
+            "template-haskell"))
           (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           (hsPkgs."these" or (errorHandler.buildDepError "these"))
           (hsPkgs."time" or (errorHandler.buildDepError "time"))
           (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
-          (hsPkgs."unordered-containers" or (errorHandler.buildDepError "unordered-containers"))
+          (hsPkgs."unordered-containers" or (errorHandler.buildDepError
+            "unordered-containers"))
           (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
           (hsPkgs."witherable" or (errorHandler.buildDepError "witherable"))
           (hsPkgs."zlib" or (errorHandler.buildDepError "zlib"))
-          ];
+          (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
+          (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+          (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
+          (hsPkgs."quickcheck-instances" or (errorHandler.buildDepError
+            "quickcheck-instances"))
+          (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+          (hsPkgs."tasty-golden" or (errorHandler.buildDepError "tasty-golden"))
+          (hsPkgs."tasty-hedgehog" or (errorHandler.buildDepError
+            "tasty-hedgehog"))
+          (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+          (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError
+            "tasty-quickcheck"))
+          (hsPkgs."tasty-test-reporter" or (errorHandler.buildDepError
+            "tasty-test-reporter"))
+        ];
         build-tools = [
-          (hsPkgs.buildPackages.happy.components.exes.happy or (pkgs.buildPackages.happy or (errorHandler.buildToolDepError "happy:happy")))
-          (hsPkgs.buildPackages.alex.components.exes.alex or (pkgs.buildPackages.alex or (errorHandler.buildToolDepError "alex:alex")))
-          ];
+          (hsPkgs.buildPackages.happy.components.exes.happy or (pkgs.buildPackages.happy or (errorHandler.buildToolDepError
+            "happy:happy")))
+          (hsPkgs.buildPackages.alex.components.exes.alex or (pkgs.buildPackages.alex or (errorHandler.buildToolDepError
+            "alex:alex")))
+          (hsPkgs.buildPackages.tasty-discover.components.exes.tasty-discover or (pkgs.buildPackages.tasty-discover or (errorHandler.buildToolDepError
+            "tasty-discover:tasty-discover")))
+        ];
         buildable = true;
         modules = [
-          "Changed"
-          "Control/Monad/Counter"
-          "Data/Graph/TopologicalSort"
-          "Data/Limit"
-          "Data/Sup"
-          "Debug"
-          "ErrorContext"
-          "From"
-          "GlobalMain"
-          "Injection"
-          "Kore/AST/ApplicativeKore"
-          "Kore/AST/AstWithLocation"
-          "Kore/AST/Common"
-          "Kore/AST/Error"
-          "Kore/Attribute/Assoc"
-          "Kore/Attribute/Attributes"
-          "Kore/Attribute/Axiom"
-          "Kore/Attribute/Axiom/Concrete"
-          "Kore/Attribute/Axiom/Constructor"
-          "Kore/Attribute/Axiom/NonExecutable"
-          "Kore/Attribute/Axiom/Symbolic"
-          "Kore/Attribute/Axiom/Unit"
-          "Kore/Attribute/Comm"
-          "Kore/Attribute/Constructor"
-          "Kore/Attribute/Definition"
-          "Kore/Attribute/Function"
-          "Kore/Attribute/Functional"
-          "Kore/Attribute/Hook"
-          "Kore/Attribute/Idem"
-          "Kore/Attribute/Injective"
-          "Kore/Attribute/Label"
-          "Kore/Attribute/Location"
-          "Kore/Attribute/Null"
-          "Kore/Attribute/Overload"
-          "Kore/Attribute/Owise"
-          "Kore/Attribute/Parser"
-          "Kore/Attribute/Pattern/ConstructorLike"
-          "Kore/Attribute/Pattern/Created"
-          "Kore/Attribute/Pattern/Defined"
-          "Kore/Attribute/Pattern/FreeVariables"
-          "Kore/Attribute/Pattern/Function"
-          "Kore/Attribute/Pattern/Functional"
-          "Kore/Attribute/Pattern/Simplified"
-          "Kore/Attribute/PredicatePattern"
-          "Kore/Attribute/Priority"
-          "Kore/Attribute/ProductionID"
-          "Kore/Attribute/RuleIndex"
-          "Kore/Attribute/Simplification"
-          "Kore/Attribute/Smthook"
-          "Kore/Attribute/SmtLemma"
-          "Kore/Attribute/Smtlib"
-          "Kore/Attribute/Smtlib/Smthook"
-          "Kore/Attribute/Smtlib/Smtlib"
-          "Kore/Attribute/Sort"
-          "Kore/Attribute/Sort/Concat"
-          "Kore/Attribute/Sort/Constructors"
-          "Kore/Attribute/Sort/ConstructorsBuilder"
-          "Kore/Attribute/Sort/Element"
-          "Kore/Attribute/Sort/HasDomainValues"
-          "Kore/Attribute/Sort/Unit"
-          "Kore/Attribute/SortInjection"
-          "Kore/Attribute/Source"
-          "Kore/Attribute/SourceLocation"
-          "Kore/Attribute/Subsort"
-          "Kore/Attribute/Symbol"
-          "Kore/Attribute/Symbol/Anywhere"
-          "Kore/Attribute/Symbol/Klabel"
-          "Kore/Attribute/Symbol/Memo"
-          "Kore/Attribute/Symbol/NoEvaluators"
-          "Kore/Attribute/Symbol/SymbolKywd"
-          "Kore/Attribute/Synthetic"
-          "Kore/Attribute/Trusted"
-          "Kore/Attribute/UniqueId"
-          "Kore/BugReport"
-          "Kore/Builtin"
-          "Kore/Builtin/AssocComm/AssocComm"
-          "Kore/Builtin/AssocComm/CeilSimplifier"
-          "Kore/Builtin/AssociativeCommutative"
-          "Kore/Builtin/Attributes"
-          "Kore/Builtin/Bool"
-          "Kore/Builtin/Bool/Bool"
-          "Kore/Builtin/Builtin"
-          "Kore/Builtin/Encoding"
-          "Kore/Builtin/Endianness"
-          "Kore/Builtin/Endianness/Endianness"
-          "Kore/Builtin/EqTerm"
-          "Kore/Builtin/Error"
-          "Kore/Builtin/Inj"
-          "Kore/Builtin/Int"
-          "Kore/Builtin/Int/Int"
-          "Kore/Builtin/InternalBytes"
-          "Kore/Builtin/InternalBytes/InternalBytes"
-          "Kore/Builtin/KEqual"
-          "Kore/Builtin/Kreflection"
-          "Kore/Builtin/Krypto"
-          "Kore/Builtin/List"
-          "Kore/Builtin/List/List"
-          "Kore/Builtin/Map"
-          "Kore/Builtin/Map/Map"
-          "Kore/Builtin/Set"
-          "Kore/Builtin/Set/Set"
-          "Kore/Builtin/Signedness"
-          "Kore/Builtin/Signedness/Signedness"
-          "Kore/Builtin/String"
-          "Kore/Builtin/String/String"
-          "Kore/Builtin/Symbols"
-          "Kore/Builtin/Verifiers"
-          "Kore/Debug"
-          "Kore/Equation"
-          "Kore/Equation/Application"
-          "Kore/Equation/DebugEquation"
-          "Kore/Equation/Equation"
-          "Kore/Equation/Registry"
-          "Kore/Equation/Sentence"
-          "Kore/Equation/Simplification"
-          "Kore/Equation/Validate"
-          "Kore/Error"
-          "Kore/Exec"
-          "Kore/IndexedModule/Error"
-          "Kore/IndexedModule/IndexedModule"
-          "Kore/IndexedModule/MetadataTools"
-          "Kore/IndexedModule/MetadataToolsBuilder"
-          "Kore/IndexedModule/OverloadGraph"
-          "Kore/IndexedModule/Resolvers"
-          "Kore/IndexedModule/SortGraph"
-          "Kore/Internal/Alias"
-          "Kore/Internal/ApplicationSorts"
-          "Kore/Internal/Condition"
-          "Kore/Internal/Conditional"
-          "Kore/Internal/From"
-          "Kore/Internal/Inj"
-          "Kore/Internal/InternalBool"
-          "Kore/Internal/InternalBytes"
-          "Kore/Internal/InternalInt"
-          "Kore/Internal/InternalList"
-          "Kore/Internal/InternalMap"
-          "Kore/Internal/InternalSet"
-          "Kore/Internal/InternalString"
-          "Kore/Internal/Key"
-          "Kore/Internal/MultiAnd"
-          "Kore/Internal/MultiExists"
-          "Kore/Internal/MultiOr"
-          "Kore/Internal/NormalizedAc"
-          "Kore/Internal/OrCondition"
-          "Kore/Internal/OrPattern"
-          "Kore/Internal/Pattern"
-          "Kore/Internal/Predicate"
-          "Kore/Internal/SideCondition"
-          "Kore/Internal/SideCondition/SideCondition"
-          "Kore/Internal/Substitution"
-          "Kore/Internal/Symbol"
-          "Kore/Internal/TermLike"
-          "Kore/Internal/TermLike/Renaming"
-          "Kore/Internal/TermLike/TermLike"
-          "Kore/Internal/Variable"
-          "Kore/JsonRpc"
-          "Kore/Log"
-          "Kore/Log/DebugAppliedRewriteRules"
-          "Kore/Log/DebugAttemptedRewriteRules"
-          "Kore/Log/DebugBeginClaim"
-          "Kore/Log/DebugCreatedSubstitution"
-          "Kore/Log/DebugEvaluateCondition"
-          "Kore/Log/DebugProven"
-          "Kore/Log/DebugRetrySolverQuery"
-          "Kore/Log/DebugSolver"
-          "Kore/Log/DebugSubstitutionSimplifier"
-          "Kore/Log/DebugTransition"
-          "Kore/Log/DebugUnification"
-          "Kore/Log/DebugUnifyBottom"
-          "Kore/Log/ErrorBottomTotalFunction"
-          "Kore/Log/ErrorDecidePredicateUnknown"
-          "Kore/Log/ErrorEquationRightFunction"
-          "Kore/Log/ErrorEquationsSameMatch"
-          "Kore/Log/ErrorException"
-          "Kore/Log/ErrorOutOfDate"
-          "Kore/Log/ErrorParse"
-          "Kore/Log/ErrorRewriteLoop"
-          "Kore/Log/ErrorRewritesInstantiation"
-          "Kore/Log/ErrorVerify"
-          "Kore/Log/InfoAttemptUnification"
-          "Kore/Log/JsonRpc"
-          "Kore/Log/InfoExecBreadth"
-          "Kore/Log/InfoExecDepth"
-          "Kore/Log/InfoProofDepth"
-          "Kore/Log/InfoReachability"
-          "Kore/Log/KoreLogOptions"
-          "Kore/Log/Registry"
-          "Kore/Log/SQLite"
-          "Kore/Log/WarnBoundedModelChecker"
-          "Kore/Log/WarnClaimRHSIsBottom"
-          "Kore/Log/WarnDepthLimitExceeded"
-          "Kore/Log/WarnFunctionWithoutEvaluators"
-          "Kore/Log/WarnIfLowProductivity"
-          "Kore/Log/WarnNotImplemented"
-          "Kore/Log/WarnRestartSolver"
-          "Kore/Log/WarnStuckClaimState"
-          "Kore/Log/WarnSymbolSMTRepresentation"
-          "Kore/Log/WarnTrivialClaim"
-          "Kore/Log/WarnUnsimplified"
-          "Kore/ModelChecker/Bounded"
-          "Kore/ModelChecker/Simplification"
-          "Kore/ModelChecker/Step"
-          "Kore/Options"
-          "Kore/Parser"
-          "Kore/Parser/CString"
-          "Kore/Parser/Lexer"
-          "Kore/Parser/LexerWrapper"
-          "Kore/Parser/Parser"
-          "Kore/Parser/ParserUtils"
-          "Kore/Reachability"
-          "Kore/Reachability/AllPathClaim"
-          "Kore/Reachability/Claim"
-          "Kore/Reachability/ClaimState"
-          "Kore/Reachability/OnePathClaim"
-          "Kore/Reachability/Prim"
-          "Kore/Reachability/Prove"
-          "Kore/Reachability/SomeClaim"
-          "Kore/Repl"
-          "Kore/Repl/Data"
-          "Kore/Repl/Interpreter"
-          "Kore/Repl/Parser"
-          "Kore/Repl/State"
-          "Kore/Rewrite"
-          "Kore/Rewrite/AntiLeft"
-          "Kore/Rewrite/Axiom/EvaluationStrategy"
-          "Kore/Rewrite/Axiom/Identifier"
-          "Kore/Rewrite/Axiom/Matcher"
-          "Kore/Rewrite/Axiom/MatcherData"
-          "Kore/Rewrite/Axiom/Registry"
-          "Kore/Rewrite/AxiomPattern"
-          "Kore/Rewrite/ClaimPattern"
-          "Kore/Rewrite/Function/Evaluator"
-          "Kore/Rewrite/Function/Memo"
-          "Kore/Rewrite/Implication"
-          "Kore/Rewrite/Remainder"
-          "Kore/Rewrite/Result"
-          "Kore/Rewrite/RewriteStep"
-          "Kore/Rewrite/Rule"
-          "Kore/Rewrite/Rule/Expand"
-          "Kore/Rewrite/Rule/Simplify"
-          "Kore/Rewrite/RulePattern"
-          "Kore/Rewrite/Search"
-          "Kore/Rewrite/SMT/AST"
-          "Kore/Rewrite/SMT/Declaration"
-          "Kore/Rewrite/SMT/Encoder"
-          "Kore/Rewrite/SMT/Evaluator"
-          "Kore/Rewrite/SMT/Lemma"
-          "Kore/Rewrite/SMT/Representation/All"
-          "Kore/Rewrite/SMT/Representation/Resolve"
-          "Kore/Rewrite/SMT/Representation/Sorts"
-          "Kore/Rewrite/SMT/Representation/Symbols"
-          "Kore/Rewrite/SMT/Resolvers"
-          "Kore/Rewrite/SMT/Translate"
-          "Kore/Rewrite/Step"
-          "Kore/Rewrite/Strategy"
-          "Kore/Rewrite/Substitution"
-          "Kore/Rewrite/Transition"
-          "Kore/Rewrite/RewritingVariable"
-          "Kore/Rewrite/UnifyingRule"
-          "Kore/Simplify/And"
-          "Kore/Simplify/AndPredicates"
-          "Kore/Simplify/AndTerms"
-          "Kore/Simplify/API"
-          "Kore/Simplify/Application"
-          "Kore/Simplify/Bottom"
-          "Kore/Simplify/Ceil"
-          "Kore/Simplify/CeilSimplifier"
-          "Kore/Simplify/Condition"
-          "Kore/Simplify/DomainValue"
-          "Kore/Simplify/Equals"
-          "Kore/Simplify/Exists"
-          "Kore/Simplify/ExpandAlias"
-          "Kore/Simplify/Floor"
-          "Kore/Simplify/Forall"
-          "Kore/Simplify/Iff"
-          "Kore/Simplify/Implies"
-          "Kore/Simplify/In"
-          "Kore/Simplify/Inhabitant"
-          "Kore/Simplify/Inj"
-          "Kore/Simplify/InjSimplifier"
-          "Kore/Simplify/InternalBool"
-          "Kore/Simplify/InternalBytes"
-          "Kore/Simplify/InternalInt"
-          "Kore/Simplify/InternalList"
-          "Kore/Simplify/InternalMap"
-          "Kore/Simplify/InternalSet"
-          "Kore/Simplify/InternalString"
-          "Kore/Simplify/Mu"
-          "Kore/Simplify/Next"
-          "Kore/Simplify/NoConfusion"
-          "Kore/Simplify/Not"
-          "Kore/Simplify/NotSimplifier"
-          "Kore/Simplify/Nu"
-          "Kore/Simplify/Or"
-          "Kore/Simplify/OrPattern"
-          "Kore/Simplify/Overloading"
-          "Kore/Simplify/OverloadSimplifier"
-          "Kore/Simplify/Pattern"
-          "Kore/Simplify/Predicate"
-          "Kore/Simplify/SetVariable"
-          "Kore/Simplify/SimplificationType"
-          "Kore/Simplify/Simplify"
-          "Kore/Simplify/StringLiteral"
-          "Kore/Simplify/SubstitutionSimplifier"
-          "Kore/Simplify/TermLike"
-          "Kore/Simplify/Top"
-          "Kore/Simplify/Variable"
-          "Kore/Sort"
-          "Kore/Substitute"
-          "Kore/Syntax"
-          "Kore/Syntax/And"
-          "Kore/Syntax/Application"
-          "Kore/Syntax/Bottom"
-          "Kore/Syntax/Ceil"
-          "Kore/Syntax/Definition"
-          "Kore/Syntax/DomainValue"
-          "Kore/Syntax/Equals"
-          "Kore/Syntax/Exists"
-          "Kore/Syntax/Floor"
-          "Kore/Syntax/Forall"
-          "Kore/Syntax/Id"
-          "Kore/Syntax/Iff"
-          "Kore/Syntax/Implies"
-          "Kore/Syntax/In"
-          "Kore/Syntax/Inhabitant"
-          "Kore/Syntax/Json"
-          "Kore/Syntax/Json/Internal"
-          "Kore/Syntax/Module"
-          "Kore/Syntax/Mu"
-          "Kore/Syntax/Next"
-          "Kore/Syntax/Not"
-          "Kore/Syntax/Nu"
-          "Kore/Syntax/Or"
-          "Kore/Syntax/Pattern"
-          "Kore/Syntax/PatternF"
-          "Kore/Syntax/Rewrites"
-          "Kore/Syntax/Sentence"
-          "Kore/Syntax/StringLiteral"
-          "Kore/Syntax/Top"
-          "Kore/Syntax/Variable"
-          "Kore/TopBottom"
-          "Kore/Unification/Procedure"
-          "Kore/Unification/SubstitutionNormalization"
-          "Kore/Unification/SubstitutionSimplifier"
-          "Kore/Unification/UnifierT"
-          "Kore/Unification/Unify"
-          "Kore/Unification/NewUnifier"
-          "Kore/Unparser"
-          "Kore/Validate/AliasVerifier"
-          "Kore/Validate/AttributesVerifier"
-          "Kore/Validate/DefinitionVerifier"
-          "Kore/Validate/Error"
-          "Kore/Validate/ModuleVerifier"
-          "Kore/Validate/PatternVerifier"
-          "Kore/Validate/PatternVerifier/PatternVerifier"
-          "Kore/Validate/SentenceVerifier"
-          "Kore/Validate/SortVerifier"
-          "Kore/Validate/Verifier"
-          "Kore/Variables/Binding"
-          "Kore/Variables/Free"
-          "Kore/Variables/Fresh"
-          "Kore/Variables/Target"
-          "Kore/Verified"
-          "Kore/VersionInfo"
-          "Log"
-          "Log/Entry"
-          "Logic"
-          "Options/SMT"
-          "Pair"
-          "Partial"
-          "Paths_kore"
-          "Prelude/Kore"
-          "Pretty"
-          "Prof"
-          "SMT"
-          "SMT/AST"
-          "SMT/SimpleSMT"
-          "SQL"
-          "SQL/ColumnDef"
-          "SQL/Key"
-          "SQL/Query"
-          "SQL/SOP"
-          "SQL/SQL"
-          "Stats"
-          ];
-        hsSourceDirs = [ "src" "app/share" ];
-        };
-      exes = {
-        "kore-exec" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
-            (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
-            (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
-            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
-            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
-            (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
-            (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
-            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
-            (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
-            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
-            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-            (hsPkgs."text" or (errorHandler.buildDepError "text"))
-            (hsPkgs."time" or (errorHandler.buildDepError "time"))
-            ];
-          buildable = true;
-          hsSourceDirs = [ "app/exec" ];
-          mainPath = (([
-            "Main.hs"
-            ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
-            ""
-            ];
-          };
-        "kore-rpc" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
-            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
-            (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
-            (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
-            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-            (hsPkgs."time" or (errorHandler.buildDepError "time"))
-            ];
-          buildable = true;
-          hsSourceDirs = [ "app/rpc" ];
-          mainPath = (([
-            "Main.hs"
-            ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
-            ""
-            ];
-          };
-        "kore-format" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-            (hsPkgs."text" or (errorHandler.buildDepError "text"))
-            ];
-          buildable = true;
-          hsSourceDirs = [ "app/format" ];
-          mainPath = (([
-            "Main.hs"
-            ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
-            ""
-            ];
-          };
-        "kore-parser" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
-            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
-            ];
-          buildable = true;
-          hsSourceDirs = [ "app/parser" ];
-          mainPath = (([
-            "Main.hs"
-            ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
-            ""
-            ];
-          };
-        "kore-prof" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."eventlog2speedscope" or (errorHandler.buildDepError "eventlog2speedscope"))
-            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-            ];
-          buildable = true;
-          hsSourceDirs = [ "app/prof" ];
-          mainPath = (([
-            "Main.hs"
-            ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
-            ""
-            ];
-          };
-        "kore-repl" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
-            (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
-            (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
-            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-            ];
-          buildable = true;
-          hsSourceDirs = [ "app/repl" ];
-          mainPath = (([
-            "Main.hs"
-            ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
-            ""
-            ];
-          };
-        "kore-match-disjunction" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
-            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
-            ];
-          buildable = true;
-          hsSourceDirs = [ "app/match-disjunction" ];
-          mainPath = (([
-            "Main.hs"
-            ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
-            ""
-            ];
-          };
-        "kore-check-functions" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
-            (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
-            ];
-          buildable = true;
-          hsSourceDirs = [ "app/check-functions" ];
-          mainPath = (([
-            "Main.hs"
-            ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
-            ""
-            ];
-          };
-        "kore-simplify" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
-            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-            ];
-          buildable = true;
-          hsSourceDirs = [ "app/simplify" ];
-          mainPath = (([
-            "Main.hs"
-            ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
-            ""
-            ];
-          };
-        };
-      tests = {
-        "kore-test" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."adjunctions" or (errorHandler.buildDepError "adjunctions"))
-            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
-            (hsPkgs."aeson-pretty" or (errorHandler.buildDepError "aeson-pretty"))
-            (hsPkgs."array" or (errorHandler.buildDepError "array"))
-            (hsPkgs."async" or (errorHandler.buildDepError "async"))
-            (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
-            (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
-            (hsPkgs."co-log" or (errorHandler.buildDepError "co-log"))
-            (hsPkgs."comonad" or (errorHandler.buildDepError "comonad"))
-            (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
-            (hsPkgs."conduit-extra" or (errorHandler.buildDepError "conduit-extra"))
-            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
-            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
-            (hsPkgs."decision-diagrams" or (errorHandler.buildDepError "decision-diagrams"))
-            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
-            (hsPkgs."deriving-aeson" or (errorHandler.buildDepError "deriving-aeson"))
-            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
-            (hsPkgs."distributive" or (errorHandler.buildDepError "distributive"))
-            (hsPkgs."errors" or (errorHandler.buildDepError "errors"))
-            (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
-            (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
-            (hsPkgs."fgl" or (errorHandler.buildDepError "fgl"))
-            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
-            (hsPkgs."free" or (errorHandler.buildDepError "free"))
-            (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
-            (hsPkgs."generics-sop" or (errorHandler.buildDepError "generics-sop"))
-            (hsPkgs."ghc-trace-events" or (errorHandler.buildDepError "ghc-trace-events"))
-            (hsPkgs."gitrev" or (errorHandler.buildDepError "gitrev"))
-            (hsPkgs."graphviz" or (errorHandler.buildDepError "graphviz"))
-            (hsPkgs."hashable" or (errorHandler.buildDepError "hashable"))
-            (hsPkgs."haskeline" or (errorHandler.buildDepError "haskeline"))
-            (hsPkgs."integer-gmp" or (errorHandler.buildDepError "integer-gmp"))
-            (hsPkgs."json-rpc" or (errorHandler.buildDepError "json-rpc"))
-            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
-            (hsPkgs."logict" or (errorHandler.buildDepError "logict"))
-            (hsPkgs."matrix" or (errorHandler.buildDepError "matrix"))
-            (hsPkgs."megaparsec" or (errorHandler.buildDepError "megaparsec"))
-            (hsPkgs."mmorph" or (errorHandler.buildDepError "mmorph"))
-            (hsPkgs."monad-logger" or (errorHandler.buildDepError "monad-logger"))
-            (hsPkgs."mono-traversable" or (errorHandler.buildDepError "mono-traversable"))
-            (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
-            (hsPkgs."multiset" or (errorHandler.buildDepError "multiset"))
-            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-            (hsPkgs."parser-combinators" or (errorHandler.buildDepError "parser-combinators"))
-            (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
-            (hsPkgs."process" or (errorHandler.buildDepError "process"))
-            (hsPkgs."profunctors" or (errorHandler.buildDepError "profunctors"))
-            (hsPkgs."recursion-schemes" or (errorHandler.buildDepError "recursion-schemes"))
-            (hsPkgs."semialign" or (errorHandler.buildDepError "semialign"))
-            (hsPkgs."sqlite-simple" or (errorHandler.buildDepError "sqlite-simple"))
-            (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
-            (hsPkgs."streams" or (errorHandler.buildDepError "streams"))
-            (hsPkgs."tar" or (errorHandler.buildDepError "tar"))
-            (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
-            (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
-            (hsPkgs."text" or (errorHandler.buildDepError "text"))
-            (hsPkgs."these" or (errorHandler.buildDepError "these"))
-            (hsPkgs."time" or (errorHandler.buildDepError "time"))
-            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
-            (hsPkgs."unordered-containers" or (errorHandler.buildDepError "unordered-containers"))
-            (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
-            (hsPkgs."witherable" or (errorHandler.buildDepError "witherable"))
-            (hsPkgs."zlib" or (errorHandler.buildDepError "zlib"))
-            (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
-            (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
-            (hsPkgs."quickcheck-instances" or (errorHandler.buildDepError "quickcheck-instances"))
-            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
-            (hsPkgs."tasty-golden" or (errorHandler.buildDepError "tasty-golden"))
-            (hsPkgs."tasty-hedgehog" or (errorHandler.buildDepError "tasty-hedgehog"))
-            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
-            (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
-            (hsPkgs."tasty-test-reporter" or (errorHandler.buildDepError "tasty-test-reporter"))
-            ];
-          build-tools = [
-            (hsPkgs.buildPackages.happy.components.exes.happy or (pkgs.buildPackages.happy or (errorHandler.buildToolDepError "happy:happy")))
-            (hsPkgs.buildPackages.alex.components.exes.alex or (pkgs.buildPackages.alex or (errorHandler.buildToolDepError "alex:alex")))
-            (hsPkgs.buildPackages.tasty-discover.components.exes.tasty-discover or (pkgs.buildPackages.tasty-discover or (errorHandler.buildToolDepError "tasty-discover:tasty-discover")))
-            ];
-          buildable = true;
-          modules = [
-            "Driver"
-            "Test/ConsistentKore"
-            "Test/Data/Graph/TopologicalSort"
-            "Test/Data/Limit"
-            "Test/Data/Sup"
-            "Test/Debug"
-            "Test/Expect"
-            "Test/Injection"
-            "Test/Kore"
-            "Test/Kore/AST/Common"
-            "Test/Kore/Attribute/Assoc"
-            "Test/Kore/Attribute/Axiom/Concrete"
-            "Test/Kore/Attribute/Axiom/Symbolic"
-            "Test/Kore/Attribute/Axiom/Unit"
-            "Test/Kore/Attribute/Comm"
-            "Test/Kore/Attribute/Constructor"
-            "Test/Kore/Attribute/Function"
-            "Test/Kore/Attribute/Functional"
-            "Test/Kore/Attribute/Hook"
-            "Test/Kore/Attribute/Idem"
-            "Test/Kore/Attribute/Injective"
-            "Test/Kore/Attribute/Label"
-            "Test/Kore/Attribute/NonExecutable"
-            "Test/Kore/Attribute/Overload"
-            "Test/Kore/Attribute/Owise"
-            "Test/Kore/Attribute/Parser"
-            "Test/Kore/Attribute/Pattern/ConstructorLike"
-            "Test/Kore/Attribute/Pattern/Defined"
-            "Test/Kore/Attribute/Pattern/FreeVariables"
-            "Test/Kore/Attribute/Pattern/Function"
-            "Test/Kore/Attribute/Pattern/Functional"
-            "Test/Kore/Attribute/Pattern/Sort"
-            "Test/Kore/Attribute/Priority"
-            "Test/Kore/Attribute/ProductionID"
-            "Test/Kore/Attribute/Simplification"
-            "Test/Kore/Attribute/Smtlib"
-            "Test/Kore/Attribute/Sort/ConstructorsBuilder"
-            "Test/Kore/Attribute/Sort/HasDomainValues"
-            "Test/Kore/Attribute/Sort/Unit"
-            "Test/Kore/Attribute/SortInjection"
-            "Test/Kore/Attribute/Subsort"
-            "Test/Kore/Attribute/Symbol"
-            "Test/Kore/Attribute/Symbol/Anywhere"
-            "Test/Kore/Attribute/Symbol/Klabel"
-            "Test/Kore/Attribute/Symbol/Memo"
-            "Test/Kore/Attribute/Symbol/NoEvaluators"
-            "Test/Kore/Attribute/Symbol/SymbolKywd"
-            "Test/Kore/Attribute/Trusted"
-            "Test/Kore/Attribute/UniqueId"
-            "Test/Kore/BugReport"
-            "Test/Kore/Builtin"
-            "Test/Kore/Builtin/AssocComm/CeilSimplifier"
-            "Test/Kore/Builtin/Bool"
-            "Test/Kore/Builtin/Builtin"
-            "Test/Kore/Builtin/Definition"
-            "Test/Kore/Builtin/Encoding"
-            "Test/Kore/Builtin/Endianness"
-            "Test/Kore/Builtin/External"
-            "Test/Kore/Builtin/Inj"
-            "Test/Kore/Builtin/Int"
-            "Test/Kore/Builtin/InternalBytes"
-            "Test/Kore/Builtin/KEqual"
-            "Test/Kore/Builtin/Krypto"
-            "Test/Kore/Builtin/List"
-            "Test/Kore/Builtin/Map"
-            "Test/Kore/Builtin/Set"
-            "Test/Kore/Builtin/Signedness"
-            "Test/Kore/Builtin/String"
-            "Test/Kore/Contains"
-            "Test/Kore/Equation/Application"
-            "Test/Kore/Equation/Common"
-            "Test/Kore/Equation/Sentence"
-            "Test/Kore/Equation/Simplification"
-            "Test/Kore/Error"
-            "Test/Kore/Exec"
-            "Test/Kore/IndexedModule/Error"
-            "Test/Kore/IndexedModule/MockMetadataTools"
-            "Test/Kore/IndexedModule/OverloadGraph"
-            "Test/Kore/IndexedModule/Resolvers"
-            "Test/Kore/IndexedModule/SortGraph"
-            "Test/Kore/Internal/ApplicationSorts"
-            "Test/Kore/Internal/Condition"
-            "Test/Kore/Internal/From"
-            "Test/Kore/Internal/Key"
-            "Test/Kore/Internal/MultiAnd"
-            "Test/Kore/Internal/MultiExists"
-            "Test/Kore/Internal/OrCondition"
-            "Test/Kore/Internal/OrPattern"
-            "Test/Kore/Internal/Pattern"
-            "Test/Kore/Internal/Predicate"
-            "Test/Kore/Internal/SideCondition"
-            "Test/Kore/Internal/Substitution"
-            "Test/Kore/Internal/Symbol"
-            "Test/Kore/Internal/TermLike"
-            "Test/Kore/Log/DebugEvaluateCondition"
-            "Test/Kore/Log/ErrorBottomTotalFunction"
-            "Test/Kore/Log/WarnFunctionWithoutEvaluators"
-            "Test/Kore/Log/WarnSymbolSMTRepresentation"
-            "Test/Kore/Options"
-            "Test/Kore/Parser"
-            "Test/Kore/Parser/Lexer"
-            "Test/Kore/Parser/Parser"
-            "Test/Kore/Reachability/Claim"
-            "Test/Kore/Reachability/MockAllPath"
-            "Test/Kore/Reachability/OnePathStrategy"
-            "Test/Kore/Reachability/Prove"
-            "Test/Kore/Reachability/SomeClaim"
-            "Test/Kore/Repl/Graph"
-            "Test/Kore/Repl/Interpreter"
-            "Test/Kore/Repl/Parser"
-            "Test/Kore/Repl/ParserTest"
-            "Test/Kore/Rewrite"
-            "Test/Kore/Rewrite/AntiLeft"
-            "Test/Kore/Rewrite/Axiom/EvaluationStrategy"
-            "Test/Kore/Rewrite/Axiom/Identifier"
-            "Test/Kore/Rewrite/Axiom/Matcher"
-            "Test/Kore/Rewrite/Axiom/Registry"
-            "Test/Kore/Rewrite/ClaimPattern"
-            "Test/Kore/Rewrite/Function/Evaluator"
-            "Test/Kore/Rewrite/Function/Integration"
-            "Test/Kore/Rewrite/Function/Memo"
-            "Test/Kore/Rewrite/Implication"
-            "Test/Kore/Rewrite/MockSymbols"
-            "Test/Kore/Rewrite/Remainder"
-            "Test/Kore/Rewrite/RewriteStep"
-            "Test/Kore/Rewrite/Rule"
-            "Test/Kore/Rewrite/Rule/Common"
-            "Test/Kore/Rewrite/Rule/Expand"
-            "Test/Kore/Rewrite/Rule/Simplify"
-            "Test/Kore/Rewrite/RulePattern"
-            "Test/Kore/Rewrite/SMT/Builders"
-            "Test/Kore/Rewrite/SMT/Evaluator"
-            "Test/Kore/Rewrite/SMT/Helpers"
-            "Test/Kore/Rewrite/SMT/Representation/All"
-            "Test/Kore/Rewrite/SMT/Representation/Builders"
-            "Test/Kore/Rewrite/SMT/Representation/Helpers"
-            "Test/Kore/Rewrite/SMT/Representation/Sorts"
-            "Test/Kore/Rewrite/SMT/Representation/Symbols"
-            "Test/Kore/Rewrite/SMT/Sorts"
-            "Test/Kore/Rewrite/SMT/Symbols"
-            "Test/Kore/Rewrite/SMT/Translate"
-            "Test/Kore/Rewrite/Strategy"
-            "Test/Kore/Rewrite/Transition"
-            "Test/Kore/Rewrite/RewritingVariable"
-            "Test/Kore/Simplify"
-            "Test/Kore/Simplify/And"
-            "Test/Kore/Simplify/AndTerms"
-            "Test/Kore/Simplify/Application"
-            "Test/Kore/Simplify/Bottom"
-            "Test/Kore/Simplify/Ceil"
-            "Test/Kore/Simplify/Condition"
-            "Test/Kore/Simplify/DomainValue"
-            "Test/Kore/Simplify/Equals"
-            "Test/Kore/Simplify/Exists"
-            "Test/Kore/Simplify/Floor"
-            "Test/Kore/Simplify/Forall"
-            "Test/Kore/Simplify/Iff"
-            "Test/Kore/Simplify/Implies"
-            "Test/Kore/Simplify/Inj"
-            "Test/Kore/Simplify/InjSimplifier"
-            "Test/Kore/Simplify/Integration"
-            "Test/Kore/Simplify/IntegrationProperty"
-            "Test/Kore/Simplify/InternalList"
-            "Test/Kore/Simplify/InternalMap"
-            "Test/Kore/Simplify/InternalSet"
-            "Test/Kore/Simplify/Next"
-            "Test/Kore/Simplify/Not"
-            "Test/Kore/Simplify/Or"
-            "Test/Kore/Simplify/OrPattern"
-            "Test/Kore/Simplify/Overloading"
-            "Test/Kore/Simplify/Predicate"
-            "Test/Kore/Simplify/Pattern"
-            "Test/Kore/Simplify/StringLiteral"
-            "Test/Kore/Simplify/SubstitutionSimplifier"
-            "Test/Kore/Simplify/TermLike"
-            "Test/Kore/Simplify/Top"
-            "Test/Kore/Syntax/Id"
-            "Test/Kore/Syntax/Json"
-            "Test/Kore/Syntax/Json/Roundtrips"
-            "Test/Kore/Syntax/Variable"
-            "Test/Kore/TopBottom"
-            "Test/Kore/Unification/SubstitutionNormalization"
-            "Test/Kore/Unification/Unifier"
-            "Test/Kore/Unification/UnifierT"
-            "Test/Kore/Unparser"
-            "Test/Kore/Validate/DefinitionVerifier"
-            "Test/Kore/Validate/DefinitionVerifier/Imports"
-            "Test/Kore/Validate/DefinitionVerifier/PatternVerifier"
-            "Test/Kore/Validate/DefinitionVerifier/SentenceVerifier"
-            "Test/Kore/Validate/DefinitionVerifier/SortUsage"
-            "Test/Kore/Validate/DefinitionVerifier/UniqueNames"
-            "Test/Kore/Validate/DefinitionVerifier/UniqueSortVariables"
-            "Test/Kore/Variables/Fresh"
-            "Test/Kore/Variables/Target"
-            "Test/Kore/Variables/V"
-            "Test/Kore/Variables/W"
-            "Test/Kore/With"
-            "Test/Pretty"
-            "Test/SMT"
-            "Test/SMT/AST"
-            "Test/SQL"
-            "Test/Stats"
-            "Test/Tasty/HUnit/Ext"
-            "Test/Terse"
-            ];
-          hsSourceDirs = [ "test" ];
-          mainPath = [ "Test.hs" ];
-          };
-        };
+          "Driver"
+          "Test/ConsistentKore"
+          "Test/Data/Graph/TopologicalSort"
+          "Test/Data/Limit"
+          "Test/Data/Sup"
+          "Test/Debug"
+          "Test/Expect"
+          "Test/Injection"
+          "Test/Kore"
+          "Test/Kore/AST/Common"
+          "Test/Kore/Attribute/Assoc"
+          "Test/Kore/Attribute/Axiom/Concrete"
+          "Test/Kore/Attribute/Axiom/Symbolic"
+          "Test/Kore/Attribute/Axiom/Unit"
+          "Test/Kore/Attribute/Comm"
+          "Test/Kore/Attribute/Constructor"
+          "Test/Kore/Attribute/Function"
+          "Test/Kore/Attribute/Functional"
+          "Test/Kore/Attribute/Hook"
+          "Test/Kore/Attribute/Idem"
+          "Test/Kore/Attribute/Injective"
+          "Test/Kore/Attribute/Label"
+          "Test/Kore/Attribute/NonExecutable"
+          "Test/Kore/Attribute/Overload"
+          "Test/Kore/Attribute/Owise"
+          "Test/Kore/Attribute/Parser"
+          "Test/Kore/Attribute/Pattern/ConstructorLike"
+          "Test/Kore/Attribute/Pattern/Defined"
+          "Test/Kore/Attribute/Pattern/FreeVariables"
+          "Test/Kore/Attribute/Pattern/Function"
+          "Test/Kore/Attribute/Pattern/Functional"
+          "Test/Kore/Attribute/Pattern/Sort"
+          "Test/Kore/Attribute/Priority"
+          "Test/Kore/Attribute/ProductionID"
+          "Test/Kore/Attribute/Simplification"
+          "Test/Kore/Attribute/Smtlib"
+          "Test/Kore/Attribute/Sort/ConstructorsBuilder"
+          "Test/Kore/Attribute/Sort/HasDomainValues"
+          "Test/Kore/Attribute/Sort/Unit"
+          "Test/Kore/Attribute/SortInjection"
+          "Test/Kore/Attribute/Subsort"
+          "Test/Kore/Attribute/Symbol"
+          "Test/Kore/Attribute/Symbol/Anywhere"
+          "Test/Kore/Attribute/Symbol/Klabel"
+          "Test/Kore/Attribute/Symbol/Memo"
+          "Test/Kore/Attribute/Symbol/NoEvaluators"
+          "Test/Kore/Attribute/Symbol/SymbolKywd"
+          "Test/Kore/Attribute/Trusted"
+          "Test/Kore/Attribute/UniqueId"
+          "Test/Kore/BugReport"
+          "Test/Kore/Builtin"
+          "Test/Kore/Builtin/AssocComm/CeilSimplifier"
+          "Test/Kore/Builtin/Bool"
+          "Test/Kore/Builtin/Builtin"
+          "Test/Kore/Builtin/Definition"
+          "Test/Kore/Builtin/Encoding"
+          "Test/Kore/Builtin/Endianness"
+          "Test/Kore/Builtin/External"
+          "Test/Kore/Builtin/Inj"
+          "Test/Kore/Builtin/Int"
+          "Test/Kore/Builtin/InternalBytes"
+          "Test/Kore/Builtin/KEqual"
+          "Test/Kore/Builtin/Krypto"
+          "Test/Kore/Builtin/List"
+          "Test/Kore/Builtin/Map"
+          "Test/Kore/Builtin/Set"
+          "Test/Kore/Builtin/Signedness"
+          "Test/Kore/Builtin/String"
+          "Test/Kore/Contains"
+          "Test/Kore/Equation/Application"
+          "Test/Kore/Equation/Common"
+          "Test/Kore/Equation/Sentence"
+          "Test/Kore/Equation/Simplification"
+          "Test/Kore/Error"
+          "Test/Kore/Exec"
+          "Test/Kore/IndexedModule/Error"
+          "Test/Kore/IndexedModule/MockMetadataTools"
+          "Test/Kore/IndexedModule/OverloadGraph"
+          "Test/Kore/IndexedModule/Resolvers"
+          "Test/Kore/IndexedModule/SortGraph"
+          "Test/Kore/Internal/ApplicationSorts"
+          "Test/Kore/Internal/Condition"
+          "Test/Kore/Internal/From"
+          "Test/Kore/Internal/Key"
+          "Test/Kore/Internal/MultiAnd"
+          "Test/Kore/Internal/MultiExists"
+          "Test/Kore/Internal/OrCondition"
+          "Test/Kore/Internal/OrPattern"
+          "Test/Kore/Internal/Pattern"
+          "Test/Kore/Internal/Predicate"
+          "Test/Kore/Internal/SideCondition"
+          "Test/Kore/Internal/Substitution"
+          "Test/Kore/Internal/Symbol"
+          "Test/Kore/Internal/TermLike"
+          "Test/Kore/Log/DebugEvaluateCondition"
+          "Test/Kore/Log/ErrorBottomTotalFunction"
+          "Test/Kore/Log/WarnFunctionWithoutEvaluators"
+          "Test/Kore/Log/WarnSymbolSMTRepresentation"
+          "Test/Kore/Options"
+          "Test/Kore/Parser"
+          "Test/Kore/Parser/Lexer"
+          "Test/Kore/Parser/Parser"
+          "Test/Kore/Reachability/Claim"
+          "Test/Kore/Reachability/MockAllPath"
+          "Test/Kore/Reachability/OnePathStrategy"
+          "Test/Kore/Reachability/Prove"
+          "Test/Kore/Reachability/SomeClaim"
+          "Test/Kore/Repl/Graph"
+          "Test/Kore/Repl/Interpreter"
+          "Test/Kore/Repl/Parser"
+          "Test/Kore/Repl/ParserTest"
+          "Test/Kore/Rewrite"
+          "Test/Kore/Rewrite/AntiLeft"
+          "Test/Kore/Rewrite/Axiom/EvaluationStrategy"
+          "Test/Kore/Rewrite/Axiom/Identifier"
+          "Test/Kore/Rewrite/Axiom/Matcher"
+          "Test/Kore/Rewrite/Axiom/Registry"
+          "Test/Kore/Rewrite/ClaimPattern"
+          "Test/Kore/Rewrite/Function/Evaluator"
+          "Test/Kore/Rewrite/Function/Integration"
+          "Test/Kore/Rewrite/Function/Memo"
+          "Test/Kore/Rewrite/Implication"
+          "Test/Kore/Rewrite/MockSymbols"
+          "Test/Kore/Rewrite/Remainder"
+          "Test/Kore/Rewrite/RewriteStep"
+          "Test/Kore/Rewrite/Rule"
+          "Test/Kore/Rewrite/Rule/Common"
+          "Test/Kore/Rewrite/Rule/Expand"
+          "Test/Kore/Rewrite/Rule/Simplify"
+          "Test/Kore/Rewrite/RulePattern"
+          "Test/Kore/Rewrite/SMT/Builders"
+          "Test/Kore/Rewrite/SMT/Evaluator"
+          "Test/Kore/Rewrite/SMT/Helpers"
+          "Test/Kore/Rewrite/SMT/Representation/All"
+          "Test/Kore/Rewrite/SMT/Representation/Builders"
+          "Test/Kore/Rewrite/SMT/Representation/Helpers"
+          "Test/Kore/Rewrite/SMT/Representation/Sorts"
+          "Test/Kore/Rewrite/SMT/Representation/Symbols"
+          "Test/Kore/Rewrite/SMT/Sorts"
+          "Test/Kore/Rewrite/SMT/Symbols"
+          "Test/Kore/Rewrite/SMT/Translate"
+          "Test/Kore/Rewrite/Strategy"
+          "Test/Kore/Rewrite/Transition"
+          "Test/Kore/Rewrite/RewritingVariable"
+          "Test/Kore/Simplify"
+          "Test/Kore/Simplify/And"
+          "Test/Kore/Simplify/AndTerms"
+          "Test/Kore/Simplify/Application"
+          "Test/Kore/Simplify/Bottom"
+          "Test/Kore/Simplify/Ceil"
+          "Test/Kore/Simplify/Condition"
+          "Test/Kore/Simplify/DomainValue"
+          "Test/Kore/Simplify/Equals"
+          "Test/Kore/Simplify/Exists"
+          "Test/Kore/Simplify/Floor"
+          "Test/Kore/Simplify/Forall"
+          "Test/Kore/Simplify/Iff"
+          "Test/Kore/Simplify/Implies"
+          "Test/Kore/Simplify/Inj"
+          "Test/Kore/Simplify/InjSimplifier"
+          "Test/Kore/Simplify/Integration"
+          "Test/Kore/Simplify/IntegrationProperty"
+          "Test/Kore/Simplify/InternalList"
+          "Test/Kore/Simplify/InternalMap"
+          "Test/Kore/Simplify/InternalSet"
+          "Test/Kore/Simplify/Next"
+          "Test/Kore/Simplify/Not"
+          "Test/Kore/Simplify/Or"
+          "Test/Kore/Simplify/OrPattern"
+          "Test/Kore/Simplify/Overloading"
+          "Test/Kore/Simplify/Predicate"
+          "Test/Kore/Simplify/Pattern"
+          "Test/Kore/Simplify/StringLiteral"
+          "Test/Kore/Simplify/SubstitutionSimplifier"
+          "Test/Kore/Simplify/TermLike"
+          "Test/Kore/Simplify/Top"
+          "Test/Kore/Syntax/Id"
+          "Test/Kore/Syntax/Json"
+          "Test/Kore/Syntax/Json/Roundtrips"
+          "Test/Kore/Syntax/Variable"
+          "Test/Kore/TopBottom"
+          "Test/Kore/Unification/SubstitutionNormalization"
+          "Test/Kore/Unification/Unifier"
+          "Test/Kore/Unification/UnifierT"
+          "Test/Kore/Unparser"
+          "Test/Kore/Validate/DefinitionVerifier"
+          "Test/Kore/Validate/DefinitionVerifier/Imports"
+          "Test/Kore/Validate/DefinitionVerifier/PatternVerifier"
+          "Test/Kore/Validate/DefinitionVerifier/SentenceVerifier"
+          "Test/Kore/Validate/DefinitionVerifier/SortUsage"
+          "Test/Kore/Validate/DefinitionVerifier/UniqueNames"
+          "Test/Kore/Validate/DefinitionVerifier/UniqueSortVariables"
+          "Test/Kore/Variables/Fresh"
+          "Test/Kore/Variables/Target"
+          "Test/Kore/Variables/V"
+          "Test/Kore/Variables/W"
+          "Test/Kore/With"
+          "Test/Pretty"
+          "Test/SMT"
+          "Test/SMT/AST"
+          "Test/SQL"
+          "Test/Stats"
+          "Test/Tasty/HUnit/Ext"
+          "Test/Terse"
+        ];
+        hsSourceDirs = [ "test" ];
+        mainPath = [ "Test.hs" ];
       };
-    } // rec { src = (pkgs.lib).mkDefault ./kore; }
+    };
+  };
+} // rec {
+  src = (pkgs.lib).mkDefault ./kore;
+}

--- a/nix/kore-ghc923.nix.d/default.nix
+++ b/nix/kore-ghc923.nix.d/default.nix
@@ -1,43 +1,45 @@
 {
-  extras = hackage:
-    {
-      packages = {
-        "ghc-trace-events" = (((hackage.ghc-trace-events)."0.1.2.1").revisions).default;
-        "monoidal-containers" = (((hackage.monoidal-containers)."0.6.0.1").revisions).default;
-        "newtype" = (((hackage.newtype)."0.2.2.0").revisions).default;
-        "sqlite-simple" = (((hackage.sqlite-simple)."0.4.18.0").revisions).default;
-        "direct-sqlite" = (((hackage.direct-sqlite)."2.3.26").revisions).default;
-        "witherable" = (((hackage.witherable)."0.4.2").revisions).default;
-        "witherable-class" = (((hackage.witherable-class)."0").revisions).default;
-        "ghc-events" = (((hackage.ghc-events)."0.17.0.3").revisions).default;
-        "tasty-test-reporter" = (((hackage.tasty-test-reporter)."0.1.1.4").revisions).default;
-        "junit-xml" = (((hackage.junit-xml)."0.1.0.0").revisions).default;
-        "compact" = (((hackage.compact)."0.2.0.0").revisions).default;
-        "json-rpc" = (((hackage.json-rpc)."1.0.4").revisions)."e6805381c86fdfc782102b1aa7e3708e89492f986c8e553d953b0fa21f790a0c";
-        kore = ./kore.nix;
-        co-log-core = ./.stack-to-nix.cache.0;
-        co-log = ./.stack-to-nix.cache.1;
-        chronos = ./.stack-to-nix.cache.2;
-        contiguous = ./.stack-to-nix.cache.3;
-        run-st = ./.stack-to-nix.cache.4;
-        typerep-map = ./.stack-to-nix.cache.5;
-        bytebuild = ./.stack-to-nix.cache.6;
-        bytesmith = ./.stack-to-nix.cache.7;
-        byteslice = ./.stack-to-nix.cache.8;
-        zigzag = ./.stack-to-nix.cache.9;
-        eventlog2speedscope = ./.stack-to-nix.cache.10;
-        pipes-aeson = ./.stack-to-nix.cache.11;
-        pipes-ghc-events = ./.stack-to-nix.cache.12;
-        pipes-sqlite-simple = ./.stack-to-nix.cache.13;
-        graphviz = ./.stack-to-nix.cache.14;
-        };
-      };
+  extras = hackage: {
+    packages = {
+      "ghc-trace-events" =
+        (((hackage.ghc-trace-events)."0.1.2.1").revisions).default;
+      "monoidal-containers" =
+        (((hackage.monoidal-containers)."0.6.0.1").revisions).default;
+      "newtype" = (((hackage.newtype)."0.2.2.0").revisions).default;
+      "sqlite-simple" =
+        (((hackage.sqlite-simple)."0.4.18.0").revisions).default;
+      "direct-sqlite" = (((hackage.direct-sqlite)."2.3.26").revisions).default;
+      "witherable" = (((hackage.witherable)."0.4.2").revisions).default;
+      "witherable-class" = (((hackage.witherable-class)."0").revisions).default;
+      "ghc-events" = (((hackage.ghc-events)."0.17.0.3").revisions).default;
+      "tasty-test-reporter" =
+        (((hackage.tasty-test-reporter)."0.1.1.4").revisions).default;
+      "junit-xml" = (((hackage.junit-xml)."0.1.0.0").revisions).default;
+      "compact" = (((hackage.compact)."0.2.0.0").revisions).default;
+      "json-rpc" =
+        (((hackage.json-rpc)."1.0.4").revisions)."e6805381c86fdfc782102b1aa7e3708e89492f986c8e553d953b0fa21f790a0c";
+      kore = ./kore.nix;
+      co-log-core = ./.stack-to-nix.cache.0;
+      co-log = ./.stack-to-nix.cache.1;
+      chronos = ./.stack-to-nix.cache.2;
+      contiguous = ./.stack-to-nix.cache.3;
+      run-st = ./.stack-to-nix.cache.4;
+      typerep-map = ./.stack-to-nix.cache.5;
+      bytebuild = ./.stack-to-nix.cache.6;
+      bytesmith = ./.stack-to-nix.cache.7;
+      byteslice = ./.stack-to-nix.cache.8;
+      zigzag = ./.stack-to-nix.cache.9;
+      eventlog2speedscope = ./.stack-to-nix.cache.10;
+      pipes-aeson = ./.stack-to-nix.cache.11;
+      pipes-ghc-events = ./.stack-to-nix.cache.12;
+      pipes-sqlite-simple = ./.stack-to-nix.cache.13;
+      graphviz = ./.stack-to-nix.cache.14;
+    };
+  };
   resolver = "nightly-2022-06-10";
   modules = [
-    ({ lib, ... }:
-      { packages = {}; })
+    ({ lib, ... }: { packages = { }; })
     { packages = { "$everything" = { ghcOptions = [ "-haddock" ]; }; }; }
-    ({ lib, ... }:
-      { planned = lib.mkOverride 900 true; })
-    ];
-  }
+    ({ lib, ... }: { planned = lib.mkOverride 900 true; })
+  ];
+}

--- a/nix/kore-ghc923.nix.d/kore.nix
+++ b/nix/kore-ghc923.nix.d/kore.nix
@@ -8,7 +8,7 @@
   , config
   , ... }:
   {
-    flags = { release = false; threaded = true; };
+    flags = { threaded = true; };
     package = {
       specVersion = "2.2";
       identifier = { name = "kore"; version = "0.60.0.0"; };
@@ -916,6 +916,7 @@
             "Test/Kore/Simplify/Top"
             "Test/Kore/Syntax/Id"
             "Test/Kore/Syntax/Json"
+            "Test/Kore/Syntax/Json/Roundtrips"
             "Test/Kore/Syntax/Variable"
             "Test/Kore/TopBottom"
             "Test/Kore/Unification/SubstitutionNormalization"

--- a/nix/kore-ghc923.nix.d/kore.nix
+++ b/nix/kore-ghc923.nix.d/kore.nix
@@ -1,37 +1,673 @@
-{ system
-  , compiler
-  , flags
-  , pkgs
-  , hsPkgs
-  , pkgconfPkgs
-  , errorHandler
-  , config
-  , ... }:
-  {
-    flags = { threaded = true; };
-    package = {
-      specVersion = "2.2";
-      identifier = { name = "kore"; version = "0.60.0.0"; };
-      license = "BSD-3-Clause";
-      copyright = "2018-2021 Runtime Verification Inc";
-      maintainer = "ana.pantilie@runtimeverification.com";
-      author = "Runtime Verification Inc";
-      homepage = "https://github.com/runtimeverification/haskell-backend#readme";
-      url = "";
-      synopsis = "";
-      description = "Please see the [README](README.md) file.";
-      buildType = "Simple";
-      isLocal = true;
-      detailLevel = "FullDetails";
-      licenseFiles = [ "LICENSE" ];
-      dataDir = ".";
-      dataFiles = [];
-      extraSrcFiles = [ "README.md" "CHANGELOG.md" ];
-      extraTmpFiles = [];
-      extraDocFiles = [];
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, errorHandler, config, ...
+}:
+{
+  flags = { threaded = true; };
+  package = {
+    specVersion = "2.2";
+    identifier = {
+      name = "kore";
+      version = "0.60.0.0";
+    };
+    license = "BSD-3-Clause";
+    copyright = "2018-2021 Runtime Verification Inc";
+    maintainer = "ana.pantilie@runtimeverification.com";
+    author = "Runtime Verification Inc";
+    homepage = "https://github.com/runtimeverification/haskell-backend#readme";
+    url = "";
+    synopsis = "";
+    description = "Please see the [README](README.md) file.";
+    buildType = "Simple";
+    isLocal = true;
+    detailLevel = "FullDetails";
+    licenseFiles = [ "LICENSE" ];
+    dataDir = ".";
+    dataFiles = [ ];
+    extraSrcFiles = [ "README.md" "CHANGELOG.md" ];
+    extraTmpFiles = [ ];
+    extraDocFiles = [ ];
+  };
+  components = {
+    "library" = {
+      depends = [
+        (hsPkgs."base" or (errorHandler.buildDepError "base"))
+        (hsPkgs."adjunctions" or (errorHandler.buildDepError "adjunctions"))
+        (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+        (hsPkgs."aeson-pretty" or (errorHandler.buildDepError "aeson-pretty"))
+        (hsPkgs."array" or (errorHandler.buildDepError "array"))
+        (hsPkgs."async" or (errorHandler.buildDepError "async"))
+        (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
+        (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+        (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
+        (hsPkgs."co-log" or (errorHandler.buildDepError "co-log"))
+        (hsPkgs."comonad" or (errorHandler.buildDepError "comonad"))
+        (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
+        (hsPkgs."conduit-extra" or (errorHandler.buildDepError "conduit-extra"))
+        (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+        (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
+        (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+        (hsPkgs."decision-diagrams" or (errorHandler.buildDepError
+          "decision-diagrams"))
+        (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+        (hsPkgs."deriving-aeson" or (errorHandler.buildDepError
+          "deriving-aeson"))
+        (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+        (hsPkgs."distributive" or (errorHandler.buildDepError "distributive"))
+        (hsPkgs."errors" or (errorHandler.buildDepError "errors"))
+        (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
+        (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+        (hsPkgs."fgl" or (errorHandler.buildDepError "fgl"))
+        (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+        (hsPkgs."free" or (errorHandler.buildDepError "free"))
+        (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
+        (hsPkgs."generics-sop" or (errorHandler.buildDepError "generics-sop"))
+        (hsPkgs."ghc-trace-events" or (errorHandler.buildDepError
+          "ghc-trace-events"))
+        (hsPkgs."gitrev" or (errorHandler.buildDepError "gitrev"))
+        (hsPkgs."graphviz" or (errorHandler.buildDepError "graphviz"))
+        (hsPkgs."hashable" or (errorHandler.buildDepError "hashable"))
+        (hsPkgs."haskeline" or (errorHandler.buildDepError "haskeline"))
+        (hsPkgs."integer-gmp" or (errorHandler.buildDepError "integer-gmp"))
+        (hsPkgs."json-rpc" or (errorHandler.buildDepError "json-rpc"))
+        (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+        (hsPkgs."logict" or (errorHandler.buildDepError "logict"))
+        (hsPkgs."matrix" or (errorHandler.buildDepError "matrix"))
+        (hsPkgs."megaparsec" or (errorHandler.buildDepError "megaparsec"))
+        (hsPkgs."mmorph" or (errorHandler.buildDepError "mmorph"))
+        (hsPkgs."monad-logger" or (errorHandler.buildDepError "monad-logger"))
+        (hsPkgs."mono-traversable" or (errorHandler.buildDepError
+          "mono-traversable"))
+        (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
+        (hsPkgs."multiset" or (errorHandler.buildDepError "multiset"))
+        (hsPkgs."optparse-applicative" or (errorHandler.buildDepError
+          "optparse-applicative"))
+        (hsPkgs."parser-combinators" or (errorHandler.buildDepError
+          "parser-combinators"))
+        (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
+        (hsPkgs."process" or (errorHandler.buildDepError "process"))
+        (hsPkgs."profunctors" or (errorHandler.buildDepError "profunctors"))
+        (hsPkgs."recursion-schemes" or (errorHandler.buildDepError
+          "recursion-schemes"))
+        (hsPkgs."semialign" or (errorHandler.buildDepError "semialign"))
+        (hsPkgs."sqlite-simple" or (errorHandler.buildDepError "sqlite-simple"))
+        (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+        (hsPkgs."streams" or (errorHandler.buildDepError "streams"))
+        (hsPkgs."tar" or (errorHandler.buildDepError "tar"))
+        (hsPkgs."template-haskell" or (errorHandler.buildDepError
+          "template-haskell"))
+        (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
+        (hsPkgs."text" or (errorHandler.buildDepError "text"))
+        (hsPkgs."these" or (errorHandler.buildDepError "these"))
+        (hsPkgs."time" or (errorHandler.buildDepError "time"))
+        (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+        (hsPkgs."unordered-containers" or (errorHandler.buildDepError
+          "unordered-containers"))
+        (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
+        (hsPkgs."witherable" or (errorHandler.buildDepError "witherable"))
+        (hsPkgs."zlib" or (errorHandler.buildDepError "zlib"))
+      ];
+      build-tools = [
+        (hsPkgs.buildPackages.happy.components.exes.happy or (pkgs.buildPackages.happy or (errorHandler.buildToolDepError
+          "happy:happy")))
+        (hsPkgs.buildPackages.alex.components.exes.alex or (pkgs.buildPackages.alex or (errorHandler.buildToolDepError
+          "alex:alex")))
+      ];
+      buildable = true;
+      modules = [
+        "Changed"
+        "Control/Monad/Counter"
+        "Data/Graph/TopologicalSort"
+        "Data/Limit"
+        "Data/Sup"
+        "Debug"
+        "ErrorContext"
+        "From"
+        "GlobalMain"
+        "Injection"
+        "Kore/AST/ApplicativeKore"
+        "Kore/AST/AstWithLocation"
+        "Kore/AST/Common"
+        "Kore/AST/Error"
+        "Kore/Attribute/Assoc"
+        "Kore/Attribute/Attributes"
+        "Kore/Attribute/Axiom"
+        "Kore/Attribute/Axiom/Concrete"
+        "Kore/Attribute/Axiom/Constructor"
+        "Kore/Attribute/Axiom/NonExecutable"
+        "Kore/Attribute/Axiom/Symbolic"
+        "Kore/Attribute/Axiom/Unit"
+        "Kore/Attribute/Comm"
+        "Kore/Attribute/Constructor"
+        "Kore/Attribute/Definition"
+        "Kore/Attribute/Function"
+        "Kore/Attribute/Functional"
+        "Kore/Attribute/Hook"
+        "Kore/Attribute/Idem"
+        "Kore/Attribute/Injective"
+        "Kore/Attribute/Label"
+        "Kore/Attribute/Location"
+        "Kore/Attribute/Null"
+        "Kore/Attribute/Overload"
+        "Kore/Attribute/Owise"
+        "Kore/Attribute/Parser"
+        "Kore/Attribute/Pattern/ConstructorLike"
+        "Kore/Attribute/Pattern/Created"
+        "Kore/Attribute/Pattern/Defined"
+        "Kore/Attribute/Pattern/FreeVariables"
+        "Kore/Attribute/Pattern/Function"
+        "Kore/Attribute/Pattern/Functional"
+        "Kore/Attribute/Pattern/Simplified"
+        "Kore/Attribute/PredicatePattern"
+        "Kore/Attribute/Priority"
+        "Kore/Attribute/ProductionID"
+        "Kore/Attribute/RuleIndex"
+        "Kore/Attribute/Simplification"
+        "Kore/Attribute/Smthook"
+        "Kore/Attribute/SmtLemma"
+        "Kore/Attribute/Smtlib"
+        "Kore/Attribute/Smtlib/Smthook"
+        "Kore/Attribute/Smtlib/Smtlib"
+        "Kore/Attribute/Sort"
+        "Kore/Attribute/Sort/Concat"
+        "Kore/Attribute/Sort/Constructors"
+        "Kore/Attribute/Sort/ConstructorsBuilder"
+        "Kore/Attribute/Sort/Element"
+        "Kore/Attribute/Sort/HasDomainValues"
+        "Kore/Attribute/Sort/Unit"
+        "Kore/Attribute/SortInjection"
+        "Kore/Attribute/Source"
+        "Kore/Attribute/SourceLocation"
+        "Kore/Attribute/Subsort"
+        "Kore/Attribute/Symbol"
+        "Kore/Attribute/Symbol/Anywhere"
+        "Kore/Attribute/Symbol/Klabel"
+        "Kore/Attribute/Symbol/Memo"
+        "Kore/Attribute/Symbol/NoEvaluators"
+        "Kore/Attribute/Symbol/SymbolKywd"
+        "Kore/Attribute/Synthetic"
+        "Kore/Attribute/Trusted"
+        "Kore/Attribute/UniqueId"
+        "Kore/BugReport"
+        "Kore/Builtin"
+        "Kore/Builtin/AssocComm/AssocComm"
+        "Kore/Builtin/AssocComm/CeilSimplifier"
+        "Kore/Builtin/AssociativeCommutative"
+        "Kore/Builtin/Attributes"
+        "Kore/Builtin/Bool"
+        "Kore/Builtin/Bool/Bool"
+        "Kore/Builtin/Builtin"
+        "Kore/Builtin/Encoding"
+        "Kore/Builtin/Endianness"
+        "Kore/Builtin/Endianness/Endianness"
+        "Kore/Builtin/EqTerm"
+        "Kore/Builtin/Error"
+        "Kore/Builtin/Inj"
+        "Kore/Builtin/Int"
+        "Kore/Builtin/Int/Int"
+        "Kore/Builtin/InternalBytes"
+        "Kore/Builtin/InternalBytes/InternalBytes"
+        "Kore/Builtin/KEqual"
+        "Kore/Builtin/Kreflection"
+        "Kore/Builtin/Krypto"
+        "Kore/Builtin/List"
+        "Kore/Builtin/List/List"
+        "Kore/Builtin/Map"
+        "Kore/Builtin/Map/Map"
+        "Kore/Builtin/Set"
+        "Kore/Builtin/Set/Set"
+        "Kore/Builtin/Signedness"
+        "Kore/Builtin/Signedness/Signedness"
+        "Kore/Builtin/String"
+        "Kore/Builtin/String/String"
+        "Kore/Builtin/Symbols"
+        "Kore/Builtin/Verifiers"
+        "Kore/Debug"
+        "Kore/Equation"
+        "Kore/Equation/Application"
+        "Kore/Equation/DebugEquation"
+        "Kore/Equation/Equation"
+        "Kore/Equation/Registry"
+        "Kore/Equation/Sentence"
+        "Kore/Equation/Simplification"
+        "Kore/Equation/Validate"
+        "Kore/Error"
+        "Kore/Exec"
+        "Kore/IndexedModule/Error"
+        "Kore/IndexedModule/IndexedModule"
+        "Kore/IndexedModule/MetadataTools"
+        "Kore/IndexedModule/MetadataToolsBuilder"
+        "Kore/IndexedModule/OverloadGraph"
+        "Kore/IndexedModule/Resolvers"
+        "Kore/IndexedModule/SortGraph"
+        "Kore/Internal/Alias"
+        "Kore/Internal/ApplicationSorts"
+        "Kore/Internal/Condition"
+        "Kore/Internal/Conditional"
+        "Kore/Internal/From"
+        "Kore/Internal/Inj"
+        "Kore/Internal/InternalBool"
+        "Kore/Internal/InternalBytes"
+        "Kore/Internal/InternalInt"
+        "Kore/Internal/InternalList"
+        "Kore/Internal/InternalMap"
+        "Kore/Internal/InternalSet"
+        "Kore/Internal/InternalString"
+        "Kore/Internal/Key"
+        "Kore/Internal/MultiAnd"
+        "Kore/Internal/MultiExists"
+        "Kore/Internal/MultiOr"
+        "Kore/Internal/NormalizedAc"
+        "Kore/Internal/OrCondition"
+        "Kore/Internal/OrPattern"
+        "Kore/Internal/Pattern"
+        "Kore/Internal/Predicate"
+        "Kore/Internal/SideCondition"
+        "Kore/Internal/SideCondition/SideCondition"
+        "Kore/Internal/Substitution"
+        "Kore/Internal/Symbol"
+        "Kore/Internal/TermLike"
+        "Kore/Internal/TermLike/Renaming"
+        "Kore/Internal/TermLike/TermLike"
+        "Kore/Internal/Variable"
+        "Kore/JsonRpc"
+        "Kore/Log"
+        "Kore/Log/DebugAppliedRewriteRules"
+        "Kore/Log/DebugAttemptedRewriteRules"
+        "Kore/Log/DebugBeginClaim"
+        "Kore/Log/DebugCreatedSubstitution"
+        "Kore/Log/DebugEvaluateCondition"
+        "Kore/Log/DebugProven"
+        "Kore/Log/DebugRetrySolverQuery"
+        "Kore/Log/DebugSolver"
+        "Kore/Log/DebugSubstitutionSimplifier"
+        "Kore/Log/DebugTransition"
+        "Kore/Log/DebugUnification"
+        "Kore/Log/DebugUnifyBottom"
+        "Kore/Log/ErrorBottomTotalFunction"
+        "Kore/Log/ErrorDecidePredicateUnknown"
+        "Kore/Log/ErrorEquationRightFunction"
+        "Kore/Log/ErrorEquationsSameMatch"
+        "Kore/Log/ErrorException"
+        "Kore/Log/ErrorOutOfDate"
+        "Kore/Log/ErrorParse"
+        "Kore/Log/ErrorRewriteLoop"
+        "Kore/Log/ErrorRewritesInstantiation"
+        "Kore/Log/ErrorVerify"
+        "Kore/Log/InfoAttemptUnification"
+        "Kore/Log/JsonRpc"
+        "Kore/Log/InfoExecBreadth"
+        "Kore/Log/InfoExecDepth"
+        "Kore/Log/InfoProofDepth"
+        "Kore/Log/InfoReachability"
+        "Kore/Log/KoreLogOptions"
+        "Kore/Log/Registry"
+        "Kore/Log/SQLite"
+        "Kore/Log/WarnBoundedModelChecker"
+        "Kore/Log/WarnClaimRHSIsBottom"
+        "Kore/Log/WarnDepthLimitExceeded"
+        "Kore/Log/WarnFunctionWithoutEvaluators"
+        "Kore/Log/WarnIfLowProductivity"
+        "Kore/Log/WarnNotImplemented"
+        "Kore/Log/WarnRestartSolver"
+        "Kore/Log/WarnStuckClaimState"
+        "Kore/Log/WarnSymbolSMTRepresentation"
+        "Kore/Log/WarnTrivialClaim"
+        "Kore/Log/WarnUnsimplified"
+        "Kore/ModelChecker/Bounded"
+        "Kore/ModelChecker/Simplification"
+        "Kore/ModelChecker/Step"
+        "Kore/Options"
+        "Kore/Parser"
+        "Kore/Parser/CString"
+        "Kore/Parser/Lexer"
+        "Kore/Parser/LexerWrapper"
+        "Kore/Parser/Parser"
+        "Kore/Parser/ParserUtils"
+        "Kore/Reachability"
+        "Kore/Reachability/AllPathClaim"
+        "Kore/Reachability/Claim"
+        "Kore/Reachability/ClaimState"
+        "Kore/Reachability/OnePathClaim"
+        "Kore/Reachability/Prim"
+        "Kore/Reachability/Prove"
+        "Kore/Reachability/SomeClaim"
+        "Kore/Repl"
+        "Kore/Repl/Data"
+        "Kore/Repl/Interpreter"
+        "Kore/Repl/Parser"
+        "Kore/Repl/State"
+        "Kore/Rewrite"
+        "Kore/Rewrite/AntiLeft"
+        "Kore/Rewrite/Axiom/EvaluationStrategy"
+        "Kore/Rewrite/Axiom/Identifier"
+        "Kore/Rewrite/Axiom/Matcher"
+        "Kore/Rewrite/Axiom/MatcherData"
+        "Kore/Rewrite/Axiom/Registry"
+        "Kore/Rewrite/AxiomPattern"
+        "Kore/Rewrite/ClaimPattern"
+        "Kore/Rewrite/Function/Evaluator"
+        "Kore/Rewrite/Function/Memo"
+        "Kore/Rewrite/Implication"
+        "Kore/Rewrite/Remainder"
+        "Kore/Rewrite/Result"
+        "Kore/Rewrite/RewriteStep"
+        "Kore/Rewrite/Rule"
+        "Kore/Rewrite/Rule/Expand"
+        "Kore/Rewrite/Rule/Simplify"
+        "Kore/Rewrite/RulePattern"
+        "Kore/Rewrite/Search"
+        "Kore/Rewrite/SMT/AST"
+        "Kore/Rewrite/SMT/Declaration"
+        "Kore/Rewrite/SMT/Encoder"
+        "Kore/Rewrite/SMT/Evaluator"
+        "Kore/Rewrite/SMT/Lemma"
+        "Kore/Rewrite/SMT/Representation/All"
+        "Kore/Rewrite/SMT/Representation/Resolve"
+        "Kore/Rewrite/SMT/Representation/Sorts"
+        "Kore/Rewrite/SMT/Representation/Symbols"
+        "Kore/Rewrite/SMT/Resolvers"
+        "Kore/Rewrite/SMT/Translate"
+        "Kore/Rewrite/Step"
+        "Kore/Rewrite/Strategy"
+        "Kore/Rewrite/Substitution"
+        "Kore/Rewrite/Transition"
+        "Kore/Rewrite/RewritingVariable"
+        "Kore/Rewrite/UnifyingRule"
+        "Kore/Simplify/And"
+        "Kore/Simplify/AndPredicates"
+        "Kore/Simplify/AndTerms"
+        "Kore/Simplify/API"
+        "Kore/Simplify/Application"
+        "Kore/Simplify/Bottom"
+        "Kore/Simplify/Ceil"
+        "Kore/Simplify/CeilSimplifier"
+        "Kore/Simplify/Condition"
+        "Kore/Simplify/DomainValue"
+        "Kore/Simplify/Equals"
+        "Kore/Simplify/Exists"
+        "Kore/Simplify/ExpandAlias"
+        "Kore/Simplify/Floor"
+        "Kore/Simplify/Forall"
+        "Kore/Simplify/Iff"
+        "Kore/Simplify/Implies"
+        "Kore/Simplify/In"
+        "Kore/Simplify/Inhabitant"
+        "Kore/Simplify/Inj"
+        "Kore/Simplify/InjSimplifier"
+        "Kore/Simplify/InternalBool"
+        "Kore/Simplify/InternalBytes"
+        "Kore/Simplify/InternalInt"
+        "Kore/Simplify/InternalList"
+        "Kore/Simplify/InternalMap"
+        "Kore/Simplify/InternalSet"
+        "Kore/Simplify/InternalString"
+        "Kore/Simplify/Mu"
+        "Kore/Simplify/Next"
+        "Kore/Simplify/NoConfusion"
+        "Kore/Simplify/Not"
+        "Kore/Simplify/NotSimplifier"
+        "Kore/Simplify/Nu"
+        "Kore/Simplify/Or"
+        "Kore/Simplify/OrPattern"
+        "Kore/Simplify/Overloading"
+        "Kore/Simplify/OverloadSimplifier"
+        "Kore/Simplify/Pattern"
+        "Kore/Simplify/Predicate"
+        "Kore/Simplify/SetVariable"
+        "Kore/Simplify/SimplificationType"
+        "Kore/Simplify/Simplify"
+        "Kore/Simplify/StringLiteral"
+        "Kore/Simplify/SubstitutionSimplifier"
+        "Kore/Simplify/TermLike"
+        "Kore/Simplify/Top"
+        "Kore/Simplify/Variable"
+        "Kore/Sort"
+        "Kore/Substitute"
+        "Kore/Syntax"
+        "Kore/Syntax/And"
+        "Kore/Syntax/Application"
+        "Kore/Syntax/Bottom"
+        "Kore/Syntax/Ceil"
+        "Kore/Syntax/Definition"
+        "Kore/Syntax/DomainValue"
+        "Kore/Syntax/Equals"
+        "Kore/Syntax/Exists"
+        "Kore/Syntax/Floor"
+        "Kore/Syntax/Forall"
+        "Kore/Syntax/Id"
+        "Kore/Syntax/Iff"
+        "Kore/Syntax/Implies"
+        "Kore/Syntax/In"
+        "Kore/Syntax/Inhabitant"
+        "Kore/Syntax/Json"
+        "Kore/Syntax/Json/Internal"
+        "Kore/Syntax/Module"
+        "Kore/Syntax/Mu"
+        "Kore/Syntax/Next"
+        "Kore/Syntax/Not"
+        "Kore/Syntax/Nu"
+        "Kore/Syntax/Or"
+        "Kore/Syntax/Pattern"
+        "Kore/Syntax/PatternF"
+        "Kore/Syntax/Rewrites"
+        "Kore/Syntax/Sentence"
+        "Kore/Syntax/StringLiteral"
+        "Kore/Syntax/Top"
+        "Kore/Syntax/Variable"
+        "Kore/TopBottom"
+        "Kore/Unification/Procedure"
+        "Kore/Unification/SubstitutionNormalization"
+        "Kore/Unification/SubstitutionSimplifier"
+        "Kore/Unification/UnifierT"
+        "Kore/Unification/Unify"
+        "Kore/Unification/NewUnifier"
+        "Kore/Unparser"
+        "Kore/Validate/AliasVerifier"
+        "Kore/Validate/AttributesVerifier"
+        "Kore/Validate/DefinitionVerifier"
+        "Kore/Validate/Error"
+        "Kore/Validate/ModuleVerifier"
+        "Kore/Validate/PatternVerifier"
+        "Kore/Validate/PatternVerifier/PatternVerifier"
+        "Kore/Validate/SentenceVerifier"
+        "Kore/Validate/SortVerifier"
+        "Kore/Validate/Verifier"
+        "Kore/Variables/Binding"
+        "Kore/Variables/Free"
+        "Kore/Variables/Fresh"
+        "Kore/Variables/Target"
+        "Kore/Verified"
+        "Kore/VersionInfo"
+        "Log"
+        "Log/Entry"
+        "Logic"
+        "Options/SMT"
+        "Pair"
+        "Partial"
+        "Paths_kore"
+        "Prelude/Kore"
+        "Pretty"
+        "Prof"
+        "SMT"
+        "SMT/AST"
+        "SMT/SimpleSMT"
+        "SQL"
+        "SQL/ColumnDef"
+        "SQL/Key"
+        "SQL/Query"
+        "SQL/SOP"
+        "SQL/SQL"
+        "Stats"
+      ];
+      hsSourceDirs = [ "src" "app/share" ];
+    };
+    exes = {
+      "kore-exec" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
+          (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
+          (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+          (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+          (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
+          (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+          (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+          (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
+          (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError
+            "optparse-applicative"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."time" or (errorHandler.buildDepError "time"))
+        ];
+        buildable = true;
+        hsSourceDirs = [ "app/exec" ];
+        mainPath = (([ "Main.hs" ]
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4")
+          "")
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8")
+          "") ++ [ "" ];
       };
-    components = {
-      "library" = {
+      "kore-rpc" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
+          (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
+          (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+          (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
+          (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError
+            "optparse-applicative"))
+          (hsPkgs."time" or (errorHandler.buildDepError "time"))
+        ];
+        buildable = true;
+        hsSourceDirs = [ "app/rpc" ];
+        mainPath = (([ "Main.hs" ]
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4")
+          "")
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8")
+          "") ++ [ "" ];
+      };
+      "kore-format" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError
+            "optparse-applicative"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+        ];
+        buildable = true;
+        hsSourceDirs = [ "app/format" ];
+        mainPath = (([ "Main.hs" ]
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4")
+          "")
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8")
+          "") ++ [ "" ];
+      };
+      "kore-parser" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
+        ];
+        buildable = true;
+        hsSourceDirs = [ "app/parser" ];
+        mainPath = (([ "Main.hs" ]
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4")
+          "")
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8")
+          "") ++ [ "" ];
+      };
+      "kore-prof" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
+          (hsPkgs."eventlog2speedscope" or (errorHandler.buildDepError
+            "eventlog2speedscope"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError
+            "optparse-applicative"))
+        ];
+        buildable = true;
+        hsSourceDirs = [ "app/prof" ];
+        mainPath = (([ "Main.hs" ]
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4")
+          "")
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8")
+          "") ++ [ "" ];
+      };
+      "kore-repl" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
+          (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
+          (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
+          (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError
+            "optparse-applicative"))
+        ];
+        buildable = true;
+        hsSourceDirs = [ "app/repl" ];
+        mainPath = (([ "Main.hs" ]
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4")
+          "")
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8")
+          "") ++ [ "" ];
+      };
+      "kore-match-disjunction" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
+          (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError
+            "optparse-applicative"))
+          (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+        ];
+        buildable = true;
+        hsSourceDirs = [ "app/match-disjunction" ];
+        mainPath = (([ "Main.hs" ]
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4")
+          "")
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8")
+          "") ++ [ "" ];
+      };
+      "kore-check-functions" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
+          (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
+          (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
+        ];
+        buildable = true;
+        hsSourceDirs = [ "app/check-functions" ];
+        mainPath = (([ "Main.hs" ]
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4")
+          "")
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8")
+          "") ++ [ "" ];
+      };
+      "kore-simplify" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
+          (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError
+            "optparse-applicative"))
+        ];
+        buildable = true;
+        hsSourceDirs = [ "app/simplify" ];
+        mainPath = (([ "Main.hs" ]
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4")
+          "")
+          ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8")
+          "") ++ [ "" ];
+      };
+    };
+    tests = {
+      "kore-test" = {
         depends = [
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."adjunctions" or (errorHandler.buildDepError "adjunctions"))
@@ -45,13 +681,16 @@
           (hsPkgs."co-log" or (errorHandler.buildDepError "co-log"))
           (hsPkgs."comonad" or (errorHandler.buildDepError "comonad"))
           (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
-          (hsPkgs."conduit-extra" or (errorHandler.buildDepError "conduit-extra"))
+          (hsPkgs."conduit-extra" or (errorHandler.buildDepError
+            "conduit-extra"))
           (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
           (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
           (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
-          (hsPkgs."decision-diagrams" or (errorHandler.buildDepError "decision-diagrams"))
+          (hsPkgs."decision-diagrams" or (errorHandler.buildDepError
+            "decision-diagrams"))
           (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
-          (hsPkgs."deriving-aeson" or (errorHandler.buildDepError "deriving-aeson"))
+          (hsPkgs."deriving-aeson" or (errorHandler.buildDepError
+            "deriving-aeson"))
           (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
           (hsPkgs."distributive" or (errorHandler.buildDepError "distributive"))
           (hsPkgs."errors" or (errorHandler.buildDepError "errors"))
@@ -62,7 +701,8 @@
           (hsPkgs."free" or (errorHandler.buildDepError "free"))
           (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
           (hsPkgs."generics-sop" or (errorHandler.buildDepError "generics-sop"))
-          (hsPkgs."ghc-trace-events" or (errorHandler.buildDepError "ghc-trace-events"))
+          (hsPkgs."ghc-trace-events" or (errorHandler.buildDepError
+            "ghc-trace-events"))
           (hsPkgs."gitrev" or (errorHandler.buildDepError "gitrev"))
           (hsPkgs."graphviz" or (errorHandler.buildDepError "graphviz"))
           (hsPkgs."hashable" or (errorHandler.buildDepError "hashable"))
@@ -75,877 +715,273 @@
           (hsPkgs."megaparsec" or (errorHandler.buildDepError "megaparsec"))
           (hsPkgs."mmorph" or (errorHandler.buildDepError "mmorph"))
           (hsPkgs."monad-logger" or (errorHandler.buildDepError "monad-logger"))
-          (hsPkgs."mono-traversable" or (errorHandler.buildDepError "mono-traversable"))
+          (hsPkgs."mono-traversable" or (errorHandler.buildDepError
+            "mono-traversable"))
           (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
           (hsPkgs."multiset" or (errorHandler.buildDepError "multiset"))
-          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-          (hsPkgs."parser-combinators" or (errorHandler.buildDepError "parser-combinators"))
-          (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError
+            "optparse-applicative"))
+          (hsPkgs."parser-combinators" or (errorHandler.buildDepError
+            "parser-combinators"))
+          (hsPkgs."prettyprinter" or (errorHandler.buildDepError
+            "prettyprinter"))
           (hsPkgs."process" or (errorHandler.buildDepError "process"))
           (hsPkgs."profunctors" or (errorHandler.buildDepError "profunctors"))
-          (hsPkgs."recursion-schemes" or (errorHandler.buildDepError "recursion-schemes"))
+          (hsPkgs."recursion-schemes" or (errorHandler.buildDepError
+            "recursion-schemes"))
           (hsPkgs."semialign" or (errorHandler.buildDepError "semialign"))
-          (hsPkgs."sqlite-simple" or (errorHandler.buildDepError "sqlite-simple"))
+          (hsPkgs."sqlite-simple" or (errorHandler.buildDepError
+            "sqlite-simple"))
           (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
           (hsPkgs."streams" or (errorHandler.buildDepError "streams"))
           (hsPkgs."tar" or (errorHandler.buildDepError "tar"))
-          (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+          (hsPkgs."template-haskell" or (errorHandler.buildDepError
+            "template-haskell"))
           (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           (hsPkgs."these" or (errorHandler.buildDepError "these"))
           (hsPkgs."time" or (errorHandler.buildDepError "time"))
           (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
-          (hsPkgs."unordered-containers" or (errorHandler.buildDepError "unordered-containers"))
+          (hsPkgs."unordered-containers" or (errorHandler.buildDepError
+            "unordered-containers"))
           (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
           (hsPkgs."witherable" or (errorHandler.buildDepError "witherable"))
           (hsPkgs."zlib" or (errorHandler.buildDepError "zlib"))
-          ];
+          (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
+          (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+          (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
+          (hsPkgs."quickcheck-instances" or (errorHandler.buildDepError
+            "quickcheck-instances"))
+          (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+          (hsPkgs."tasty-golden" or (errorHandler.buildDepError "tasty-golden"))
+          (hsPkgs."tasty-hedgehog" or (errorHandler.buildDepError
+            "tasty-hedgehog"))
+          (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+          (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError
+            "tasty-quickcheck"))
+          (hsPkgs."tasty-test-reporter" or (errorHandler.buildDepError
+            "tasty-test-reporter"))
+        ];
         build-tools = [
-          (hsPkgs.buildPackages.happy.components.exes.happy or (pkgs.buildPackages.happy or (errorHandler.buildToolDepError "happy:happy")))
-          (hsPkgs.buildPackages.alex.components.exes.alex or (pkgs.buildPackages.alex or (errorHandler.buildToolDepError "alex:alex")))
-          ];
+          (hsPkgs.buildPackages.happy.components.exes.happy or (pkgs.buildPackages.happy or (errorHandler.buildToolDepError
+            "happy:happy")))
+          (hsPkgs.buildPackages.alex.components.exes.alex or (pkgs.buildPackages.alex or (errorHandler.buildToolDepError
+            "alex:alex")))
+          (hsPkgs.buildPackages.tasty-discover.components.exes.tasty-discover or (pkgs.buildPackages.tasty-discover or (errorHandler.buildToolDepError
+            "tasty-discover:tasty-discover")))
+        ];
         buildable = true;
         modules = [
-          "Changed"
-          "Control/Monad/Counter"
-          "Data/Graph/TopologicalSort"
-          "Data/Limit"
-          "Data/Sup"
-          "Debug"
-          "ErrorContext"
-          "From"
-          "GlobalMain"
-          "Injection"
-          "Kore/AST/ApplicativeKore"
-          "Kore/AST/AstWithLocation"
-          "Kore/AST/Common"
-          "Kore/AST/Error"
-          "Kore/Attribute/Assoc"
-          "Kore/Attribute/Attributes"
-          "Kore/Attribute/Axiom"
-          "Kore/Attribute/Axiom/Concrete"
-          "Kore/Attribute/Axiom/Constructor"
-          "Kore/Attribute/Axiom/NonExecutable"
-          "Kore/Attribute/Axiom/Symbolic"
-          "Kore/Attribute/Axiom/Unit"
-          "Kore/Attribute/Comm"
-          "Kore/Attribute/Constructor"
-          "Kore/Attribute/Definition"
-          "Kore/Attribute/Function"
-          "Kore/Attribute/Functional"
-          "Kore/Attribute/Hook"
-          "Kore/Attribute/Idem"
-          "Kore/Attribute/Injective"
-          "Kore/Attribute/Label"
-          "Kore/Attribute/Location"
-          "Kore/Attribute/Null"
-          "Kore/Attribute/Overload"
-          "Kore/Attribute/Owise"
-          "Kore/Attribute/Parser"
-          "Kore/Attribute/Pattern/ConstructorLike"
-          "Kore/Attribute/Pattern/Created"
-          "Kore/Attribute/Pattern/Defined"
-          "Kore/Attribute/Pattern/FreeVariables"
-          "Kore/Attribute/Pattern/Function"
-          "Kore/Attribute/Pattern/Functional"
-          "Kore/Attribute/Pattern/Simplified"
-          "Kore/Attribute/PredicatePattern"
-          "Kore/Attribute/Priority"
-          "Kore/Attribute/ProductionID"
-          "Kore/Attribute/RuleIndex"
-          "Kore/Attribute/Simplification"
-          "Kore/Attribute/Smthook"
-          "Kore/Attribute/SmtLemma"
-          "Kore/Attribute/Smtlib"
-          "Kore/Attribute/Smtlib/Smthook"
-          "Kore/Attribute/Smtlib/Smtlib"
-          "Kore/Attribute/Sort"
-          "Kore/Attribute/Sort/Concat"
-          "Kore/Attribute/Sort/Constructors"
-          "Kore/Attribute/Sort/ConstructorsBuilder"
-          "Kore/Attribute/Sort/Element"
-          "Kore/Attribute/Sort/HasDomainValues"
-          "Kore/Attribute/Sort/Unit"
-          "Kore/Attribute/SortInjection"
-          "Kore/Attribute/Source"
-          "Kore/Attribute/SourceLocation"
-          "Kore/Attribute/Subsort"
-          "Kore/Attribute/Symbol"
-          "Kore/Attribute/Symbol/Anywhere"
-          "Kore/Attribute/Symbol/Klabel"
-          "Kore/Attribute/Symbol/Memo"
-          "Kore/Attribute/Symbol/NoEvaluators"
-          "Kore/Attribute/Symbol/SymbolKywd"
-          "Kore/Attribute/Synthetic"
-          "Kore/Attribute/Trusted"
-          "Kore/Attribute/UniqueId"
-          "Kore/BugReport"
-          "Kore/Builtin"
-          "Kore/Builtin/AssocComm/AssocComm"
-          "Kore/Builtin/AssocComm/CeilSimplifier"
-          "Kore/Builtin/AssociativeCommutative"
-          "Kore/Builtin/Attributes"
-          "Kore/Builtin/Bool"
-          "Kore/Builtin/Bool/Bool"
-          "Kore/Builtin/Builtin"
-          "Kore/Builtin/Encoding"
-          "Kore/Builtin/Endianness"
-          "Kore/Builtin/Endianness/Endianness"
-          "Kore/Builtin/EqTerm"
-          "Kore/Builtin/Error"
-          "Kore/Builtin/Inj"
-          "Kore/Builtin/Int"
-          "Kore/Builtin/Int/Int"
-          "Kore/Builtin/InternalBytes"
-          "Kore/Builtin/InternalBytes/InternalBytes"
-          "Kore/Builtin/KEqual"
-          "Kore/Builtin/Kreflection"
-          "Kore/Builtin/Krypto"
-          "Kore/Builtin/List"
-          "Kore/Builtin/List/List"
-          "Kore/Builtin/Map"
-          "Kore/Builtin/Map/Map"
-          "Kore/Builtin/Set"
-          "Kore/Builtin/Set/Set"
-          "Kore/Builtin/Signedness"
-          "Kore/Builtin/Signedness/Signedness"
-          "Kore/Builtin/String"
-          "Kore/Builtin/String/String"
-          "Kore/Builtin/Symbols"
-          "Kore/Builtin/Verifiers"
-          "Kore/Debug"
-          "Kore/Equation"
-          "Kore/Equation/Application"
-          "Kore/Equation/DebugEquation"
-          "Kore/Equation/Equation"
-          "Kore/Equation/Registry"
-          "Kore/Equation/Sentence"
-          "Kore/Equation/Simplification"
-          "Kore/Equation/Validate"
-          "Kore/Error"
-          "Kore/Exec"
-          "Kore/IndexedModule/Error"
-          "Kore/IndexedModule/IndexedModule"
-          "Kore/IndexedModule/MetadataTools"
-          "Kore/IndexedModule/MetadataToolsBuilder"
-          "Kore/IndexedModule/OverloadGraph"
-          "Kore/IndexedModule/Resolvers"
-          "Kore/IndexedModule/SortGraph"
-          "Kore/Internal/Alias"
-          "Kore/Internal/ApplicationSorts"
-          "Kore/Internal/Condition"
-          "Kore/Internal/Conditional"
-          "Kore/Internal/From"
-          "Kore/Internal/Inj"
-          "Kore/Internal/InternalBool"
-          "Kore/Internal/InternalBytes"
-          "Kore/Internal/InternalInt"
-          "Kore/Internal/InternalList"
-          "Kore/Internal/InternalMap"
-          "Kore/Internal/InternalSet"
-          "Kore/Internal/InternalString"
-          "Kore/Internal/Key"
-          "Kore/Internal/MultiAnd"
-          "Kore/Internal/MultiExists"
-          "Kore/Internal/MultiOr"
-          "Kore/Internal/NormalizedAc"
-          "Kore/Internal/OrCondition"
-          "Kore/Internal/OrPattern"
-          "Kore/Internal/Pattern"
-          "Kore/Internal/Predicate"
-          "Kore/Internal/SideCondition"
-          "Kore/Internal/SideCondition/SideCondition"
-          "Kore/Internal/Substitution"
-          "Kore/Internal/Symbol"
-          "Kore/Internal/TermLike"
-          "Kore/Internal/TermLike/Renaming"
-          "Kore/Internal/TermLike/TermLike"
-          "Kore/Internal/Variable"
-          "Kore/JsonRpc"
-          "Kore/Log"
-          "Kore/Log/DebugAppliedRewriteRules"
-          "Kore/Log/DebugAttemptedRewriteRules"
-          "Kore/Log/DebugBeginClaim"
-          "Kore/Log/DebugCreatedSubstitution"
-          "Kore/Log/DebugEvaluateCondition"
-          "Kore/Log/DebugProven"
-          "Kore/Log/DebugRetrySolverQuery"
-          "Kore/Log/DebugSolver"
-          "Kore/Log/DebugSubstitutionSimplifier"
-          "Kore/Log/DebugTransition"
-          "Kore/Log/DebugUnification"
-          "Kore/Log/DebugUnifyBottom"
-          "Kore/Log/ErrorBottomTotalFunction"
-          "Kore/Log/ErrorDecidePredicateUnknown"
-          "Kore/Log/ErrorEquationRightFunction"
-          "Kore/Log/ErrorEquationsSameMatch"
-          "Kore/Log/ErrorException"
-          "Kore/Log/ErrorOutOfDate"
-          "Kore/Log/ErrorParse"
-          "Kore/Log/ErrorRewriteLoop"
-          "Kore/Log/ErrorRewritesInstantiation"
-          "Kore/Log/ErrorVerify"
-          "Kore/Log/InfoAttemptUnification"
-          "Kore/Log/JsonRpc"
-          "Kore/Log/InfoExecBreadth"
-          "Kore/Log/InfoExecDepth"
-          "Kore/Log/InfoProofDepth"
-          "Kore/Log/InfoReachability"
-          "Kore/Log/KoreLogOptions"
-          "Kore/Log/Registry"
-          "Kore/Log/SQLite"
-          "Kore/Log/WarnBoundedModelChecker"
-          "Kore/Log/WarnClaimRHSIsBottom"
-          "Kore/Log/WarnDepthLimitExceeded"
-          "Kore/Log/WarnFunctionWithoutEvaluators"
-          "Kore/Log/WarnIfLowProductivity"
-          "Kore/Log/WarnNotImplemented"
-          "Kore/Log/WarnRestartSolver"
-          "Kore/Log/WarnStuckClaimState"
-          "Kore/Log/WarnSymbolSMTRepresentation"
-          "Kore/Log/WarnTrivialClaim"
-          "Kore/Log/WarnUnsimplified"
-          "Kore/ModelChecker/Bounded"
-          "Kore/ModelChecker/Simplification"
-          "Kore/ModelChecker/Step"
-          "Kore/Options"
-          "Kore/Parser"
-          "Kore/Parser/CString"
-          "Kore/Parser/Lexer"
-          "Kore/Parser/LexerWrapper"
-          "Kore/Parser/Parser"
-          "Kore/Parser/ParserUtils"
-          "Kore/Reachability"
-          "Kore/Reachability/AllPathClaim"
-          "Kore/Reachability/Claim"
-          "Kore/Reachability/ClaimState"
-          "Kore/Reachability/OnePathClaim"
-          "Kore/Reachability/Prim"
-          "Kore/Reachability/Prove"
-          "Kore/Reachability/SomeClaim"
-          "Kore/Repl"
-          "Kore/Repl/Data"
-          "Kore/Repl/Interpreter"
-          "Kore/Repl/Parser"
-          "Kore/Repl/State"
-          "Kore/Rewrite"
-          "Kore/Rewrite/AntiLeft"
-          "Kore/Rewrite/Axiom/EvaluationStrategy"
-          "Kore/Rewrite/Axiom/Identifier"
-          "Kore/Rewrite/Axiom/Matcher"
-          "Kore/Rewrite/Axiom/MatcherData"
-          "Kore/Rewrite/Axiom/Registry"
-          "Kore/Rewrite/AxiomPattern"
-          "Kore/Rewrite/ClaimPattern"
-          "Kore/Rewrite/Function/Evaluator"
-          "Kore/Rewrite/Function/Memo"
-          "Kore/Rewrite/Implication"
-          "Kore/Rewrite/Remainder"
-          "Kore/Rewrite/Result"
-          "Kore/Rewrite/RewriteStep"
-          "Kore/Rewrite/Rule"
-          "Kore/Rewrite/Rule/Expand"
-          "Kore/Rewrite/Rule/Simplify"
-          "Kore/Rewrite/RulePattern"
-          "Kore/Rewrite/Search"
-          "Kore/Rewrite/SMT/AST"
-          "Kore/Rewrite/SMT/Declaration"
-          "Kore/Rewrite/SMT/Encoder"
-          "Kore/Rewrite/SMT/Evaluator"
-          "Kore/Rewrite/SMT/Lemma"
-          "Kore/Rewrite/SMT/Representation/All"
-          "Kore/Rewrite/SMT/Representation/Resolve"
-          "Kore/Rewrite/SMT/Representation/Sorts"
-          "Kore/Rewrite/SMT/Representation/Symbols"
-          "Kore/Rewrite/SMT/Resolvers"
-          "Kore/Rewrite/SMT/Translate"
-          "Kore/Rewrite/Step"
-          "Kore/Rewrite/Strategy"
-          "Kore/Rewrite/Substitution"
-          "Kore/Rewrite/Transition"
-          "Kore/Rewrite/RewritingVariable"
-          "Kore/Rewrite/UnifyingRule"
-          "Kore/Simplify/And"
-          "Kore/Simplify/AndPredicates"
-          "Kore/Simplify/AndTerms"
-          "Kore/Simplify/API"
-          "Kore/Simplify/Application"
-          "Kore/Simplify/Bottom"
-          "Kore/Simplify/Ceil"
-          "Kore/Simplify/CeilSimplifier"
-          "Kore/Simplify/Condition"
-          "Kore/Simplify/DomainValue"
-          "Kore/Simplify/Equals"
-          "Kore/Simplify/Exists"
-          "Kore/Simplify/ExpandAlias"
-          "Kore/Simplify/Floor"
-          "Kore/Simplify/Forall"
-          "Kore/Simplify/Iff"
-          "Kore/Simplify/Implies"
-          "Kore/Simplify/In"
-          "Kore/Simplify/Inhabitant"
-          "Kore/Simplify/Inj"
-          "Kore/Simplify/InjSimplifier"
-          "Kore/Simplify/InternalBool"
-          "Kore/Simplify/InternalBytes"
-          "Kore/Simplify/InternalInt"
-          "Kore/Simplify/InternalList"
-          "Kore/Simplify/InternalMap"
-          "Kore/Simplify/InternalSet"
-          "Kore/Simplify/InternalString"
-          "Kore/Simplify/Mu"
-          "Kore/Simplify/Next"
-          "Kore/Simplify/NoConfusion"
-          "Kore/Simplify/Not"
-          "Kore/Simplify/NotSimplifier"
-          "Kore/Simplify/Nu"
-          "Kore/Simplify/Or"
-          "Kore/Simplify/OrPattern"
-          "Kore/Simplify/Overloading"
-          "Kore/Simplify/OverloadSimplifier"
-          "Kore/Simplify/Pattern"
-          "Kore/Simplify/Predicate"
-          "Kore/Simplify/SetVariable"
-          "Kore/Simplify/SimplificationType"
-          "Kore/Simplify/Simplify"
-          "Kore/Simplify/StringLiteral"
-          "Kore/Simplify/SubstitutionSimplifier"
-          "Kore/Simplify/TermLike"
-          "Kore/Simplify/Top"
-          "Kore/Simplify/Variable"
-          "Kore/Sort"
-          "Kore/Substitute"
-          "Kore/Syntax"
-          "Kore/Syntax/And"
-          "Kore/Syntax/Application"
-          "Kore/Syntax/Bottom"
-          "Kore/Syntax/Ceil"
-          "Kore/Syntax/Definition"
-          "Kore/Syntax/DomainValue"
-          "Kore/Syntax/Equals"
-          "Kore/Syntax/Exists"
-          "Kore/Syntax/Floor"
-          "Kore/Syntax/Forall"
-          "Kore/Syntax/Id"
-          "Kore/Syntax/Iff"
-          "Kore/Syntax/Implies"
-          "Kore/Syntax/In"
-          "Kore/Syntax/Inhabitant"
-          "Kore/Syntax/Json"
-          "Kore/Syntax/Json/Internal"
-          "Kore/Syntax/Module"
-          "Kore/Syntax/Mu"
-          "Kore/Syntax/Next"
-          "Kore/Syntax/Not"
-          "Kore/Syntax/Nu"
-          "Kore/Syntax/Or"
-          "Kore/Syntax/Pattern"
-          "Kore/Syntax/PatternF"
-          "Kore/Syntax/Rewrites"
-          "Kore/Syntax/Sentence"
-          "Kore/Syntax/StringLiteral"
-          "Kore/Syntax/Top"
-          "Kore/Syntax/Variable"
-          "Kore/TopBottom"
-          "Kore/Unification/Procedure"
-          "Kore/Unification/SubstitutionNormalization"
-          "Kore/Unification/SubstitutionSimplifier"
-          "Kore/Unification/UnifierT"
-          "Kore/Unification/Unify"
-          "Kore/Unification/NewUnifier"
-          "Kore/Unparser"
-          "Kore/Validate/AliasVerifier"
-          "Kore/Validate/AttributesVerifier"
-          "Kore/Validate/DefinitionVerifier"
-          "Kore/Validate/Error"
-          "Kore/Validate/ModuleVerifier"
-          "Kore/Validate/PatternVerifier"
-          "Kore/Validate/PatternVerifier/PatternVerifier"
-          "Kore/Validate/SentenceVerifier"
-          "Kore/Validate/SortVerifier"
-          "Kore/Validate/Verifier"
-          "Kore/Variables/Binding"
-          "Kore/Variables/Free"
-          "Kore/Variables/Fresh"
-          "Kore/Variables/Target"
-          "Kore/Verified"
-          "Kore/VersionInfo"
-          "Log"
-          "Log/Entry"
-          "Logic"
-          "Options/SMT"
-          "Pair"
-          "Partial"
-          "Paths_kore"
-          "Prelude/Kore"
-          "Pretty"
-          "Prof"
-          "SMT"
-          "SMT/AST"
-          "SMT/SimpleSMT"
-          "SQL"
-          "SQL/ColumnDef"
-          "SQL/Key"
-          "SQL/Query"
-          "SQL/SOP"
-          "SQL/SQL"
-          "Stats"
-          ];
-        hsSourceDirs = [ "src" "app/share" ];
-        };
-      exes = {
-        "kore-exec" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
-            (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
-            (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
-            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
-            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
-            (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
-            (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
-            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
-            (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
-            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
-            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-            (hsPkgs."text" or (errorHandler.buildDepError "text"))
-            (hsPkgs."time" or (errorHandler.buildDepError "time"))
-            ];
-          buildable = true;
-          hsSourceDirs = [ "app/exec" ];
-          mainPath = (([
-            "Main.hs"
-            ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
-            ""
-            ];
-          };
-        "kore-rpc" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
-            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
-            (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
-            (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
-            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-            (hsPkgs."time" or (errorHandler.buildDepError "time"))
-            ];
-          buildable = true;
-          hsSourceDirs = [ "app/rpc" ];
-          mainPath = (([
-            "Main.hs"
-            ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
-            ""
-            ];
-          };
-        "kore-format" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-            (hsPkgs."text" or (errorHandler.buildDepError "text"))
-            ];
-          buildable = true;
-          hsSourceDirs = [ "app/format" ];
-          mainPath = (([
-            "Main.hs"
-            ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
-            ""
-            ];
-          };
-        "kore-parser" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
-            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
-            ];
-          buildable = true;
-          hsSourceDirs = [ "app/parser" ];
-          mainPath = (([
-            "Main.hs"
-            ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
-            ""
-            ];
-          };
-        "kore-prof" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."eventlog2speedscope" or (errorHandler.buildDepError "eventlog2speedscope"))
-            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-            ];
-          buildable = true;
-          hsSourceDirs = [ "app/prof" ];
-          mainPath = (([
-            "Main.hs"
-            ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
-            ""
-            ];
-          };
-        "kore-repl" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
-            (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
-            (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
-            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-            ];
-          buildable = true;
-          hsSourceDirs = [ "app/repl" ];
-          mainPath = (([
-            "Main.hs"
-            ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
-            ""
-            ];
-          };
-        "kore-match-disjunction" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
-            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
-            ];
-          buildable = true;
-          hsSourceDirs = [ "app/match-disjunction" ];
-          mainPath = (([
-            "Main.hs"
-            ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
-            ""
-            ];
-          };
-        "kore-check-functions" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
-            (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
-            ];
-          buildable = true;
-          hsSourceDirs = [ "app/check-functions" ];
-          mainPath = (([
-            "Main.hs"
-            ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
-            ""
-            ];
-          };
-        "kore-simplify" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
-            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-            ];
-          buildable = true;
-          hsSourceDirs = [ "app/simplify" ];
-          mainPath = (([
-            "Main.hs"
-            ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.4") "") ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).ge "8.8") "") ++ [
-            ""
-            ];
-          };
-        };
-      tests = {
-        "kore-test" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."adjunctions" or (errorHandler.buildDepError "adjunctions"))
-            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
-            (hsPkgs."aeson-pretty" or (errorHandler.buildDepError "aeson-pretty"))
-            (hsPkgs."array" or (errorHandler.buildDepError "array"))
-            (hsPkgs."async" or (errorHandler.buildDepError "async"))
-            (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
-            (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
-            (hsPkgs."co-log" or (errorHandler.buildDepError "co-log"))
-            (hsPkgs."comonad" or (errorHandler.buildDepError "comonad"))
-            (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
-            (hsPkgs."conduit-extra" or (errorHandler.buildDepError "conduit-extra"))
-            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
-            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
-            (hsPkgs."decision-diagrams" or (errorHandler.buildDepError "decision-diagrams"))
-            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
-            (hsPkgs."deriving-aeson" or (errorHandler.buildDepError "deriving-aeson"))
-            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
-            (hsPkgs."distributive" or (errorHandler.buildDepError "distributive"))
-            (hsPkgs."errors" or (errorHandler.buildDepError "errors"))
-            (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
-            (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
-            (hsPkgs."fgl" or (errorHandler.buildDepError "fgl"))
-            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
-            (hsPkgs."free" or (errorHandler.buildDepError "free"))
-            (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
-            (hsPkgs."generics-sop" or (errorHandler.buildDepError "generics-sop"))
-            (hsPkgs."ghc-trace-events" or (errorHandler.buildDepError "ghc-trace-events"))
-            (hsPkgs."gitrev" or (errorHandler.buildDepError "gitrev"))
-            (hsPkgs."graphviz" or (errorHandler.buildDepError "graphviz"))
-            (hsPkgs."hashable" or (errorHandler.buildDepError "hashable"))
-            (hsPkgs."haskeline" or (errorHandler.buildDepError "haskeline"))
-            (hsPkgs."integer-gmp" or (errorHandler.buildDepError "integer-gmp"))
-            (hsPkgs."json-rpc" or (errorHandler.buildDepError "json-rpc"))
-            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
-            (hsPkgs."logict" or (errorHandler.buildDepError "logict"))
-            (hsPkgs."matrix" or (errorHandler.buildDepError "matrix"))
-            (hsPkgs."megaparsec" or (errorHandler.buildDepError "megaparsec"))
-            (hsPkgs."mmorph" or (errorHandler.buildDepError "mmorph"))
-            (hsPkgs."monad-logger" or (errorHandler.buildDepError "monad-logger"))
-            (hsPkgs."mono-traversable" or (errorHandler.buildDepError "mono-traversable"))
-            (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
-            (hsPkgs."multiset" or (errorHandler.buildDepError "multiset"))
-            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-            (hsPkgs."parser-combinators" or (errorHandler.buildDepError "parser-combinators"))
-            (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
-            (hsPkgs."process" or (errorHandler.buildDepError "process"))
-            (hsPkgs."profunctors" or (errorHandler.buildDepError "profunctors"))
-            (hsPkgs."recursion-schemes" or (errorHandler.buildDepError "recursion-schemes"))
-            (hsPkgs."semialign" or (errorHandler.buildDepError "semialign"))
-            (hsPkgs."sqlite-simple" or (errorHandler.buildDepError "sqlite-simple"))
-            (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
-            (hsPkgs."streams" or (errorHandler.buildDepError "streams"))
-            (hsPkgs."tar" or (errorHandler.buildDepError "tar"))
-            (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
-            (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
-            (hsPkgs."text" or (errorHandler.buildDepError "text"))
-            (hsPkgs."these" or (errorHandler.buildDepError "these"))
-            (hsPkgs."time" or (errorHandler.buildDepError "time"))
-            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
-            (hsPkgs."unordered-containers" or (errorHandler.buildDepError "unordered-containers"))
-            (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
-            (hsPkgs."witherable" or (errorHandler.buildDepError "witherable"))
-            (hsPkgs."zlib" or (errorHandler.buildDepError "zlib"))
-            (hsPkgs."kore" or (errorHandler.buildDepError "kore"))
-            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
-            (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
-            (hsPkgs."quickcheck-instances" or (errorHandler.buildDepError "quickcheck-instances"))
-            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
-            (hsPkgs."tasty-golden" or (errorHandler.buildDepError "tasty-golden"))
-            (hsPkgs."tasty-hedgehog" or (errorHandler.buildDepError "tasty-hedgehog"))
-            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
-            (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
-            (hsPkgs."tasty-test-reporter" or (errorHandler.buildDepError "tasty-test-reporter"))
-            ];
-          build-tools = [
-            (hsPkgs.buildPackages.happy.components.exes.happy or (pkgs.buildPackages.happy or (errorHandler.buildToolDepError "happy:happy")))
-            (hsPkgs.buildPackages.alex.components.exes.alex or (pkgs.buildPackages.alex or (errorHandler.buildToolDepError "alex:alex")))
-            (hsPkgs.buildPackages.tasty-discover.components.exes.tasty-discover or (pkgs.buildPackages.tasty-discover or (errorHandler.buildToolDepError "tasty-discover:tasty-discover")))
-            ];
-          buildable = true;
-          modules = [
-            "Driver"
-            "Test/ConsistentKore"
-            "Test/Data/Graph/TopologicalSort"
-            "Test/Data/Limit"
-            "Test/Data/Sup"
-            "Test/Debug"
-            "Test/Expect"
-            "Test/Injection"
-            "Test/Kore"
-            "Test/Kore/AST/Common"
-            "Test/Kore/Attribute/Assoc"
-            "Test/Kore/Attribute/Axiom/Concrete"
-            "Test/Kore/Attribute/Axiom/Symbolic"
-            "Test/Kore/Attribute/Axiom/Unit"
-            "Test/Kore/Attribute/Comm"
-            "Test/Kore/Attribute/Constructor"
-            "Test/Kore/Attribute/Function"
-            "Test/Kore/Attribute/Functional"
-            "Test/Kore/Attribute/Hook"
-            "Test/Kore/Attribute/Idem"
-            "Test/Kore/Attribute/Injective"
-            "Test/Kore/Attribute/Label"
-            "Test/Kore/Attribute/NonExecutable"
-            "Test/Kore/Attribute/Overload"
-            "Test/Kore/Attribute/Owise"
-            "Test/Kore/Attribute/Parser"
-            "Test/Kore/Attribute/Pattern/ConstructorLike"
-            "Test/Kore/Attribute/Pattern/Defined"
-            "Test/Kore/Attribute/Pattern/FreeVariables"
-            "Test/Kore/Attribute/Pattern/Function"
-            "Test/Kore/Attribute/Pattern/Functional"
-            "Test/Kore/Attribute/Pattern/Sort"
-            "Test/Kore/Attribute/Priority"
-            "Test/Kore/Attribute/ProductionID"
-            "Test/Kore/Attribute/Simplification"
-            "Test/Kore/Attribute/Smtlib"
-            "Test/Kore/Attribute/Sort/ConstructorsBuilder"
-            "Test/Kore/Attribute/Sort/HasDomainValues"
-            "Test/Kore/Attribute/Sort/Unit"
-            "Test/Kore/Attribute/SortInjection"
-            "Test/Kore/Attribute/Subsort"
-            "Test/Kore/Attribute/Symbol"
-            "Test/Kore/Attribute/Symbol/Anywhere"
-            "Test/Kore/Attribute/Symbol/Klabel"
-            "Test/Kore/Attribute/Symbol/Memo"
-            "Test/Kore/Attribute/Symbol/NoEvaluators"
-            "Test/Kore/Attribute/Symbol/SymbolKywd"
-            "Test/Kore/Attribute/Trusted"
-            "Test/Kore/Attribute/UniqueId"
-            "Test/Kore/BugReport"
-            "Test/Kore/Builtin"
-            "Test/Kore/Builtin/AssocComm/CeilSimplifier"
-            "Test/Kore/Builtin/Bool"
-            "Test/Kore/Builtin/Builtin"
-            "Test/Kore/Builtin/Definition"
-            "Test/Kore/Builtin/Encoding"
-            "Test/Kore/Builtin/Endianness"
-            "Test/Kore/Builtin/External"
-            "Test/Kore/Builtin/Inj"
-            "Test/Kore/Builtin/Int"
-            "Test/Kore/Builtin/InternalBytes"
-            "Test/Kore/Builtin/KEqual"
-            "Test/Kore/Builtin/Krypto"
-            "Test/Kore/Builtin/List"
-            "Test/Kore/Builtin/Map"
-            "Test/Kore/Builtin/Set"
-            "Test/Kore/Builtin/Signedness"
-            "Test/Kore/Builtin/String"
-            "Test/Kore/Contains"
-            "Test/Kore/Equation/Application"
-            "Test/Kore/Equation/Common"
-            "Test/Kore/Equation/Sentence"
-            "Test/Kore/Equation/Simplification"
-            "Test/Kore/Error"
-            "Test/Kore/Exec"
-            "Test/Kore/IndexedModule/Error"
-            "Test/Kore/IndexedModule/MockMetadataTools"
-            "Test/Kore/IndexedModule/OverloadGraph"
-            "Test/Kore/IndexedModule/Resolvers"
-            "Test/Kore/IndexedModule/SortGraph"
-            "Test/Kore/Internal/ApplicationSorts"
-            "Test/Kore/Internal/Condition"
-            "Test/Kore/Internal/From"
-            "Test/Kore/Internal/Key"
-            "Test/Kore/Internal/MultiAnd"
-            "Test/Kore/Internal/MultiExists"
-            "Test/Kore/Internal/OrCondition"
-            "Test/Kore/Internal/OrPattern"
-            "Test/Kore/Internal/Pattern"
-            "Test/Kore/Internal/Predicate"
-            "Test/Kore/Internal/SideCondition"
-            "Test/Kore/Internal/Substitution"
-            "Test/Kore/Internal/Symbol"
-            "Test/Kore/Internal/TermLike"
-            "Test/Kore/Log/DebugEvaluateCondition"
-            "Test/Kore/Log/ErrorBottomTotalFunction"
-            "Test/Kore/Log/WarnFunctionWithoutEvaluators"
-            "Test/Kore/Log/WarnSymbolSMTRepresentation"
-            "Test/Kore/Options"
-            "Test/Kore/Parser"
-            "Test/Kore/Parser/Lexer"
-            "Test/Kore/Parser/Parser"
-            "Test/Kore/Reachability/Claim"
-            "Test/Kore/Reachability/MockAllPath"
-            "Test/Kore/Reachability/OnePathStrategy"
-            "Test/Kore/Reachability/Prove"
-            "Test/Kore/Reachability/SomeClaim"
-            "Test/Kore/Repl/Graph"
-            "Test/Kore/Repl/Interpreter"
-            "Test/Kore/Repl/Parser"
-            "Test/Kore/Repl/ParserTest"
-            "Test/Kore/Rewrite"
-            "Test/Kore/Rewrite/AntiLeft"
-            "Test/Kore/Rewrite/Axiom/EvaluationStrategy"
-            "Test/Kore/Rewrite/Axiom/Identifier"
-            "Test/Kore/Rewrite/Axiom/Matcher"
-            "Test/Kore/Rewrite/Axiom/Registry"
-            "Test/Kore/Rewrite/ClaimPattern"
-            "Test/Kore/Rewrite/Function/Evaluator"
-            "Test/Kore/Rewrite/Function/Integration"
-            "Test/Kore/Rewrite/Function/Memo"
-            "Test/Kore/Rewrite/Implication"
-            "Test/Kore/Rewrite/MockSymbols"
-            "Test/Kore/Rewrite/Remainder"
-            "Test/Kore/Rewrite/RewriteStep"
-            "Test/Kore/Rewrite/Rule"
-            "Test/Kore/Rewrite/Rule/Common"
-            "Test/Kore/Rewrite/Rule/Expand"
-            "Test/Kore/Rewrite/Rule/Simplify"
-            "Test/Kore/Rewrite/RulePattern"
-            "Test/Kore/Rewrite/SMT/Builders"
-            "Test/Kore/Rewrite/SMT/Evaluator"
-            "Test/Kore/Rewrite/SMT/Helpers"
-            "Test/Kore/Rewrite/SMT/Representation/All"
-            "Test/Kore/Rewrite/SMT/Representation/Builders"
-            "Test/Kore/Rewrite/SMT/Representation/Helpers"
-            "Test/Kore/Rewrite/SMT/Representation/Sorts"
-            "Test/Kore/Rewrite/SMT/Representation/Symbols"
-            "Test/Kore/Rewrite/SMT/Sorts"
-            "Test/Kore/Rewrite/SMT/Symbols"
-            "Test/Kore/Rewrite/SMT/Translate"
-            "Test/Kore/Rewrite/Strategy"
-            "Test/Kore/Rewrite/Transition"
-            "Test/Kore/Rewrite/RewritingVariable"
-            "Test/Kore/Simplify"
-            "Test/Kore/Simplify/And"
-            "Test/Kore/Simplify/AndTerms"
-            "Test/Kore/Simplify/Application"
-            "Test/Kore/Simplify/Bottom"
-            "Test/Kore/Simplify/Ceil"
-            "Test/Kore/Simplify/Condition"
-            "Test/Kore/Simplify/DomainValue"
-            "Test/Kore/Simplify/Equals"
-            "Test/Kore/Simplify/Exists"
-            "Test/Kore/Simplify/Floor"
-            "Test/Kore/Simplify/Forall"
-            "Test/Kore/Simplify/Iff"
-            "Test/Kore/Simplify/Implies"
-            "Test/Kore/Simplify/Inj"
-            "Test/Kore/Simplify/InjSimplifier"
-            "Test/Kore/Simplify/Integration"
-            "Test/Kore/Simplify/IntegrationProperty"
-            "Test/Kore/Simplify/InternalList"
-            "Test/Kore/Simplify/InternalMap"
-            "Test/Kore/Simplify/InternalSet"
-            "Test/Kore/Simplify/Next"
-            "Test/Kore/Simplify/Not"
-            "Test/Kore/Simplify/Or"
-            "Test/Kore/Simplify/OrPattern"
-            "Test/Kore/Simplify/Overloading"
-            "Test/Kore/Simplify/Predicate"
-            "Test/Kore/Simplify/Pattern"
-            "Test/Kore/Simplify/StringLiteral"
-            "Test/Kore/Simplify/SubstitutionSimplifier"
-            "Test/Kore/Simplify/TermLike"
-            "Test/Kore/Simplify/Top"
-            "Test/Kore/Syntax/Id"
-            "Test/Kore/Syntax/Json"
-            "Test/Kore/Syntax/Json/Roundtrips"
-            "Test/Kore/Syntax/Variable"
-            "Test/Kore/TopBottom"
-            "Test/Kore/Unification/SubstitutionNormalization"
-            "Test/Kore/Unification/Unifier"
-            "Test/Kore/Unification/UnifierT"
-            "Test/Kore/Unparser"
-            "Test/Kore/Validate/DefinitionVerifier"
-            "Test/Kore/Validate/DefinitionVerifier/Imports"
-            "Test/Kore/Validate/DefinitionVerifier/PatternVerifier"
-            "Test/Kore/Validate/DefinitionVerifier/SentenceVerifier"
-            "Test/Kore/Validate/DefinitionVerifier/SortUsage"
-            "Test/Kore/Validate/DefinitionVerifier/UniqueNames"
-            "Test/Kore/Validate/DefinitionVerifier/UniqueSortVariables"
-            "Test/Kore/Variables/Fresh"
-            "Test/Kore/Variables/Target"
-            "Test/Kore/Variables/V"
-            "Test/Kore/Variables/W"
-            "Test/Kore/With"
-            "Test/Pretty"
-            "Test/SMT"
-            "Test/SMT/AST"
-            "Test/SQL"
-            "Test/Stats"
-            "Test/Tasty/HUnit/Ext"
-            "Test/Terse"
-            ];
-          hsSourceDirs = [ "test" ];
-          mainPath = [ "Test.hs" ];
-          };
-        };
+          "Driver"
+          "Test/ConsistentKore"
+          "Test/Data/Graph/TopologicalSort"
+          "Test/Data/Limit"
+          "Test/Data/Sup"
+          "Test/Debug"
+          "Test/Expect"
+          "Test/Injection"
+          "Test/Kore"
+          "Test/Kore/AST/Common"
+          "Test/Kore/Attribute/Assoc"
+          "Test/Kore/Attribute/Axiom/Concrete"
+          "Test/Kore/Attribute/Axiom/Symbolic"
+          "Test/Kore/Attribute/Axiom/Unit"
+          "Test/Kore/Attribute/Comm"
+          "Test/Kore/Attribute/Constructor"
+          "Test/Kore/Attribute/Function"
+          "Test/Kore/Attribute/Functional"
+          "Test/Kore/Attribute/Hook"
+          "Test/Kore/Attribute/Idem"
+          "Test/Kore/Attribute/Injective"
+          "Test/Kore/Attribute/Label"
+          "Test/Kore/Attribute/NonExecutable"
+          "Test/Kore/Attribute/Overload"
+          "Test/Kore/Attribute/Owise"
+          "Test/Kore/Attribute/Parser"
+          "Test/Kore/Attribute/Pattern/ConstructorLike"
+          "Test/Kore/Attribute/Pattern/Defined"
+          "Test/Kore/Attribute/Pattern/FreeVariables"
+          "Test/Kore/Attribute/Pattern/Function"
+          "Test/Kore/Attribute/Pattern/Functional"
+          "Test/Kore/Attribute/Pattern/Sort"
+          "Test/Kore/Attribute/Priority"
+          "Test/Kore/Attribute/ProductionID"
+          "Test/Kore/Attribute/Simplification"
+          "Test/Kore/Attribute/Smtlib"
+          "Test/Kore/Attribute/Sort/ConstructorsBuilder"
+          "Test/Kore/Attribute/Sort/HasDomainValues"
+          "Test/Kore/Attribute/Sort/Unit"
+          "Test/Kore/Attribute/SortInjection"
+          "Test/Kore/Attribute/Subsort"
+          "Test/Kore/Attribute/Symbol"
+          "Test/Kore/Attribute/Symbol/Anywhere"
+          "Test/Kore/Attribute/Symbol/Klabel"
+          "Test/Kore/Attribute/Symbol/Memo"
+          "Test/Kore/Attribute/Symbol/NoEvaluators"
+          "Test/Kore/Attribute/Symbol/SymbolKywd"
+          "Test/Kore/Attribute/Trusted"
+          "Test/Kore/Attribute/UniqueId"
+          "Test/Kore/BugReport"
+          "Test/Kore/Builtin"
+          "Test/Kore/Builtin/AssocComm/CeilSimplifier"
+          "Test/Kore/Builtin/Bool"
+          "Test/Kore/Builtin/Builtin"
+          "Test/Kore/Builtin/Definition"
+          "Test/Kore/Builtin/Encoding"
+          "Test/Kore/Builtin/Endianness"
+          "Test/Kore/Builtin/External"
+          "Test/Kore/Builtin/Inj"
+          "Test/Kore/Builtin/Int"
+          "Test/Kore/Builtin/InternalBytes"
+          "Test/Kore/Builtin/KEqual"
+          "Test/Kore/Builtin/Krypto"
+          "Test/Kore/Builtin/List"
+          "Test/Kore/Builtin/Map"
+          "Test/Kore/Builtin/Set"
+          "Test/Kore/Builtin/Signedness"
+          "Test/Kore/Builtin/String"
+          "Test/Kore/Contains"
+          "Test/Kore/Equation/Application"
+          "Test/Kore/Equation/Common"
+          "Test/Kore/Equation/Sentence"
+          "Test/Kore/Equation/Simplification"
+          "Test/Kore/Error"
+          "Test/Kore/Exec"
+          "Test/Kore/IndexedModule/Error"
+          "Test/Kore/IndexedModule/MockMetadataTools"
+          "Test/Kore/IndexedModule/OverloadGraph"
+          "Test/Kore/IndexedModule/Resolvers"
+          "Test/Kore/IndexedModule/SortGraph"
+          "Test/Kore/Internal/ApplicationSorts"
+          "Test/Kore/Internal/Condition"
+          "Test/Kore/Internal/From"
+          "Test/Kore/Internal/Key"
+          "Test/Kore/Internal/MultiAnd"
+          "Test/Kore/Internal/MultiExists"
+          "Test/Kore/Internal/OrCondition"
+          "Test/Kore/Internal/OrPattern"
+          "Test/Kore/Internal/Pattern"
+          "Test/Kore/Internal/Predicate"
+          "Test/Kore/Internal/SideCondition"
+          "Test/Kore/Internal/Substitution"
+          "Test/Kore/Internal/Symbol"
+          "Test/Kore/Internal/TermLike"
+          "Test/Kore/Log/DebugEvaluateCondition"
+          "Test/Kore/Log/ErrorBottomTotalFunction"
+          "Test/Kore/Log/WarnFunctionWithoutEvaluators"
+          "Test/Kore/Log/WarnSymbolSMTRepresentation"
+          "Test/Kore/Options"
+          "Test/Kore/Parser"
+          "Test/Kore/Parser/Lexer"
+          "Test/Kore/Parser/Parser"
+          "Test/Kore/Reachability/Claim"
+          "Test/Kore/Reachability/MockAllPath"
+          "Test/Kore/Reachability/OnePathStrategy"
+          "Test/Kore/Reachability/Prove"
+          "Test/Kore/Reachability/SomeClaim"
+          "Test/Kore/Repl/Graph"
+          "Test/Kore/Repl/Interpreter"
+          "Test/Kore/Repl/Parser"
+          "Test/Kore/Repl/ParserTest"
+          "Test/Kore/Rewrite"
+          "Test/Kore/Rewrite/AntiLeft"
+          "Test/Kore/Rewrite/Axiom/EvaluationStrategy"
+          "Test/Kore/Rewrite/Axiom/Identifier"
+          "Test/Kore/Rewrite/Axiom/Matcher"
+          "Test/Kore/Rewrite/Axiom/Registry"
+          "Test/Kore/Rewrite/ClaimPattern"
+          "Test/Kore/Rewrite/Function/Evaluator"
+          "Test/Kore/Rewrite/Function/Integration"
+          "Test/Kore/Rewrite/Function/Memo"
+          "Test/Kore/Rewrite/Implication"
+          "Test/Kore/Rewrite/MockSymbols"
+          "Test/Kore/Rewrite/Remainder"
+          "Test/Kore/Rewrite/RewriteStep"
+          "Test/Kore/Rewrite/Rule"
+          "Test/Kore/Rewrite/Rule/Common"
+          "Test/Kore/Rewrite/Rule/Expand"
+          "Test/Kore/Rewrite/Rule/Simplify"
+          "Test/Kore/Rewrite/RulePattern"
+          "Test/Kore/Rewrite/SMT/Builders"
+          "Test/Kore/Rewrite/SMT/Evaluator"
+          "Test/Kore/Rewrite/SMT/Helpers"
+          "Test/Kore/Rewrite/SMT/Representation/All"
+          "Test/Kore/Rewrite/SMT/Representation/Builders"
+          "Test/Kore/Rewrite/SMT/Representation/Helpers"
+          "Test/Kore/Rewrite/SMT/Representation/Sorts"
+          "Test/Kore/Rewrite/SMT/Representation/Symbols"
+          "Test/Kore/Rewrite/SMT/Sorts"
+          "Test/Kore/Rewrite/SMT/Symbols"
+          "Test/Kore/Rewrite/SMT/Translate"
+          "Test/Kore/Rewrite/Strategy"
+          "Test/Kore/Rewrite/Transition"
+          "Test/Kore/Rewrite/RewritingVariable"
+          "Test/Kore/Simplify"
+          "Test/Kore/Simplify/And"
+          "Test/Kore/Simplify/AndTerms"
+          "Test/Kore/Simplify/Application"
+          "Test/Kore/Simplify/Bottom"
+          "Test/Kore/Simplify/Ceil"
+          "Test/Kore/Simplify/Condition"
+          "Test/Kore/Simplify/DomainValue"
+          "Test/Kore/Simplify/Equals"
+          "Test/Kore/Simplify/Exists"
+          "Test/Kore/Simplify/Floor"
+          "Test/Kore/Simplify/Forall"
+          "Test/Kore/Simplify/Iff"
+          "Test/Kore/Simplify/Implies"
+          "Test/Kore/Simplify/Inj"
+          "Test/Kore/Simplify/InjSimplifier"
+          "Test/Kore/Simplify/Integration"
+          "Test/Kore/Simplify/IntegrationProperty"
+          "Test/Kore/Simplify/InternalList"
+          "Test/Kore/Simplify/InternalMap"
+          "Test/Kore/Simplify/InternalSet"
+          "Test/Kore/Simplify/Next"
+          "Test/Kore/Simplify/Not"
+          "Test/Kore/Simplify/Or"
+          "Test/Kore/Simplify/OrPattern"
+          "Test/Kore/Simplify/Overloading"
+          "Test/Kore/Simplify/Predicate"
+          "Test/Kore/Simplify/Pattern"
+          "Test/Kore/Simplify/StringLiteral"
+          "Test/Kore/Simplify/SubstitutionSimplifier"
+          "Test/Kore/Simplify/TermLike"
+          "Test/Kore/Simplify/Top"
+          "Test/Kore/Syntax/Id"
+          "Test/Kore/Syntax/Json"
+          "Test/Kore/Syntax/Json/Roundtrips"
+          "Test/Kore/Syntax/Variable"
+          "Test/Kore/TopBottom"
+          "Test/Kore/Unification/SubstitutionNormalization"
+          "Test/Kore/Unification/Unifier"
+          "Test/Kore/Unification/UnifierT"
+          "Test/Kore/Unparser"
+          "Test/Kore/Validate/DefinitionVerifier"
+          "Test/Kore/Validate/DefinitionVerifier/Imports"
+          "Test/Kore/Validate/DefinitionVerifier/PatternVerifier"
+          "Test/Kore/Validate/DefinitionVerifier/SentenceVerifier"
+          "Test/Kore/Validate/DefinitionVerifier/SortUsage"
+          "Test/Kore/Validate/DefinitionVerifier/UniqueNames"
+          "Test/Kore/Validate/DefinitionVerifier/UniqueSortVariables"
+          "Test/Kore/Variables/Fresh"
+          "Test/Kore/Variables/Target"
+          "Test/Kore/Variables/V"
+          "Test/Kore/Variables/W"
+          "Test/Kore/With"
+          "Test/Pretty"
+          "Test/SMT"
+          "Test/SMT/AST"
+          "Test/SQL"
+          "Test/Stats"
+          "Test/Tasty/HUnit/Ext"
+          "Test/Terse"
+        ];
+        hsSourceDirs = [ "test" ];
+        mainPath = [ "Test.hs" ];
       };
-    } // rec { src = (pkgs.lib).mkDefault ./kore; }
+    };
+  };
+} // rec {
+  src = (pkgs.lib).mkDefault ./kore;
+}


### PR DESCRIPTION
Updated the `Update/ Nix` CI script to re-materialize both the current GHC8.10.* and the GHC9 expressions in the `nix/` folder.