### PR TITLE
Fix Cabal and Stack CI caching

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,3 +67,71 @@ jobs:
 
       - name: Build
         run: nix-build -A kore -A project.kore.checks
+
+  cache-cabal:
+    name: 'Cache Cabal'
+    runs-on: ubuntu-latest
+    env:
+      ghc_version: "8.10.7"
+    steps:
+      - name: Install prerequisites
+        run: |
+          sudo apt install --yes z3
+
+      - name: Check out code
+        uses: actions/checkout@v2.3.4
+        with:
+          submodules: recursive
+
+      - name: Cache Cabal package database and store
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+          key: cabal-1-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('cabal.project') }}
+          restore-keys: |
+            cabal-1-${{ runner.os }}-ghc-${{ env.ghc_version }}-
+            cabal-1-${{ runner.os }}-ghc-
+
+      - uses: haskell/actions/setup@v1
+        id: setup-haskell-cabal
+        with:
+          ghc-version: ${{ env.ghc_version }}
+          cabal-version: "3.2"
+
+      - name: Build
+        run: cabal v2-build --enable-tests --enable-benchmarks all
+
+  cache-stack:
+    name: 'Cache Stack'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install prerequisites
+        run: |
+          sudo apt install --yes z3
+
+      - name: Check out code
+        uses: actions/checkout@v2.3.4
+        with:
+          submodules: recursive
+
+      - name: Cache Stack root
+        uses: actions/cache@v2
+        with:
+          path: ~/.stack
+          key: stack-1-${{ runner.os }}-${{ hashFiles('stack.yaml.lock') }}
+          restore-keys: |
+            stack-1-${{ runner.os }}-
+            stack-1-
+
+      - uses: haskell/actions/setup@v1
+        id: setup-haskell-stack
+        with:
+          enable-stack: true
+          stack-no-global: true
+          stack-setup-ghc: true
+
+      - name: Build dependencies
+        run: |
+          stack build --test --only-dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,10 @@ jobs:
             ~/.cabal/packages
             ~/.cabal/store
           key: cabal-1-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('cabal.project') }}
+          restore-keys: |
+            cabal-1-${{ runner.os }}-ghc-${{ env.ghc_version }}-
+            cabal-1-${{ runner.os }}-ghc-
+            cabal-1-
 
       - uses: haskell/actions/setup@v1
         id: setup-haskell-cabal
@@ -129,6 +133,9 @@ jobs:
         with:
           path: ~/.stack
           key: stack-1-${{ runner.os }}-${{ hashFiles('stack.yaml.lock') }}
+          restore-keys: |
+            stack-1-${{ runner.os }}-
+            stack-1-
 
       - uses: haskell/actions/setup@v1
         id: setup-haskell-stack


### PR DESCRIPTION
Fixes #3165

This PR adds two new jobs to be ran at release, which build the haskell and cabal projects and cache the results. This way, the cache is persisted between feature branches as they originate from master (see the issue for details).
We also have fallback options when a new package is added to `kore.cabal`, which would otherwise cause a cache miss. Now, we should be able to get the last cache anyway and not have to build from scratch.