### PR TITLE
[#3112] Use `InternedText` for verifying IDs are unique

### DIFF
--- a/kore/app/share/GlobalMain.hs
+++ b/kore/app/share/GlobalMain.hs
@@ -58,8 +58,9 @@ import Data.Compact.Serialize (
 import Data.Generics.Product (
     field,
  )
+import Data.HashMap.Strict (HashMap)
 import Data.IORef (readIORef)
-import Data.InternedText (InternedTextCache, globalInternedTextCache)
+import Data.InternedText (InternedText, InternedTextCache, globalInternedTextCache)
 import Data.List (
     intercalate,
     nub,
@@ -496,13 +497,13 @@ Also prints timing information; see 'mainParse'.
 verifyDefinitionWithBase ::
     -- | already verified definition
     ( Map.Map ModuleName (VerifiedModule Attribute.Symbol)
-    , Map.Map Text AstLocation
+    , HashMap InternedText AstLocation
     ) ->
     -- | Parsed definition to check well-formedness
     ParsedDefinition ->
     Main
         ( Map.Map ModuleName (VerifiedModule Attribute.Symbol)
-        , Map.Map Text AstLocation
+        , HashMap InternedText AstLocation
         )
 verifyDefinitionWithBase
     alreadyVerified
@@ -663,7 +664,7 @@ type LoadedModuleSyntax = VerifiedModuleSyntax Attribute.Symbol
 
 data LoadedDefinition = LoadedDefinition
     { indexedModules :: Map ModuleName LoadedModule
-    , definedNames :: Map Text AstLocation
+    , definedNames :: HashMap InternedText AstLocation
     , kFileLocations :: KFileLocations
     }
 

--- a/kore/src/Kore/IndexedModule/IndexedModule.hs
+++ b/kore/src/Kore/IndexedModule/IndexedModule.hs
@@ -54,6 +54,7 @@ module Kore.IndexedModule.IndexedModule (
     implicitModules,
 ) where
 
+import Control.Arrow ((&&&))
 import Control.Lens qualified as Lens
 import Control.Monad.Extra (
     unlessM,
@@ -63,6 +64,9 @@ import Control.Monad.State.Strict (
  )
 import Control.Monad.State.Strict qualified as Monad.State
 import Data.Default as Default
+import Data.HashMap.Strict (HashMap)
+import Data.HashMap.Strict qualified as HashMap
+import Data.InternedText (InternedText)
 import Data.Map.Strict (
     Map,
  )
@@ -608,11 +612,11 @@ implicitIndexedModule =
             , sentenceSortAttributes = Attributes []
             }
 
-implicitNames :: Map Text AstLocation
+implicitNames :: HashMap InternedText AstLocation
 implicitNames =
-    Map.mapKeys getId $
-        Map.fromSet idLocation $
-            Set.insert predicateSortId implicitSortNames
+    HashMap.fromList $
+        (getInternedId &&& idLocation)
+            <$> (predicateSortId : Set.toList implicitSortNames)
 
 implicitSortNames :: Set Id
 implicitSortNames = Set.fromList [stringMetaSortId]

--- a/kore/src/Kore/Validate/DefinitionVerifier.hs
+++ b/kore/src/Kore/Validate/DefinitionVerifier.hs
@@ -23,6 +23,8 @@ import Control.Monad (
 import Data.Generics.Product (
     field,
  )
+import Data.HashMap.Strict (HashMap)
+import Data.InternedText (InternedText)
 import Data.List (
     sortOn,
  )
@@ -30,9 +32,6 @@ import Data.Map.Strict (
     Map,
  )
 import Data.Map.Strict qualified as Map
-import Data.Text (
-    Text,
- )
 import Kore.Attribute.Axiom qualified as Attribute
 import Kore.Attribute.Parser as Attribute.Parser
 import Kore.Attribute.Symbol qualified as Attribute.Symbol
@@ -104,12 +103,12 @@ If verification is successfull, it returns the updated maps of indexed modules
 and defined names.
 -}
 verifyAndIndexDefinitionWithBase ::
-    (Map ModuleName VerifiedModule', Map Text AstLocation) ->
+    (Map ModuleName VerifiedModule', HashMap InternedText AstLocation) ->
     Builtin.Verifiers ->
     ParsedDefinition ->
     Either
         (Error VerifyError)
-        (Map ModuleName VerifiedModule', Map Text AstLocation)
+        (Map ModuleName VerifiedModule', HashMap InternedText AstLocation)
 verifyAndIndexDefinitionWithBase
     alreadyVerified
     builtinVerifiers

--- a/kore/src/Kore/Validate/ModuleVerifier.hs
+++ b/kore/src/Kore/Validate/ModuleVerifier.hs
@@ -19,11 +19,10 @@ import Control.Lens qualified as Lens
 import Control.Monad.Reader.Class qualified as Reader
 import Control.Monad.State.Class qualified as State
 import Data.Generics.Product
+import Data.HashMap.Strict (HashMap)
+import Data.InternedText (InternedText)
 import Data.List qualified as List
 import Data.Map.Strict qualified as Map
-import Data.Text (
-    Text,
- )
 import Kore.AST.Error
 import Kore.Attribute.Parser (
     ParseAttributes,
@@ -54,11 +53,11 @@ within the module and outside, using the provided name set.
 -}
 verifyUniqueNames ::
     -- | Names that are already defined.
-    Map.Map Text AstLocation ->
+    HashMap InternedText AstLocation ->
     Module (Sentence pat) ->
     -- | On success returns the names that were previously defined together with
     -- the names defined in the given 'Module'.
-    Either (Error VerifyError) (Map.Map Text AstLocation)
+    Either (Error VerifyError) (HashMap InternedText AstLocation)
 verifyUniqueNames existingNames koreModule =
     withContext
         ("module '" ++ getModuleNameForError (moduleName koreModule) ++ "'")


### PR DESCRIPTION
Fixes part of #3112

### Scope:

When `GlobalMain` loads a definition, it needs to verify that all `Id`s
are unique. The following chain of events is triggered:

```
GlobalMain.loadDefinitions
 -> GlobalMain.verifyDefinitionWithBase
 -> DefinitionVerifier.verifyAndIndexDefinitionWithBase
 -> ModuleVerifier.verifyUniqueNames
 -> SentenceVerifier.verifyUniqueNames
 -> SentenceVerifier.verifyUniqueId
```

This process:
* Builds up a list of all visited `Kore.Syntax.Id`s in a `Map Text AstLocation`
* Un-interns the text contained inside `Id.getInternedId` (see
  `SentenceVerifier.toUnparameterizedId`)
* Check whether that `Text` exists in the `Map Text AstLocation` (see
  `SentenceVerifier.verifyUniqueId`)

The problem is that we're un-interning the string prematurely. This
would probably be faster if we took advantage of `InternedText`.

Solution:
* Change `Map Text` to `Map InternedText`
* The `Hashable InternedText` instance takes better advantage of
  interned strings than `Ord InternedText`, so `HashMap` would probably
  be better here than `Map`. Therefore, we change it to a `HashMap
  InternedText AstLocation`.

Observations: We've observed a ~1% speedup compared to #3217, see [report](https://github.com/runtimeverification/haskell-backend/files/9488402/report-uniq-ids_refact.pdf).


### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [x] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [x] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [x] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [x] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
