### PR TITLE
3119 output unexplored leaf count when failing

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -157,6 +157,7 @@
     within:
       - GlobalMain
       - Kore.Log.InfoExecDepth
+      - Kore.Log.WarnUnexploredBranches
 
 - ignore: {name: "Redundant compare", within: [Kore.Syntax.Id]}
 

--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -394,6 +394,7 @@ library
     Kore.Log.WarnStuckClaimState
     Kore.Log.WarnSymbolSMTRepresentation
     Kore.Log.WarnTrivialClaim
+    Kore.Log.WarnUnexploredBranches
     Kore.Log.WarnUnsimplified
     Kore.ModelChecker.Bounded
     Kore.ModelChecker.Simplification

--- a/kore/src/Kore/Log/Registry.hs
+++ b/kore/src/Kore/Log/Registry.hs
@@ -145,6 +145,9 @@ import Kore.Log.WarnSymbolSMTRepresentation (
 import Kore.Log.WarnTrivialClaim (
     WarnTrivialClaim,
  )
+import Kore.Log.WarnUnexploredBranches (
+    WarnUnexploredBranches,
+ )
 import Kore.Log.WarnUnsimplified (
     WarnUnsimplifiedCondition,
     WarnUnsimplifiedPredicate,
@@ -213,6 +216,7 @@ entryHelpDocsErr, entryHelpDocsNoErr :: [Pretty.Doc ()]
             , mk $ Proxy @WarnClaimRHSIsBottom
             , mk $ Proxy @WarnIfLowProductivity
             , mk $ Proxy @WarnTrivialClaim
+            , mk $ Proxy @WarnUnexploredBranches
             , mk $ Proxy @DebugRetrySolverQuery
             , mk $ Proxy @DebugUnifyBottom
             , mk $ Proxy @DebugEvaluateCondition

--- a/kore/src/Kore/Log/WarnUnexploredBranches.hs
+++ b/kore/src/Kore/Log/WarnUnexploredBranches.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE NoStrict #-}
+{-# LANGUAGE NoStrictData #-}
+
+{- |
+Copyright   : (c) Runtime Verification, 2019-2022
+License     : BSD-3-Clause
+-}
+module Kore.Log.WarnUnexploredBranches (
+    WarnUnexploredBranches (..),
+    warnUnexploredBranches,
+) where
+
+import Log
+import Numeric.Natural
+import Prelude.Kore
+import Pretty (
+    Pretty,
+ )
+import Pretty qualified
+
+{- | @WarnUnexploredBranches@ is emitted when a proof gets stuck. It
+   indicates how many other branches in the proof were left unexplored
+   (and may also be failing if explored).
+-}
+data WarnUnexploredBranches
+    = WarnUnexploredBranches Natural
+    deriving stock (Show)
+
+instance Pretty WarnUnexploredBranches where
+    pretty (WarnUnexploredBranches count) =
+        Pretty.pretty count
+            Pretty.<+> "branches were still unexplored when the action failed."
+
+instance Entry WarnUnexploredBranches where
+    entrySeverity _ = Warning
+    oneLineDoc (WarnUnexploredBranches count) =
+        Pretty.pretty count
+            Pretty.<+> "branches were still unexplored when the action failed."
+    helpDoc _ =
+        "indicate whether and how many unexplored branches existed when failing."
+
+warnUnexploredBranches :: MonadLog log => Natural -> log ()
+warnUnexploredBranches = logEntry . WarnUnexploredBranches

--- a/kore/test/Test/Kore/Reachability/Prove.hs
+++ b/kore/test/Test/Kore/Reachability/Prove.hs
@@ -771,6 +771,30 @@ test_proveClaims =
          in [ mkTest "OnePath" simpleOnePathClaim
             , mkTest "AllPath" simpleAllPathClaim
             ]
+    , testGroup "warns about unexplored branch when one of several stuck claims returned" $
+        let axioms = [simpleAxiom Mock.a (mkOr Mock.b Mock.c)]
+            mkTest name mkSimpleClaim =
+                testCase name $ do
+                    actual <-
+                        Test.Kore.Reachability.Prove.proveClaims
+                            Unlimited
+                            Unlimited
+                            1
+                            axioms
+                            [mkSimpleClaim Mock.a Mock.d]
+                            []
+                    let stuck = mkSimpleClaim Mock.b Mock.d
+                        expect =
+                            ProveClaimsResult
+                                { stuckClaims = MultiAnd.singleton (StuckClaim stuck)
+                                , provenClaims = MultiAnd.top
+                                , unexplored = 1
+                                }
+                    assertEqual "count" (unexplored expect) (unexplored actual)
+                    assertEqual "claim" (stuckClaims expect) (stuckClaims actual)
+         in [ mkTest "OnePath" simpleOnePathClaim
+            , mkTest "AllPath" simpleAllPathClaim
+            ]
     ]
 
 test_transitionRule :: TestTree

--- a/nix/kore-ghc8107.nix.d/kore.nix
+++ b/nix/kore-ghc8107.nix.d/kore.nix
@@ -312,6 +312,7 @@
         "Kore/Log/WarnStuckClaimState"
         "Kore/Log/WarnSymbolSMTRepresentation"
         "Kore/Log/WarnTrivialClaim"
+        "Kore/Log/WarnUnexploredBranches"
         "Kore/Log/WarnUnsimplified"
         "Kore/ModelChecker/Bounded"
         "Kore/ModelChecker/Simplification"

--- a/nix/kore-ghc923.nix.d/kore.nix
+++ b/nix/kore-ghc923.nix.d/kore.nix
@@ -312,6 +312,7 @@
         "Kore/Log/WarnStuckClaimState"
         "Kore/Log/WarnSymbolSMTRepresentation"
         "Kore/Log/WarnTrivialClaim"
+        "Kore/Log/WarnUnexploredBranches"
         "Kore/Log/WarnUnsimplified"
         "Kore/ModelChecker/Bounded"
         "Kore/ModelChecker/Simplification"


### PR DESCRIPTION
Fixes #3119 

### Scope:
When a proof fails on one branch (or more, when using `--max-counterexamples`), the prover indicates with a warning if any other branches existed that were left unexplored.

### Estimate:


---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
