### PR TITLE
Added auto profiling to nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,8 @@
             "*.nix.sh"
             "/.github"
             "flake.lock"
+            "/profile"
+            "/profile-*"
             ./.gitignore
           ] ./.;
           postPatch = ''
@@ -157,7 +159,6 @@
         ghcOptions = [ "-eventlog" ];
       };
 
-
       projectGhc9 = projectForGhc {
         ghc = "ghc923";
         stack-yaml = "stack-nix-ghc9.yaml";
@@ -170,10 +171,9 @@
         ghcOptions = [ "-eventlog" ];
       };
 
-      projectGhc9ProfilingEventlogInfoTable = projectForGhc {
+      projectGhc9EventlogInfoTable = projectForGhc {
         ghc = "ghc923";
         stack-yaml = "stack-nix-ghc9.yaml";
-        profiling = true;
         ghcOptions =
           [ "-finfo-table-map" "-fdistinct-constructor-tables" "-eventlog" ];
       };
@@ -191,8 +191,8 @@
             self.projectProfilingEventlog.${system}.hsPkgs.kore.components.exes.kore-exec;
           kore-exec-prof-ghc9 =
             self.projectGhc9ProfilingEventlog.${system}.hsPkgs.kore.components.exes.kore-exec;
-          kore-exec-prof-infotable =
-            self.projectGhc9ProfilingEventlogInfoTable.${system}.hsPkgs.kore.components.exes.kore-exec;
+          kore-exec-infotable =
+            self.projectGhc9EventlogInfoTable.${system}.hsPkgs.kore.components.exes.kore-exec;
 
           test-rpc = let pkgs = nixpkgsFor system;
           in pkgs.callPackage ./test/rpc-server {
@@ -205,7 +205,22 @@
           };
         });
 
-      apps = perSystem (system: self.flake.${system}.apps);
+      apps = perSystem (system:
+        self.flake.${system}.apps // {
+          profile = let
+            pkgs = nixpkgsFor system;
+            script = pkgs.callPackage ./nix/profile.nix {
+              inherit (pkgs.haskellPackages) hp2pretty eventlog2html;
+              kore-exec-prof =
+                self.projectProfilingEventlog.${system}.hsPkgs.kore.components.exes.kore-exec;
+              kore-exec-infotable =
+                self.projectGhc9EventlogInfoTable.${system}.hsPkgs.kore.components.exes.kore-exec;
+            };
+          in {
+            type = "app";
+            program = "${script}/bin/profile";
+          };
+        });
 
       devShells = perSystem (system: {
         default = self.flake.${system}.devShell;

--- a/nix/profile.nix
+++ b/nix/profile.nix
@@ -1,0 +1,34 @@
+{ stdenv, writeScriptBin, gnutar, kore-exec-prof, kore-exec-infotable, hp2pretty, eventlog2html }:
+
+writeScriptBin "profile" ''
+  #! ${stdenv.shell}
+  filename=$(basename -- "$1")
+  timeout="''${2:-4m}"
+
+  mkdir -p profile
+  ${gnutar}/bin/tar -xzvf "$1" -C ./profile
+  cd profile
+  # generate .prof and .eventlog profiles
+  timeout --foreground -s INT "$timeout" env GHCRTS='-p -l-au' PATH='$PATH:${kore-exec-prof}/bin' ./kore-exec.sh
+  mkdir -p ../profile-$filename
+  cp kore-exec.prof ../profile-$filename/
+  cp kore-exec.eventlog ../profile-$filename/prof.eventlog
+
+  # generate a heap profile based on cost centers
+  timeout --foreground -s INT "$timeout" env GHCRTS='-l -hc' PATH='$PATH:${kore-exec-prof}/bin' ./kore-exec.sh
+  cp kore-exec.hp ../profile-$filename/heap-cost-centers.hp
+  cp kore-exec.eventlog ../profile-$filename/heap-cost-centers.eventlog
+  ${hp2pretty}/bin/hp2pretty kore-exec.hp
+  ${eventlog2html}/bin/eventlog2html kore-exec.eventlog
+  cp kore-exec.svg ../profile-$filename/heap-cost-centers.svg
+  cp kore-exec.eventlog.html ../profile-$filename/heap-cost-centers.html
+
+  # generate a heap profile based on infotables (GHC9)
+  timeout --foreground -s INT "$timeout" env GHCRTS='-l -hi' PATH='$PATH:${kore-exec-infotable}/bin' ./kore-exec.sh
+  cp kore-exec.eventlog ../profile-$filename/heap-infotables.eventlog
+  ${eventlog2html}/bin/eventlog2html kore-exec.eventlog
+  cp kore-exec.eventlog.html ../profile-$filename/heap-infotables.html
+
+  cd ..
+  rm -r profile
+''


### PR DESCRIPTION
Based on the discussion here https://github.com/runtimeverification/haskell-backend/issues/3221
I've implemented a quick script under
```
nix run github:runtimeverification/haskell-backend#profile smoke.tar.gz (4m)
```
which will profile the provided `smoke.tar.gz` for 4 minutes (defaults to 4m if left blank).
The script will produce a `profile-smoke.tar.gz` folder with the following files:

**Time Profiling**
`kore-exec.prof` - Basic profile
`prof-speedscope.json` - same profile loadable in speedscope.app
`raw/prof.eventlog` - basic profile data captured in an eventlog, used to produce `prof-speedscope.json`

**Heap Profiling**
`heap-cost-centers.svg` - basic heap chart produced from `raw/heap-cost-centers.hp`
`heap-cost-centers.html` - interactive heap profile based on `raw/heap-cost-centers.eventlog`

**Heap Profiling GHC9**
`heap-infotables.html` - interactive heap profile (much more detailed than `heap-cost-centers.html`) based on `raw/heap-infotables.eventlog`

Please let me know if these are all the files we want to produce etc.