### PR TITLE
[#3112] Intern IDs

### DIFF
--- a/kore/app/exec/Main.hs
+++ b/kore/app/exec/Main.hs
@@ -21,6 +21,7 @@ import Data.Generics.Product (
     field,
  )
 import Data.IORef (writeIORef)
+import Data.InternedText (globalInternedTextCache)
 import Data.Limit (
     Limit (..),
     maybeLimit,
@@ -118,7 +119,6 @@ import Kore.Syntax.Definition (
     Sentence (..),
  )
 import Kore.Syntax.Definition qualified as Definition.DoNotUse
-import Kore.Syntax.Id (globalIdMap)
 import Kore.Unparser (
     unparse,
  )
@@ -672,9 +672,9 @@ koreSearch LocalOptions{execOptions} searchOptions = do
     let KoreExecOptions{definitionFileName} = execOptions
     let KoreExecOptions{mainModuleName} = execOptions
     let KoreExecOptions{koreSolverOptions} = execOptions
-    SerializedDefinition{serializedModule, lemmas, locations, idCache} <-
+    SerializedDefinition{serializedModule, lemmas, locations, internedTextCache} <-
         deserializeDefinition koreSolverOptions definitionFileName mainModuleName
-    lift $ writeIORef globalIdMap idCache
+    lift $ writeIORef globalInternedTextCache internedTextCache
     let SerializedModule{verifiedModule, metadataTools} = serializedModule
     let KoreSearchOptions{searchFileName} = searchOptions
     target <- mainParseSearchPattern verifiedModule searchFileName
@@ -701,12 +701,12 @@ koreRun LocalOptions{execOptions} = do
     let KoreExecOptions{definitionFileName} = execOptions
     let KoreExecOptions{mainModuleName} = execOptions
     let KoreExecOptions{koreSolverOptions} = execOptions
-    SerializedDefinition{serializedModule, lemmas, locations, idCache} <-
+    SerializedDefinition{serializedModule, lemmas, locations, internedTextCache} <-
         deserializeDefinition
             koreSolverOptions
             definitionFileName
             mainModuleName
-    lift $ writeIORef globalIdMap idCache
+    lift $ writeIORef globalInternedTextCache internedTextCache
     let SerializedModule{verifiedModule, metadataTools} = serializedModule
     let KoreExecOptions{patternFileName} = execOptions
     initial <- loadPattern verifiedModule patternFileName

--- a/kore/app/exec/Main.hs
+++ b/kore/app/exec/Main.hs
@@ -20,6 +20,7 @@ import Data.Default (
 import Data.Generics.Product (
     field,
  )
+import Data.IORef (writeIORef)
 import Data.Limit (
     Limit (..),
     maybeLimit,
@@ -117,6 +118,7 @@ import Kore.Syntax.Definition (
     Sentence (..),
  )
 import Kore.Syntax.Definition qualified as Definition.DoNotUse
+import Kore.Syntax.Id (globalIdMap)
 import Kore.Unparser (
     unparse,
  )
@@ -670,8 +672,9 @@ koreSearch LocalOptions{execOptions} searchOptions = do
     let KoreExecOptions{definitionFileName} = execOptions
     let KoreExecOptions{mainModuleName} = execOptions
     let KoreExecOptions{koreSolverOptions} = execOptions
-    SerializedDefinition{serializedModule, lemmas, locations} <-
+    SerializedDefinition{serializedModule, lemmas, locations, idCache} <-
         deserializeDefinition koreSolverOptions definitionFileName mainModuleName
+    lift $ writeIORef globalIdMap idCache
     let SerializedModule{verifiedModule, metadataTools} = serializedModule
     let KoreSearchOptions{searchFileName} = searchOptions
     target <- mainParseSearchPattern verifiedModule searchFileName
@@ -698,11 +701,12 @@ koreRun LocalOptions{execOptions} = do
     let KoreExecOptions{definitionFileName} = execOptions
     let KoreExecOptions{mainModuleName} = execOptions
     let KoreExecOptions{koreSolverOptions} = execOptions
-    SerializedDefinition{serializedModule, lemmas, locations} <-
+    SerializedDefinition{serializedModule, lemmas, locations, idCache} <-
         deserializeDefinition
             koreSolverOptions
             definitionFileName
             mainModuleName
+    lift $ writeIORef globalIdMap idCache
     let SerializedModule{verifiedModule, metadataTools} = serializedModule
     let KoreExecOptions{patternFileName} = execOptions
     initial <- loadPattern verifiedModule patternFileName

--- a/kore/app/rpc/Main.hs
+++ b/kore/app/rpc/Main.hs
@@ -10,6 +10,7 @@ import Control.Monad.Reader (
     ReaderT (..),
  )
 import Data.IORef (writeIORef)
+import Data.InternedText (globalInternedTextCache)
 import GlobalMain qualified
 import Kore.BugReport (
     BugReportOption,
@@ -33,7 +34,6 @@ import Kore.Rewrite.SMT.Lemma (declareSMTLemmas)
 import Kore.Syntax.Definition (
     ModuleName (..),
  )
-import Kore.Syntax.Id (globalIdMap)
 import Log qualified
 import Options.Applicative (
     InfoMod,
@@ -143,12 +143,12 @@ koreRpcServerRun ::
     GlobalMain.LocalOptions KoreRpcServerOptions ->
     GlobalMain.Main ExitCode
 koreRpcServerRun GlobalMain.LocalOptions{execOptions} = do
-    GlobalMain.SerializedDefinition{serializedModule, lemmas, idCache} <-
+    GlobalMain.SerializedDefinition{serializedModule, lemmas, internedTextCache} <-
         GlobalMain.deserializeDefinition
             koreSolverOptions
             definitionFileName
             mainModuleName
-    lift $ writeIORef globalIdMap idCache
+    lift $ writeIORef globalInternedTextCache internedTextCache
 
     let SerializedModule{metadataTools} = serializedModule
 

--- a/kore/app/rpc/Main.hs
+++ b/kore/app/rpc/Main.hs
@@ -9,6 +9,7 @@ import Control.Monad.Catch (
 import Control.Monad.Reader (
     ReaderT (..),
  )
+import Data.IORef (writeIORef)
 import GlobalMain qualified
 import Kore.BugReport (
     BugReportOption,
@@ -32,6 +33,7 @@ import Kore.Rewrite.SMT.Lemma (declareSMTLemmas)
 import Kore.Syntax.Definition (
     ModuleName (..),
  )
+import Kore.Syntax.Id (globalIdMap)
 import Log qualified
 import Options.Applicative (
     InfoMod,
@@ -141,11 +143,13 @@ koreRpcServerRun ::
     GlobalMain.LocalOptions KoreRpcServerOptions ->
     GlobalMain.Main ExitCode
 koreRpcServerRun GlobalMain.LocalOptions{execOptions} = do
-    GlobalMain.SerializedDefinition{serializedModule, lemmas} <-
+    GlobalMain.SerializedDefinition{serializedModule, lemmas, idCache} <-
         GlobalMain.deserializeDefinition
             koreSolverOptions
             definitionFileName
             mainModuleName
+    lift $ writeIORef globalIdMap idCache
+
     let SerializedModule{metadataTools} = serializedModule
 
     -- initialize an SMT solver with user declared lemmas

--- a/kore/app/share/GlobalMain.hs
+++ b/kore/app/share/GlobalMain.hs
@@ -59,6 +59,7 @@ import Data.Generics.Product (
     field,
  )
 import Data.IORef (readIORef)
+import Data.InternedText (InternedTextCache, globalInternedTextCache)
 import Data.List (
     intercalate,
     nub,
@@ -575,7 +576,7 @@ data SerializedDefinition = SerializedDefinition
     { serializedModule :: SerializedModule
     , lemmas :: [SentenceAxiom (TermLike VariableName)]
     , locations :: KFileLocations
-    , idCache :: InternedTextCache
+    , internedTextCache :: InternedTextCache
     }
     deriving stock (GHC.Generic)
     deriving anyclass (NFData)
@@ -646,13 +647,13 @@ makeSerializedDefinition solverOptions definitionFileName mainModuleName = do
         execute solverOptions metadataTools lemmas $
             makeSerializedModule mainModule
     let locations = kFileLocations definition
-    idCache <- lift $ readIORef globalIdMap
+    internedTextCache <- lift $ readIORef globalInternedTextCache
     let serializedDefinition =
             SerializedDefinition
                 { serializedModule
                 , lemmas
                 , locations
-                , idCache
+                , internedTextCache
                 }
     serializedDefinition `deepseq` pure ()
     return serializedDefinition

--- a/kore/app/share/GlobalMain.hs
+++ b/kore/app/share/GlobalMain.hs
@@ -58,6 +58,8 @@ import Data.Compact.Serialize (
 import Data.Generics.Product (
     field,
  )
+import Data.HashMap.Strict (HashMap)
+import Data.IORef (readIORef)
 import Data.List (
     intercalate,
     nub,
@@ -574,6 +576,7 @@ data SerializedDefinition = SerializedDefinition
     { serializedModule :: SerializedModule
     , lemmas :: [SentenceAxiom (TermLike VariableName)]
     , locations :: KFileLocations
+    , idCache :: HashMap Text Int
     }
     deriving stock (GHC.Generic)
     deriving anyclass (NFData)
@@ -644,11 +647,13 @@ makeSerializedDefinition solverOptions definitionFileName mainModuleName = do
         execute solverOptions metadataTools lemmas $
             makeSerializedModule mainModule
     let locations = kFileLocations definition
+    idCache <- lift $ readIORef globalIdMap
     let serializedDefinition =
             SerializedDefinition
                 { serializedModule
                 , lemmas
                 , locations
+                , idCache
                 }
     serializedDefinition `deepseq` pure ()
     return serializedDefinition

--- a/kore/app/share/GlobalMain.hs
+++ b/kore/app/share/GlobalMain.hs
@@ -58,7 +58,6 @@ import Data.Compact.Serialize (
 import Data.Generics.Product (
     field,
  )
-import Data.HashMap.Strict (HashMap)
 import Data.IORef (readIORef)
 import Data.List (
     intercalate,
@@ -576,7 +575,7 @@ data SerializedDefinition = SerializedDefinition
     { serializedModule :: SerializedModule
     , lemmas :: [SentenceAxiom (TermLike VariableName)]
     , locations :: KFileLocations
-    , idCache :: HashMap Text Int
+    , idCache :: InternedTextCache
     }
     deriving stock (GHC.Generic)
     deriving anyclass (NFData)

--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -199,6 +199,7 @@ library
     Changed
     Control.Monad.Counter
     Data.Graph.TopologicalSort
+    Data.InternedText
     Data.Limit
     Data.Sup
     Debug

--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -701,6 +701,7 @@ test-suite kore-test
     Driver
     Test.ConsistentKore
     Test.Data.Graph.TopologicalSort
+    Test.Data.InternedText
     Test.Data.Limit
     Test.Data.Sup
     Test.Debug

--- a/kore/src/Data/InternedText.hs
+++ b/kore/src/Data/InternedText.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE BlockArguments #-}
+
+{- |
+Copyright   : (c) Runtime Verification, 2022
+License     : BSD-3-Clause
+-}
+module Data.InternedText (
+    -- * Interned text
+    InternedText,
+    internedText,
+    internText,
+
+    -- * Cache
+    InternedTextCache (..),
+    globalInternedTextCache,
+) where
+
+import Data.HashMap.Strict as HashMap
+import Data.IORef
+import Data.Text (
+    Text,
+ )
+import GHC.Generics (Generic)
+import GHC.Generics qualified as GHC
+import Generics.SOP qualified as SOP
+import Kore.Debug
+import Prelude.Kore
+import System.IO.Unsafe (unsafePerformIO)
+
+data InternedTextCache = InternedTextCache
+    { counter :: {-# UNPACK #-} !Word
+    , internedTexts :: !(HashMap Text InternedText)
+    }
+    deriving stock (Generic)
+    deriving anyclass (NFData)
+
+data InternedText = InternedText
+    { internedText :: {-# UNPACK #-} !Text
+    , internedId :: {-# UNPACK #-} !Word
+    }
+    deriving stock (GHC.Generic)
+    deriving anyclass (NFData)
+    deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
+
+instance Show InternedText where
+    showsPrec prec = showsPrec prec . internedText
+
+instance Debug InternedText where
+    debugPrec = debugPrec . internedText
+
+instance Diff InternedText where
+    diffPrec = diffPrec `on` internedText
+
+instance Eq InternedText where
+    a == b = internedId a == internedId b
+    {-# INLINE (==) #-}
+
+instance Hashable InternedText where
+    hashWithSalt salt = hashWithSalt salt . internedId
+    {-# INLINE hashWithSalt #-}
+    hash = hash . internedId
+    {-# INLINE hash #-}
+
+instance Ord InternedText where
+    a `compare` b
+        -- Quickly check if their interned IDs are equal.
+        | internedId a == internedId b = EQ
+        -- If they're not, fallback to using lexical order by comparing the strings' actual contents.
+        | otherwise = internedText a `compare` internedText b
+    {-# INLINE compare #-}
+
+globalInternedTextCache :: IORef InternedTextCache
+globalInternedTextCache = unsafePerformIO $ newIORef $ InternedTextCache 0 HashMap.empty
+{-# NOINLINE globalInternedTextCache #-}
+
+internText :: Text -> InternedText
+internText text =
+    unsafePerformIO do
+        atomicModifyIORef' globalInternedTextCache \InternedTextCache{counter, internedTexts} ->
+            let ((internedText, newCounter), newInternedTexts) =
+                    HashMap.alterF
+                        \case
+                            -- If this text is already interned, reuse it.
+                            existing@(Just interned) -> ((interned, counter), existing)
+                            -- Otherwise, create a new ID for it and intern it.
+                            Nothing ->
+                                let newIden = counter
+                                    newInterned = InternedText text newIden
+                                 in ((newInterned, counter + 1), Just newInterned)
+                        text
+                        internedTexts
+             in (InternedTextCache newCounter newInternedTexts, internedText)
+{-# INLINE internText #-}

--- a/kore/src/Data/InternedText.hs
+++ b/kore/src/Data/InternedText.hs
@@ -3,11 +3,19 @@
 {- |
 Copyright   : (c) Runtime Verification, 2022
 License     : BSD-3-Clause
+
+An implementation of string interning.
+Instead of keeping many copies of the same `Text` in memory, we keep only one shared `InternedText`.
+
+Each `InternedText` has a unique ID. As a result:
+
+* the `Eq` instance can more quickly check if the ID of two `InternedText`s are equal,
+instead of checking every single character.
+* the `Hashable` instance can hash the ID, which is a lot faster than hashing the string's contents.
 -}
 module Data.InternedText (
     -- * Interned text
-    InternedText,
-    internedText,
+    InternedText (..),
     internText,
 
     -- * Cache
@@ -27,14 +35,21 @@ import Kore.Debug
 import Prelude.Kore
 import System.IO.Unsafe (unsafePerformIO)
 
+-- | A pool containing all of the process' interned strings.
 data InternedTextCache = InternedTextCache
-    { counter :: {-# UNPACK #-} !Word
-    , internedTexts :: !(HashMap Text InternedText)
+    { internedTexts :: !(HashMap Text InternedText)
+    , -- | An incremental counter used to generate new IDs.
+      counter :: {-# UNPACK #-} !Word
     }
     deriving stock (Generic)
     deriving anyclass (NFData)
 
-data InternedText = InternedText
+{- | An interned `Text`.
+
+ The constructor `UnsafeMkInternedText` should not be used directly - it's exported for testing only.
+ Use `internText` instead.
+-}
+data InternedText = UnsafeMkInternedText
     { internedText :: {-# UNPACK #-} !Text
     , internedId :: {-# UNPACK #-} !Word
     }
@@ -51,10 +66,12 @@ instance Debug InternedText where
 instance Diff InternedText where
     diffPrec = diffPrec `on` internedText
 
+-- | Checks if the IDs are equal.
 instance Eq InternedText where
     a == b = internedId a == internedId b
     {-# INLINE (==) #-}
 
+-- | Hashes the `InternedText`'s ID.
 instance Hashable InternedText where
     hashWithSalt salt = hashWithSalt salt . internedId
     {-# INLINE hashWithSalt #-}
@@ -69,10 +86,19 @@ instance Ord InternedText where
         | otherwise = internedText a `compare` internedText b
     {-# INLINE compare #-}
 
+-- | The global cache with all of the process' interned strings.
 globalInternedTextCache :: IORef InternedTextCache
-globalInternedTextCache = unsafePerformIO $ newIORef $ InternedTextCache 0 HashMap.empty
+globalInternedTextCache = unsafePerformIO $ newIORef $ InternedTextCache HashMap.empty 0
 {-# NOINLINE globalInternedTextCache #-}
 
+{- | If the argument text has been previously interned, the existing `InternedText` instance is returned.
+If it hasn't, a new `InternedText` with a brand new ID is allocated and returned.
+
+In other words, multiple evaluations of `internText` with the same argument
+should return a pointer to the exact same `InternedText` object.
+
+@O(log (number of interned strings))@.
+-}
 internText :: Text -> InternedText
 internText text =
     unsafePerformIO do
@@ -85,9 +111,9 @@ internText text =
                             -- Otherwise, create a new ID for it and intern it.
                             Nothing ->
                                 let newIden = counter
-                                    newInterned = InternedText text newIden
+                                    !newInterned = UnsafeMkInternedText text newIden
                                  in ((newInterned, counter + 1), Just newInterned)
                         text
                         internedTexts
-             in (InternedTextCache newCounter newInternedTexts, internedText)
+             in (InternedTextCache newInternedTexts newCounter, internedText)
 {-# INLINE internText #-}

--- a/kore/src/Kore/Reachability/AllPathClaim.hs
+++ b/kore/src/Kore/Reachability/AllPathClaim.hs
@@ -32,9 +32,9 @@ import Kore.Internal.Pattern qualified as Pattern
 import Kore.Internal.Predicate qualified as Predicate
 import Kore.Internal.TermLike (
     ElementVariable,
-    Id (getId),
     TermLike,
     VariableName,
+    getId,
     weakAlwaysFinally,
  )
 import Kore.Internal.TermLike qualified as TermLike

--- a/kore/src/Kore/Reachability/OnePathClaim.hs
+++ b/kore/src/Kore/Reachability/OnePathClaim.hs
@@ -29,9 +29,9 @@ import Kore.Internal.Pattern qualified as Pattern
 import Kore.Internal.Predicate qualified as Predicate
 import Kore.Internal.TermLike (
     ElementVariable,
-    Id (getId),
     TermLike,
     VariableName,
+    getId,
     weakExistsFinally,
  )
 import Kore.Internal.TermLike qualified as TermLike

--- a/kore/src/Kore/Repl/Interpreter.hs
+++ b/kore/src/Kore/Repl/Interpreter.hs
@@ -186,7 +186,7 @@ import Kore.Simplify.API (
  )
 import Kore.Syntax.Application
 import Kore.Syntax.Id qualified as Id (
-    Id (..),
+    getId,
  )
 import Kore.Syntax.Variable
 import Kore.Unparser (

--- a/kore/src/Kore/Rewrite/Rule.hs
+++ b/kore/src/Kore/Rewrite/Rule.hs
@@ -83,7 +83,7 @@ import Kore.Sort (
  )
 import Kore.Syntax.Definition qualified as Syntax
 import Kore.Syntax.Id (
-    Id (..),
+    getId,
  )
 import Kore.Unparser (
     unparse,

--- a/kore/src/Kore/Rewrite/RulePattern.hs
+++ b/kore/src/Kore/Rewrite/RulePattern.hs
@@ -112,7 +112,9 @@ import Kore.Sort (
 import Kore.Substitute
 import Kore.Syntax.Id (
     AstLocation (..),
-    Id (..),
+    getId,
+    idLocation,
+    pattern Id,
  )
 import Kore.TopBottom (
     TopBottom (..),

--- a/kore/src/Kore/Rewrite/SMT/AST.hs
+++ b/kore/src/Kore/Rewrite/SMT/AST.hs
@@ -57,7 +57,9 @@ import Kore.Sort qualified as Kore (
     Sort,
  )
 import Kore.Syntax.Id qualified as Kore (
-    Id (Id, getId),
+    Id,
+    getId,
+    pattern Id,
  )
 import Prelude.Kore
 import SMT.AST qualified as AST

--- a/kore/src/Kore/Syntax/Id.hs
+++ b/kore/src/Kore/Syntax/Id.hs
@@ -47,7 +47,7 @@ import System.IO.Unsafe (unsafePerformIO)
 
 data InternedTextCache = InternedTextCache
     { counter :: {-# UNPACK #-} !Word
-    , internedTexts :: !(HashMap Text Word)
+    , internedTexts :: !(HashMap Text InternedText)
     }
     deriving stock (Generic)
     deriving anyclass (NFData)
@@ -81,11 +81,12 @@ internText text =
                     HashMap.alterF
                         \case
                             -- If this text is already interned, reuse it.
-                            existing@(Just iden) -> ((InternedText text iden, counter), existing)
+                            existing@(Just interned) -> ((interned, counter), existing)
                             -- Otherwise, create a new ID for it and intern it.
                             Nothing ->
                                 let newIden = counter
-                                 in ((InternedText text newIden, counter + 1), Just newIden)
+                                    newInterned = InternedText text newIden
+                                 in ((newInterned, counter + 1), Just newInterned)
                         text
                         internedTexts
              in (InternedTextCache newCounter newInternedTexts, internedText)

--- a/kore/src/Kore/Syntax/Id.hs
+++ b/kore/src/Kore/Syntax/Id.hs
@@ -46,9 +46,11 @@ data Id = InternedId
     { getInternedId :: !InternedText
     , internedIdLocation :: !AstLocation
     }
+    deriving stock (Show)
     deriving stock (GHC.Generic)
     deriving anyclass (NFData)
     deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
+    deriving anyclass (Debug)
 
 pattern Id :: Text -> AstLocation -> Id
 pattern Id{getId, idLocation} <-
@@ -57,35 +59,6 @@ pattern Id{getId, idLocation} <-
         Id text location = InternedId (internText text) location
 
 {-# COMPLETE Id #-}
-
-instance Show Id where
-    showsPrec = showsPrecId False
-
-{- | Produces valid syntax for the 'Id' pattern synonym.
-   This hides the interning of the Text, including the unique identifier.
--}
-instance Debug Id where
-    debugPrec a prec = Pretty.pretty (showsPrecId True prec a "")
-
-{- | ShowS an 'Id' in accordance with the old uninterned interface.
-   If the predicate 'useSpace' is 'True', spaces are placed between the braces and the field
-   names.
--}
-showsPrecId :: Bool -> Int -> Id -> ShowS
-showsPrecId useSpace prec (Id iden location) = showParen (prec > 10) showId
-  where
-    showId =
-        showString "Id {"
-            . space
-            . showString "getId = "
-            . shows iden
-            . showString ", idLocation = "
-            . shows location
-            . space
-            . showChar '}'
-    space
-        | useSpace = showChar ' '
-        | otherwise = id
 
 {- | The @HasField "getId"@ instance for the Id type maintains compatibility with
    the old interface of non-interned Ids.

--- a/kore/src/Kore/Syntax/Id.hs
+++ b/kore/src/Kore/Syntax/Id.hs
@@ -21,8 +21,6 @@ module Kore.Syntax.Id (
     prettyPrintAstLocation,
 ) where
 
-import Control.Lens (lens)
-import Data.Generics.Product
 import Data.InternedText
 import Data.String (
     IsString (..),
@@ -52,6 +50,7 @@ data Id = InternedId
     deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
     deriving anyclass (Debug)
 
+-- | A pattern synonym to abstract away `InternedText`.
 pattern Id :: Text -> AstLocation -> Id
 pattern Id{getId, idLocation} <-
     InternedId (internedText -> getId) idLocation
@@ -59,18 +58,6 @@ pattern Id{getId, idLocation} <-
         Id text location = InternedId (internText text) location
 
 {-# COMPLETE Id #-}
-
-{- | The @HasField "getId"@ instance for the Id type maintains compatibility with
-   the old interface of non-interned Ids.
--}
-instance {-# OVERLAPPING #-} HasField "getId" Id Id Text Text where
-    field = lens getId (\(Id _ iden) text -> Id text iden)
-
-{- | The @HasField "idLocation"@ instance for the Id type maintains compatibility with
-   the old interface of non-interned Ids.
--}
-instance {-# OVERLAPPING #-} HasField "idLocation" Id Id AstLocation AstLocation where
-    field = field @"internedIdLocation"
 
 -- | 'Ord' ignores the 'AstLocation'
 instance Ord Id where

--- a/kore/src/Kore/Syntax/Id.hs
+++ b/kore/src/Kore/Syntax/Id.hs
@@ -46,8 +46,8 @@ import Pretty qualified
 import System.IO.Unsafe (unsafePerformIO)
 
 data InternedTextCache = InternedTextCache
-    { counter :: {-# UNPACK #-} !Int
-    , internedTexts :: !(HashMap Text Int)
+    { counter :: {-# UNPACK #-} !Word
+    , internedTexts :: !(HashMap Text Word)
     }
     deriving stock (Generic)
     deriving anyclass (NFData)
@@ -58,7 +58,7 @@ globalIdMap = unsafePerformIO $ newIORef $ InternedTextCache 0 HashMap.empty
 
 data InternedText = InternedText
     { getText :: {-# UNPACK #-} !Text
-    , getUniqueId :: {-# UNPACK #-} !Int
+    , getUniqueId :: {-# UNPACK #-} !Word
     }
     deriving stock (GHC.Generic)
     deriving anyclass (NFData)

--- a/kore/src/Kore/Validate/SentenceVerifier.hs
+++ b/kore/src/Kore/Validate/SentenceVerifier.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BlockArguments #-}
+
 {- |
 Module      : Kore.Validate.SentenceVerifier
 Description : Tools for verifying the wellformedness of a Kore 'Sentence'.
@@ -126,12 +128,15 @@ verifyUniqueId ::
     UnparameterizedId ->
     Either (Error VerifyError) (Map.Map Text AstLocation)
 verifyUniqueId existing (UnparameterizedId name location) =
-    case Map.lookup name existing of
-        Just location' ->
-            koreFailWithLocations
-                [location, location']
-                ("Duplicated name: " <> name <> ".")
-        _ -> Right (Map.insert name location existing)
+    Map.alterF
+        \case
+            Just location' ->
+                koreFailWithLocations
+                    [location, location']
+                    ("Duplicated name: " <> name <> ".")
+            _ -> Right $ Just location
+        name
+        existing
 
 definedNamesForSentence :: Sentence pat -> [UnparameterizedId]
 definedNamesForSentence (SentenceAliasSentence sentenceAlias) =

--- a/kore/src/Kore/Variables/Fresh.hs
+++ b/kore/src/Kore/Variables/Fresh.hs
@@ -101,7 +101,7 @@ instance FreshPartialOrd VariableName where
     nextName name1 name2 =
         name1
             & Lens.set (field @"counter") counter'
-            & Lens.set (field @"base" . field @"idLocation") generated
+            & Lens.set (field @"base" . field @"internedIdLocation") generated
             & Just
       where
         generated = AstLocationGeneratedVariable

--- a/kore/test/Test/Data/InternedText.hs
+++ b/kore/test/Test/Data/InternedText.hs
@@ -1,0 +1,64 @@
+module Test.Data.InternedText (
+    hprop_hashes_id,
+    hprop_tests_equality_using_id,
+    hprop_internText_does_not_change_the_strings_contents,
+    hprop_internText_returns_the_same_id_for_the_same_string,
+    hprop_internText_returns_different_ids_for_different_strings,
+) where
+
+import Data.InternedText
+import Hedgehog
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Prelude.Kore
+
+hprop_hashes_id :: Property
+hprop_hashes_id =
+    property $ do
+        text <- forAll $ Gen.text (Range.linear 0 10) Gen.unicode
+        iden <- forAll $ Gen.word Range.linearBounded
+        salt <- forAll $ Gen.int Range.linearBounded
+
+        let interned = UnsafeMkInternedText text iden
+
+        hash iden === hash interned
+        hashWithSalt salt iden === hashWithSalt salt interned
+
+hprop_tests_equality_using_id :: Property
+hprop_tests_equality_using_id =
+    property $ do
+        text1 <- forAll $ Gen.text (Range.linear 0 10) Gen.unicode
+        text2 <- forAll $ Gen.text (Range.linear 0 10) Gen.unicode
+
+        -- Generate two different IDs
+        iden1 <- forAll $ Gen.word Range.linearBounded
+        iden2 <- forAll $ Gen.word $ Range.linear (iden1 + 1) maxBound
+
+        -- When the two IDs are different, then the two `InternedText`s are different
+        -- (regardless of the strings' contents).
+        UnsafeMkInternedText text1 iden1 /== UnsafeMkInternedText text2 iden2
+
+        -- When the two IDs are equal, then the two `InternedText`s are equal
+        -- (regardless of the strings' contents).
+        UnsafeMkInternedText text1 iden1 === UnsafeMkInternedText text2 iden1
+
+hprop_internText_does_not_change_the_strings_contents :: Property
+hprop_internText_does_not_change_the_strings_contents =
+    property $ do
+        text <- forAll $ Gen.text (Range.linear 0 10) Gen.unicode
+        internedText (internText text) === text
+
+hprop_internText_returns_the_same_id_for_the_same_string :: Property
+hprop_internText_returns_the_same_id_for_the_same_string =
+    property $ do
+        text <- forAll $ Gen.text (Range.linear 0 10) Gen.unicode
+
+        internedId (internText text) === internedId (internText text)
+
+hprop_internText_returns_different_ids_for_different_strings :: Property
+hprop_internText_returns_different_ids_for_different_strings =
+    property $ do
+        text1 <- forAll $ Gen.text (Range.linear 0 10) Gen.unicode
+        text2 <- forAll $ Gen.filter (/= text1) $ Gen.text (Range.linear 1 10) Gen.unicode
+
+        internedId (internText text1) /== internedId (internText text2)

--- a/kore/test/Test/Debug.hs
+++ b/kore/test/Test/Debug.hs
@@ -159,18 +159,23 @@ test_Debug =
         `yields` "Variable\n\
                  \{ variableName =\n\
                  \    VariableName\n\
-                 \    { base = Id { getId = \"v\", idLocation = AstLocationTest }\n\
+                 \    { base =\n\
+                 \        InternedId { getInternedId = \"v\", internedIdLocation = AstLocationTest }\n\
                  \    , counter = Nothing\n\
                  \    }\n\
                  \, variableSort =\n\
                  \    SortVariableSort\n\
                  \        SortVariable\n\
-                 \        { getSortVariable = Id { getId = \"sv\", idLocation = AstLocationTest }\n\
+                 \        { getSortVariable =\n\
+                 \            InternedId\n\
+                 \            { getInternedId = \"sv\"\n\
+                 \            , internedIdLocation = AstLocationTest\n\
+                 \            }\n\
                  \        }\n\
                  \}"
         $ "Variable"
     , Just (testId "v")
-        `yields` "Just Id { getId = \"v\", idLocation = AstLocationTest }"
+        `yields` "Just InternedId { getInternedId = \"v\", internedIdLocation = AstLocationTest }"
         $ "Maybe - Just"
     , (Nothing :: Maybe Id)
         `yields` "Nothing"

--- a/kore/test/Test/Kore/AST/Common.hs
+++ b/kore/test/Test/Kore/AST/Common.hs
@@ -3,6 +3,7 @@ module Test.Kore.AST.Common (
     test_prettyPrintAstLocation,
 ) where
 
+import Data.InternedText (internText)
 import Kore.Syntax.Id
 import Prelude.Kore
 import Test.Tasty
@@ -81,16 +82,16 @@ test_id =
             "Id show"
             ( assertEqual
                 ""
-                "Id {getId = \"a\", idLocation = AstLocationNone}"
+                "InternedId {getInternedId = \"a\", internedIdLocation = AstLocationNone}"
                 (show (Id "a" AstLocationNone))
             )
         , testCase
             "noLocationId"
             ( assertEqual
                 ""
-                Id
-                    { getId = "a"
-                    , idLocation = AstLocationNone
+                InternedId
+                    { getInternedId = internText "a"
+                    , internedIdLocation = AstLocationNone
                     }
                 (noLocationId "a")
             )

--- a/kore/test/Test/Kore/Attribute/Sort/ConstructorsBuilder.hs
+++ b/kore/test/Test/Kore/Attribute/Sort/ConstructorsBuilder.hs
@@ -34,7 +34,8 @@ import Kore.Sort (
     Sort (..),
  )
 import Kore.Syntax.Id (
-    Id (getId),
+    Id,
+    getId,
  )
 import Prelude.Kore
 import Test.Kore.Rewrite.SMT.Builders (

--- a/kore/test/Test/Kore/Rewrite/Axiom/Matcher.hs
+++ b/kore/test/Test/Kore/Rewrite/Axiom/Matcher.hs
@@ -1248,9 +1248,9 @@ test_matching_Map =
         "x:Int |-> y:Int  m:Map matches 0 |-> 1  2 |-> 3"
         (mkMap [(mkElemVar xInt, mkElemVar yInt)] [mkElemVar mMap])
         (mkMap [(mkInt 0, mkInt 1), (mkInt 2, mkInt 3)] [])
-        [ (inject xInt, mkInt 2)
-        , (inject yInt, mkInt 3)
-        , (inject mMap, mkMap [(mkInt 0, mkInt 1)] [])
+        [ (inject xInt, mkInt 0)
+        , (inject yInt, mkInt 1)
+        , (inject mMap, mkMap [(mkInt 2, mkInt 3)] [])
         ]
     ]
 

--- a/nix/kore-ghc8107.nix.d/kore.nix
+++ b/nix/kore-ghc8107.nix.d/kore.nix
@@ -781,6 +781,7 @@
           "Driver"
           "Test/ConsistentKore"
           "Test/Data/Graph/TopologicalSort"
+          "Test/Data/InternedText"
           "Test/Data/Limit"
           "Test/Data/Sup"
           "Test/Debug"

--- a/nix/kore-ghc8107.nix.d/kore.nix
+++ b/nix/kore-ghc8107.nix.d/kore.nix
@@ -117,6 +117,7 @@
         "Changed"
         "Control/Monad/Counter"
         "Data/Graph/TopologicalSort"
+        "Data/InternedText"
         "Data/Limit"
         "Data/Sup"
         "Debug"

--- a/nix/kore-ghc923.nix.d/kore.nix
+++ b/nix/kore-ghc923.nix.d/kore.nix
@@ -781,6 +781,7 @@
           "Driver"
           "Test/ConsistentKore"
           "Test/Data/Graph/TopologicalSort"
+          "Test/Data/InternedText"
           "Test/Data/Limit"
           "Test/Data/Sup"
           "Test/Debug"

--- a/nix/kore-ghc923.nix.d/kore.nix
+++ b/nix/kore-ghc923.nix.d/kore.nix
@@ -117,6 +117,7 @@
         "Changed"
         "Control/Monad/Counter"
         "Data/Graph/TopologicalSort"
+        "Data/InternedText"
         "Data/Limit"
         "Data/Sup"
         "Debug"

--- a/test/imp/sum-save-proofs-spec.k.save-proofs.kore.golden
+++ b/test/imp/sum-save-proofs-spec.k.save-proofs.kore.golden
@@ -111,20 +111,20 @@ module haskell-backend-saved-claims-43943e50-f723-47cd-99fd-07104d664c6d
                         /* InternalMap: */ Lbl'Unds'Map'Unds'{}(
                             /* concrete element: */ Lbl'UndsPipe'-'-GT-Unds'{}(
                                 /* Inj: */ inj{SortId{}, SortKItem{}}(
-                                    \dv{SortId{}}("n")
-                                ),
-                                /* Fl Fn D Spa */
-                                /* Inj: */ inj{SortInt{}, SortKItem{}}(
-                                    /* Fl Fn D Sfa */ VarN:SortInt{}
-                                )
-                            ),
-                            /* concrete element: */ Lbl'UndsPipe'-'-GT-Unds'{}(
-                                /* Inj: */ inj{SortId{}, SortKItem{}}(
                                     \dv{SortId{}}("sum")
                                 ),
                                 /* Fl Fn D Spa */
                                 /* Inj: */ inj{SortInt{}, SortKItem{}}(
                                     /* Fl Fn D Sfa */ VarS:SortInt{}
+                                )
+                            ),
+                            /* concrete element: */ Lbl'UndsPipe'-'-GT-Unds'{}(
+                                /* Inj: */ inj{SortId{}, SortKItem{}}(
+                                    \dv{SortId{}}("n")
+                                ),
+                                /* Fl Fn D Spa */
+                                /* Inj: */ inj{SortInt{}, SortKItem{}}(
+                                    /* Fl Fn D Sfa */ VarN:SortInt{}
                                 )
                             )
                         )


### PR DESCRIPTION
Fixes #3112

### Scope:

Profiling revealed that there are a lot of operations over identifiers (i.e. `Kore.Syntax.Id`). Operations such as `==` and `hash/hashWithSalt` operate over text values which can be slow. 

This PR uses string interning to allow for faster implementations of `Eq`/`Hashable`/`Ord`.

* Each interned string has a unique ID. 
* This ID is generated via an incremental counter. Thus, a string's ID may be different across multiple runs.
* `Eq` simply checks if the two strings' IDs are equal
* `Hashable` hashes the ID. NB: since the ID may be different across multiple runs, hashes are not stable.
* `Ord` uses a "fast path" branch to check if the IDs are equal; if so, it returns `EQ`. Otherwise, it falls back on comparing the strings' contents.

We managed to squeeze a ~10% speedup. The report is available [here](https://github.com/runtimeverification/haskell-backend/files/9487622/report-refact_master-7.pdf), using 454211800a577c6b8d13c28457ebcdfffe2a871c from master as the baseline.

### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [x] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [x] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [x] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [x] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
