### PR TITLE
[3198] fix stopping prover on branches + logging unproven

### DIFF
--- a/kore/src/Kore/Exec/GraphTraversal.hs
+++ b/kore/src/Kore/Exec/GraphTraversal.hs
@@ -19,6 +19,7 @@ import Control.Monad (foldM)
 import Control.Monad.Trans.State
 import Data.Limit
 import Data.List.NonEmpty qualified as NE
+import Data.Maybe (maybeToList)
 import Data.Sequence (Seq (..))
 import Data.Sequence qualified as Seq
 import GHC.Natural
@@ -227,11 +228,14 @@ graphTraversal
         exceedsLimit =
             not . withinLimit breadthLimit . fromIntegral . Seq.length
 
-        shouldStop :: TransitionResult (TState instr config) -> Bool
-        shouldStop =
-            case stopOn of
-                Leaf -> const False
-                LeafOrBranching -> isBranch
+        -- when stopping at branches, turn a 'Branch' result into a 'Stopped'
+        branchStop :: TransitionResult (TState i c) -> TransitionResult (TState i c)
+        branchStop result
+            | isBranch result =
+                case stopOn of
+                    Leaf -> result
+                    LeafOrBranching -> Stopped (maybeToList $ extractState result)
+            | otherwise = result
 
         worker ::
             Seq (TState instr config) ->
@@ -263,8 +267,8 @@ graphTraversal
             Seq (TState instr config) ->
             Simplifier (StepResult (TState instr config))
         step a q = do
-            next <- transit a
-            if (isStuck next || isFinal next || isStopped next || shouldStop next)
+            next <- branchStop <$> transit a
+            if (isStuck next || isFinal next || isStopped next)
                 then pure (Output next q)
                 else
                     let abort (LimitExceeded queue) = Abort next queue

--- a/kore/src/Kore/Reachability/Prove.hs
+++ b/kore/src/Kore/Reachability/Prove.hs
@@ -340,13 +340,15 @@ proveClaim
                 limitedStrategyList
                 (ProofDepth 0, startGoal)
 
-        let returnUnprovenClaims n =
+        let returnUnprovenClaims n unproven = do
+                mapM_ (infoUnprovenDepth . fst) unproven
                 pure
                     . Left
                     . (,fromIntegral n)
                     . MultiAnd.make
                     . map StuckClaim
                     . mapMaybe (extractUnproven . snd)
+                    $ unproven
 
         case traversalResult of
             GraphTraversal.GotStuck n rs ->


### PR DESCRIPTION
* The rewritten prover was returning a final instead of a stopped state when stopping at branches
* Proof depth for unproven claims was not logged at info level as before.

This fixes both problems, and adds a unit test for stopping at branches.

Fixes #3198

### Scope:

### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
