### PR TITLE
SimplifierCache: (Equation,TermLike) -> AttemptEquationError to Equation -> Termlike -> AttemptEquationError

### DIFF
--- a/kore/src/Kore/Simplify/Simplify.hs
+++ b/kore/src/Kore/Simplify/Simplify.hs
@@ -407,9 +407,10 @@ updateCache ::
     SimplifierCache
 updateCache EvaluationAttempt{cachedEquation, cachedTerm} value (SimplifierCache oldCache) =
     HashMap.alter
-        (Just . maybe
-            (HashMap.singleton cachedTerm value)
-            (HashMap.insert cachedTerm value)
+        ( Just
+            . maybe
+                (HashMap.singleton cachedTerm value)
+                (HashMap.insert cachedTerm value)
         )
         cachedEquation
         oldCache


### PR DESCRIPTION
Fixes #3189

This is a small change which didn't seem to have a significant impact on the KEVM prof performance. May still be worth merging?