### PR TITLE
make a couple values lazy so they behave more like functions

### DIFF
--- a/kore/src/Kore/Unification/NewUnifier.hs
+++ b/kore/src/Kore/Unification/NewUnifier.hs
@@ -641,7 +641,7 @@ unifyTerms' rootSort sideCondition origVars vars ((first, second) : rest) bindin
 
     discharge ::
         unifier (Condition RewritingVariableName)
-    discharge = unifyTerms' rootSort sideCondition origVars vars rest bindings constraints acEquations
+    ~discharge = unifyTerms' rootSort sideCondition origVars vars rest bindings constraints acEquations
 
     failUnify ::
         Text ->
@@ -744,7 +744,7 @@ unifyTerms' rootSort sideCondition origVars vars ((first, second) : rest) bindin
                     )
             ) = unifyTerms' rootSort sideCondition origVars vars ((term1, term2) : rest) bindings (Condition.andCondition constraints narrowingSubst) acEquations
 
-    trySubstDecompose = do
+    ~trySubstDecompose = do
         (newFirst, firstConstraints) <- substAndSimplify constraints first
         (newSecond, secondConstraints) <- substAndSimplify firstConstraints second
         if newFirst /= first || newSecond /= second
@@ -764,7 +764,8 @@ unifyTerms' rootSort sideCondition origVars vars ((first, second) : rest) bindin
         TermLike RewritingVariableName ->
         unifier (TermLike RewritingVariableName, Condition RewritingVariableName)
     substAndSimplify constraints' term = do
-        let substituted = substitute currentSubstitution term
+        let currentSubstitution = Map.mapKeys variableName $ Map.map fromFree $ Map.filter isFree bindings
+            substituted = substitute currentSubstitution term
         if substituted /= term
             then do
                 pats <- simplifyTerm sideCondition substituted
@@ -772,8 +773,6 @@ unifyTerms' rootSort sideCondition origVars vars ((first, second) : rest) bindin
                 let (term', condition) = Pattern.splitTerm pat
                 return (term', Condition.andCondition constraints' condition)
             else return (term, constraints')
-
-    currentSubstitution = Map.mapKeys variableName $ Map.map fromFree $ Map.filter isFree bindings
 
     unifyMaps ::
         InternalMap Key (TermLike RewritingVariableName) ->
@@ -870,7 +869,7 @@ unifyTerms' rootSort sideCondition origVars vars ((first, second) : rest) bindin
             (_, _, 0, 0) -> failUnify "Cannot unify empty collection with non-empty collection"
             (_, _, _, _) -> acUnifyConcat
       where
-        acUnifyConcat =
+        ~acUnifyConcat =
             let (vars1, lhs, freeEqs1) = variableAbstraction sort vars term1
                 (vars2, rhs, freeEqs2) = variableAbstraction sort vars1 term2
              in case (lhs, rhs) of


### PR DESCRIPTION
I was working on reimplementing pattern matching and Jost pointed out an issue with that code, which is that I was treating where bindings like they would only be evaluated when they were used, when in fact they get evaluated when the function that has the where binding gets called. This was leading to some issues in my code, but I realized also that it might be causing some performance degradations in the new unification algorithm as well, since that code was written in a similar style. And indeed, we were definitely making the mistake of using strict evaluation to evaluate some things that shouldn't need to get evaluated. So I made this PR. I have not tested the performance yet; want to make sure the tests pass first.

### Scope:

### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
