### PR TITLE
Speed up CI for GHC9 by building non-profiled version of `kore-exec`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         run: nix-build -A kore
 
       - name: Build GHC9
-        run: GC_DONT_GC=1 nix build .#kore-exec-prof
+        run: GC_DONT_GC=1 nix build .#kore-exec-ghc9
 
       - name: Check shell
         run: nix-shell --run "echo OK"

--- a/flake.nix
+++ b/flake.nix
@@ -177,7 +177,8 @@
         self.flake.${system}.packages // {
           update-cabal = self.project.${system}.rematerialize-kore;
           update-cabal-ghc9 = self.projectGhc9.${system}.rematerialize-kore;
-
+          kore-exec-ghc9 =
+            self.projectGhc9.${system}.hsPkgs.kore.components.exes.kore-exec;
           kore-exec-prof =
             self.projectGhc9ProfilingEventlog.${system}.hsPkgs.kore.components.exes.kore-exec;
           kore-exec-prof-infotable =


### PR DESCRIPTION
I suspec that the reason why building the GHC9 step in CI take so long is because it is building agains profile libraries which are probably not cached by haskell.nix