### PR TITLE
3243 remove strategy type

### DIFF
--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -568,7 +568,7 @@ search
                 rewriteGroups =
                     groupRewritesByPriority rewriteRules
                 runStrategy' =
-                    runStrategy
+                    Strategy.runStrategy
                         breadthLimit
                         -- search relies on exploring
                         -- the entire space of states.

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -321,7 +321,7 @@ exec
                 verifiedModule
         initialSort = termLikeSort initialTerm
 
-        execStrategy :: [GraphTraversal.Step Prim]
+        execStrategy :: [Strategy.Step Prim]
         execStrategy =
             Limit.takeWithin depthLimit $
                 [Begin, Simplify, Rewrite, Simplify] :
@@ -409,7 +409,7 @@ rpcExec
                 (Builtin.internalize metadataTools)
                 verifiedModule
 
-        execStrategy :: [GraphTraversal.Step Prim]
+        execStrategy :: [Strategy.Step Prim]
         execStrategy =
             Limit.takeWithin depthLimit $
                 [Begin, Simplify, Rewrite, Simplify] :

--- a/kore/src/Kore/Exec/GraphTraversal.hs
+++ b/kore/src/Kore/Exec/GraphTraversal.hs
@@ -8,7 +8,6 @@ Maintainer  : jost.berthold@runtimeverification.com
 module Kore.Exec.GraphTraversal (
     graphTraversal,
     simpleTransition,
-    Step,
     TState (..),
     TransitionResult (..),
     TraversalResult (..),
@@ -27,10 +26,10 @@ import GHC.Generics qualified
 import GHC.Natural
 import Generics.SOP qualified as SOP
 import Kore.Rewrite.Strategy (
-    -- FIXME assimilate definitions and remove import
     FinalNodeType (..),
     GraphSearchOrder (..),
     LimitExceeded (..),
+    Step,
     unfoldSearchOrder,
  )
 import Kore.Rewrite.Transition (
@@ -111,11 +110,6 @@ extractState = \case
     Stuck a -> Just a
     Final a -> Just a
     Stop a _ -> Just a
-
-{- | A sequence of transition instructions executed together as a
- single transition by the transition function.
--}
-type Step instr = [instr]
 
 {- | The traversal state, including subsequent steps to take in the
    traversal.

--- a/kore/src/Kore/ModelChecker/Bounded.hs
+++ b/kore/src/Kore/ModelChecker/Bounded.hs
@@ -60,6 +60,7 @@ import Kore.Rewrite.RulePattern (
 import Kore.Rewrite.Strategy (
     ExecutionGraph (..),
     GraphSearchOrder,
+    Step,
     pickFinal,
     runStrategyWithSearchOrder,
  )
@@ -86,7 +87,7 @@ newtype Axiom = Axiom {unAxiom :: RewriteRule RewritingVariableName}
 bmcStrategy ::
     [Axiom] ->
     CommonModalPattern ->
-    [[Prim CommonModalPattern (RewriteRule RewritingVariableName)]]
+    [Step (Prim CommonModalPattern (RewriteRule RewritingVariableName))]
 bmcStrategy
     axioms
     goal =
@@ -102,7 +103,7 @@ checkClaim ::
     -- | Creates a one-step strategy from a target pattern. See
     -- 'defaultStrategy'.
     ( CommonModalPattern ->
-      [[Prim CommonModalPattern (RewriteRule RewritingVariableName)]]
+      [Step (Prim CommonModalPattern (RewriteRule RewritingVariableName))]
     ) ->
     GraphSearchOrder ->
     (ImplicationRule RewritingVariableName, Limit Natural) ->

--- a/kore/src/Kore/ModelChecker/Bounded.hs
+++ b/kore/src/Kore/ModelChecker/Bounded.hs
@@ -60,7 +60,6 @@ import Kore.Rewrite.RulePattern (
 import Kore.Rewrite.Strategy (
     ExecutionGraph (..),
     GraphSearchOrder,
-    Strategy,
     pickFinal,
     runStrategyWithSearchOrder,
  )
@@ -87,7 +86,7 @@ newtype Axiom = Axiom {unAxiom :: RewriteRule RewritingVariableName}
 bmcStrategy ::
     [Axiom] ->
     CommonModalPattern ->
-    [Strategy (Prim CommonModalPattern (RewriteRule RewritingVariableName))]
+    [[Prim CommonModalPattern (RewriteRule RewritingVariableName)]]
 bmcStrategy
     axioms
     goal =
@@ -103,7 +102,7 @@ checkClaim ::
     -- | Creates a one-step strategy from a target pattern. See
     -- 'defaultStrategy'.
     ( CommonModalPattern ->
-      [Strategy (Prim CommonModalPattern (RewriteRule RewritingVariableName))]
+      [[Prim CommonModalPattern (RewriteRule RewritingVariableName)]]
     ) ->
     GraphSearchOrder ->
     (ImplicationRule RewritingVariableName, Limit Natural) ->

--- a/kore/src/Kore/ModelChecker/Step.hs
+++ b/kore/src/Kore/ModelChecker/Step.hs
@@ -43,10 +43,8 @@ import Kore.Rewrite.SMT.Evaluator qualified as SMT.Evaluator (
     filterMultiOr,
  )
 import Kore.Rewrite.Strategy (
-    Strategy,
     TransitionT,
  )
-import Kore.Rewrite.Strategy qualified as Strategy
 import Kore.Simplify.Pattern qualified as Pattern (
     simplifyTopConfiguration,
  )
@@ -231,12 +229,11 @@ defaultOneStepStrategy ::
     patt ->
     -- | normal rewrites
     [rewrite] ->
-    Strategy (Prim patt rewrite)
+    [Prim patt rewrite]
 defaultOneStepStrategy goalrhs rewrites =
-    Strategy.sequence
-        [ Strategy.apply checkProofState
-        , Strategy.apply simplify
-        , Strategy.apply (unroll goalrhs)
-        , Strategy.apply (computeWeakNext rewrites)
-        , Strategy.apply simplify
-        ]
+    [ checkProofState
+    , simplify
+    , (unroll goalrhs)
+    , (computeWeakNext rewrites)
+    , simplify
+    ]

--- a/kore/src/Kore/ModelChecker/Step.hs
+++ b/kore/src/Kore/ModelChecker/Step.hs
@@ -43,6 +43,7 @@ import Kore.Rewrite.SMT.Evaluator qualified as SMT.Evaluator (
     filterMultiOr,
  )
 import Kore.Rewrite.Strategy (
+    Step,
     TransitionT,
  )
 import Kore.Simplify.Pattern qualified as Pattern (
@@ -229,7 +230,7 @@ defaultOneStepStrategy ::
     patt ->
     -- | normal rewrites
     [rewrite] ->
-    [Prim patt rewrite]
+    Step (Prim patt rewrite)
 defaultOneStepStrategy goalrhs rewrites =
     [ checkProofState
     , simplify

--- a/kore/src/Kore/Reachability/Claim.hs
+++ b/kore/src/Kore/Reachability/Claim.hs
@@ -146,9 +146,6 @@ import Kore.Rewrite.RulePattern (
  )
 import Kore.Rewrite.SMT.Evaluator qualified as SMT.Evaluator
 import Kore.Rewrite.Step qualified as Step
-import Kore.Rewrite.Strategy (
-    Strategy,
- )
 import Kore.Rewrite.Strategy qualified as Strategy
 import Kore.Rewrite.Transition qualified as Transition
 import Kore.Simplify.API (
@@ -388,54 +385,49 @@ isRemainder :: ClaimState a -> Bool
 isRemainder (Remaining _) = True
 isRemainder _ = False
 
-reachabilityFirstStep :: Strategy Prim
+reachabilityFirstStep :: [Prim]
 reachabilityFirstStep =
-    (Strategy.sequence . map Strategy.apply)
-        [ Begin
-        , Simplify
-        , CheckImplication
-        , ApplyAxioms
-        , Simplify
-        ]
+    [ Begin
+    , Simplify
+    , CheckImplication
+    , ApplyAxioms
+    , Simplify
+    ]
 
-reachabilityNextStep :: Strategy Prim
+reachabilityNextStep :: [Prim]
 reachabilityNextStep =
-    (Strategy.sequence . map Strategy.apply)
-        [ Begin
-        , Simplify
-        , CheckImplication
-        , ApplyClaims
-        , ApplyAxioms
-        , Simplify
-        ]
+    [ Begin
+    , Simplify
+    , CheckImplication
+    , ApplyClaims
+    , ApplyAxioms
+    , Simplify
+    ]
 
-reachabilityFirstStepNoCheck :: Strategy Prim
+reachabilityFirstStepNoCheck :: [Prim]
 reachabilityFirstStepNoCheck =
-    (Strategy.sequence . map Strategy.apply)
-        [ Begin
-        , Simplify
-        , ApplyAxioms
-        , Simplify
-        ]
+    [ Begin
+    , Simplify
+    , ApplyAxioms
+    , Simplify
+    ]
 
-reachabilityNextStepNoCheck :: Strategy Prim
+reachabilityNextStepNoCheck :: [Prim]
 reachabilityNextStepNoCheck =
-    (Strategy.sequence . map Strategy.apply)
-        [ Begin
-        , Simplify
-        , ApplyClaims
-        , ApplyAxioms
-        , Simplify
-        ]
+    [ Begin
+    , Simplify
+    , ApplyClaims
+    , ApplyAxioms
+    , Simplify
+    ]
 
 {- | A strategy for the last step of depth-limited reachability proofs.
    The final such step should only perform a CheckImplication.
 -}
-reachabilityCheckOnly :: Strategy Prim
-reachabilityCheckOnly =
-    Strategy.sequence [Strategy.apply Begin, Strategy.apply CheckImplication]
+reachabilityCheckOnly :: [Prim]
+reachabilityCheckOnly = [Begin, CheckImplication]
 
-strategy :: Stream (Strategy Prim)
+strategy :: Stream [Prim]
 strategy =
     reachabilityFirstStep :> Stream.iterate id reachabilityNextStep
 
@@ -443,7 +435,7 @@ newtype MinDepth = MinDepth
     { getMinDepth :: Int
     }
 
-strategyWithMinDepth :: MinDepth -> Stream (Strategy Prim)
+strategyWithMinDepth :: MinDepth -> Stream [Prim]
 strategyWithMinDepth (MinDepth minDepth) =
     Stream.prepend
         noCheckReachabilitySteps

--- a/kore/src/Kore/Reachability/Claim.hs
+++ b/kore/src/Kore/Reachability/Claim.hs
@@ -146,6 +146,7 @@ import Kore.Rewrite.RulePattern (
  )
 import Kore.Rewrite.SMT.Evaluator qualified as SMT.Evaluator
 import Kore.Rewrite.Step qualified as Step
+import Kore.Rewrite.Strategy (Step)
 import Kore.Rewrite.Strategy qualified as Strategy
 import Kore.Rewrite.Transition qualified as Transition
 import Kore.Simplify.API (
@@ -385,7 +386,7 @@ isRemainder :: ClaimState a -> Bool
 isRemainder (Remaining _) = True
 isRemainder _ = False
 
-reachabilityFirstStep :: [Prim]
+reachabilityFirstStep :: Step Prim
 reachabilityFirstStep =
     [ Begin
     , Simplify
@@ -394,7 +395,7 @@ reachabilityFirstStep =
     , Simplify
     ]
 
-reachabilityNextStep :: [Prim]
+reachabilityNextStep :: Step Prim
 reachabilityNextStep =
     [ Begin
     , Simplify
@@ -404,7 +405,7 @@ reachabilityNextStep =
     , Simplify
     ]
 
-reachabilityFirstStepNoCheck :: [Prim]
+reachabilityFirstStepNoCheck :: Step Prim
 reachabilityFirstStepNoCheck =
     [ Begin
     , Simplify
@@ -412,7 +413,7 @@ reachabilityFirstStepNoCheck =
     , Simplify
     ]
 
-reachabilityNextStepNoCheck :: [Prim]
+reachabilityNextStepNoCheck :: Step Prim
 reachabilityNextStepNoCheck =
     [ Begin
     , Simplify
@@ -424,10 +425,10 @@ reachabilityNextStepNoCheck =
 {- | A strategy for the last step of depth-limited reachability proofs.
    The final such step should only perform a CheckImplication.
 -}
-reachabilityCheckOnly :: [Prim]
+reachabilityCheckOnly :: Step Prim
 reachabilityCheckOnly = [Begin, CheckImplication]
 
-strategy :: Stream [Prim]
+strategy :: Stream (Step Prim)
 strategy =
     reachabilityFirstStep :> Stream.iterate id reachabilityNextStep
 
@@ -435,7 +436,7 @@ newtype MinDepth = MinDepth
     { getMinDepth :: Int
     }
 
-strategyWithMinDepth :: MinDepth -> Stream [Prim]
+strategyWithMinDepth :: MinDepth -> Stream (Step Prim)
 strategyWithMinDepth (MinDepth minDepth) =
     Stream.prepend
         noCheckReachabilitySteps

--- a/kore/src/Kore/Reachability/Prove.hs
+++ b/kore/src/Kore/Reachability/Prove.hs
@@ -107,7 +107,6 @@ import Kore.Rewrite.Strategy (
     ExecutionGraph (..),
     FinalNodeType,
     GraphSearchOrder,
-    Strategy,
     executionHistoryStep,
  )
 import Kore.Rewrite.Transition (
@@ -457,16 +456,10 @@ proveClaimStep _ stuckCheck claims axioms executionGraph node =
     -- decide the appropriate strategy for the next step.
     -- We should also add a command for toggling this feature on and
     -- off.
-    strategy' :: Strategy Prim
+    strategy' :: [Prim]
     strategy'
-        | isRoot = firstStep
-        | otherwise = followupStep
-
-    firstStep :: Strategy Prim
-    firstStep = reachabilityFirstStep
-
-    followupStep :: Strategy Prim
-    followupStep = reachabilityNextStep
+        | isRoot = reachabilityFirstStep
+        | otherwise = reachabilityNextStep
 
     ExecutionGraph{root} = executionGraph
 

--- a/kore/src/Kore/Reachability/Prove.hs
+++ b/kore/src/Kore/Reachability/Prove.hs
@@ -107,6 +107,7 @@ import Kore.Rewrite.Strategy (
     ExecutionGraph (..),
     FinalNodeType,
     GraphSearchOrder,
+    Step,
     executionHistoryStep,
  )
 import Kore.Rewrite.Transition (
@@ -365,10 +366,10 @@ proveClaim
       where
         -------------------------------
         -- brought in from Claim.hs to remove Strategy type
-        infinite :: [GraphTraversal.Step Prim]
+        infinite :: [Step Prim]
         ~infinite = stepNoClaims : repeat stepWithClaims
 
-        withMinDepth :: MinDepth -> [GraphTraversal.Step Prim]
+        withMinDepth :: MinDepth -> [Step Prim]
         withMinDepth d =
             noCheckSteps <> repeat stepWithClaims
           where
@@ -456,7 +457,7 @@ proveClaimStep _ stuckCheck claims axioms executionGraph node =
     -- decide the appropriate strategy for the next step.
     -- We should also add a command for toggling this feature on and
     -- off.
-    strategy' :: [Prim]
+    strategy' :: Step Prim
     strategy'
         | isRoot = reachabilityFirstStep
         | otherwise = reachabilityNextStep

--- a/kore/src/Kore/Rewrite.hs
+++ b/kore/src/Kore/Rewrite.hs
@@ -17,9 +17,6 @@ module Kore.Rewrite (
 
     -- * Re-exports
     Natural,
-    pickLongest,
-    pickFinal,
-    runStrategy,
 ) where
 
 import Control.Monad (

--- a/kore/src/Kore/Rewrite.hs
+++ b/kore/src/Kore/Rewrite.hs
@@ -17,7 +17,6 @@ module Kore.Rewrite (
 
     -- * Re-exports
     Natural,
-    Strategy,
     pickLongest,
     pickFinal,
     runStrategy,
@@ -124,29 +123,27 @@ retractRemaining (Remaining a) = Just a
 retractRemaining _ = Nothing
 
 -- | The sequence of transitions for the symbolic execution strategy.
-executionStrategy :: Stream (Strategy Prim)
+executionStrategy :: Stream [Prim]
 executionStrategy =
     step1 Stream.:> Stream.iterate id stepN
   where
     step1 =
-        (Strategy.sequence . fmap Strategy.apply)
-            [ Begin
-            , Simplify
-            , Rewrite
-            , Simplify
-            ]
+        [ Begin
+        , Simplify
+        , Rewrite
+        , Simplify
+        ]
     stepN =
-        (Strategy.sequence . fmap Strategy.apply)
-            [ Begin
-            , Rewrite
-            , Simplify
-            ]
+        [ Begin
+        , Rewrite
+        , Simplify
+        ]
 
 {- | The sequence of transitions under the specified depth limit.
 
 See also: 'executionStrategy'
 -}
-limitedExecutionStrategy :: Limit Natural -> [Strategy Prim]
+limitedExecutionStrategy :: Limit Natural -> [[Prim]]
 limitedExecutionStrategy depthLimit =
     Limit.takeWithin depthLimit (toList executionStrategy)
 

--- a/kore/src/Kore/Rewrite.hs
+++ b/kore/src/Kore/Rewrite.hs
@@ -120,7 +120,7 @@ retractRemaining (Remaining a) = Just a
 retractRemaining _ = Nothing
 
 -- | The sequence of transitions for the symbolic execution strategy.
-executionStrategy :: Stream [Prim]
+executionStrategy :: Stream (Step Prim)
 executionStrategy =
     step1 Stream.:> Stream.iterate id stepN
   where
@@ -140,7 +140,7 @@ executionStrategy =
 
 See also: 'executionStrategy'
 -}
-limitedExecutionStrategy :: Limit Natural -> [[Prim]]
+limitedExecutionStrategy :: Limit Natural -> [Step Prim]
 limitedExecutionStrategy depthLimit =
     Limit.takeWithin depthLimit (toList executionStrategy)
 

--- a/kore/src/Kore/Rewrite/Strategy.hs
+++ b/kore/src/Kore/Rewrite/Strategy.hs
@@ -11,6 +11,9 @@ import Kore.Rewrite.Strategy qualified as Strategy
 @
 -}
 module Kore.Rewrite.Strategy (
+    -- * Step, a.k.a Strategy
+    Step,
+
     -- * Running strategies
     unfoldSearchOrder,
     unfoldTransition,
@@ -68,6 +71,9 @@ import GHC.Generics qualified as GHC
 import Kore.Rewrite.Transition
 import Numeric.Natural
 import Prelude.Kore
+
+-- | A "step" (aka "strategy") is a sequence of primitive actions
+type Step action = [action]
 
 data ExecutionGraph config rule = ExecutionGraph
     { root :: Graph.Node
@@ -377,7 +383,7 @@ runStrategy ::
     -- | Primitive strategy rule
     (prim -> config -> TransitionT rule m config) ->
     -- | Steps
-    [[prim]] ->
+    [Step prim] ->
     -- | Initial configuration
     config ->
     m (ExecutionGraph config rule)
@@ -391,7 +397,7 @@ runStrategyWithSearchOrder ::
     -- | Primitive strategy rule
     (prim -> config -> TransitionT rule m config) ->
     -- | Steps
-    [[prim]] ->
+    [Step prim] ->
     -- | Search order of the execution graph
     GraphSearchOrder ->
     -- | Initial configuration

--- a/kore/test/Test/Kore/Reachability/OnePathStrategy.hs
+++ b/kore/test/Test/Kore/Reachability/OnePathStrategy.hs
@@ -46,7 +46,6 @@ import Kore.Rewrite.RulePattern (
  )
 import Kore.Rewrite.Strategy (
     ExecutionGraph (..),
-    Strategy,
     pickFinal,
     runStrategy,
  )
@@ -898,7 +897,7 @@ runSteps ::
     [[Rule claim]] ->
     -- |left-hand-side of unification
     claim ->
-    [Strategy Prim] ->
+    [[Prim]] ->
     IO a
 runSteps
     breadthLimit

--- a/kore/test/Test/Kore/Reachability/OnePathStrategy.hs
+++ b/kore/test/Test/Kore/Reachability/OnePathStrategy.hs
@@ -46,6 +46,7 @@ import Kore.Rewrite.RulePattern (
  )
 import Kore.Rewrite.Strategy (
     ExecutionGraph (..),
+    Step,
     pickFinal,
     runStrategy,
  )
@@ -897,7 +898,7 @@ runSteps ::
     [[Rule claim]] ->
     -- |left-hand-side of unification
     claim ->
-    [[Prim]] ->
+    [Step Prim] ->
     IO a
 runSteps
     breadthLimit

--- a/kore/test/Test/Kore/Rewrite.hs
+++ b/kore/test/Test/Kore/Rewrite.hs
@@ -308,24 +308,19 @@ test_executionStrategy =
             Hedgehog.assert (isLastSimplify strategy)
     ]
   where
-    genStrategies :: Gen [Strategy Prim]
+    genStrategies :: Gen [[Prim]]
     genStrategies = do
         let range = Hedgehog.Gen.integral (Hedgehog.Range.linear 1 16)
         depthLimit <- Limit <$> range
         pure (limitedExecutionStrategy depthLimit)
 
-    hasRewrite :: Strategy Prim -> Bool
-    hasRewrite = \case
-        Strategy.Seq s1 s2 -> hasRewrite s1 || hasRewrite s2
-        Strategy.Apply p -> p == Rewrite
-        Strategy.Continue -> False
+    hasRewrite :: [Prim] -> Bool
+    hasRewrite = any (== Rewrite)
 
-    isLastSimplify :: Strategy Prim -> Bool
-    isLastSimplify = \case
-        Strategy.Seq s Strategy.Continue -> isLastSimplify s
-        Strategy.Seq _ s -> isLastSimplify s
-        Strategy.Apply p -> p == Simplify
-        Strategy.Continue -> False
+    isLastSimplify :: [Prim] -> Bool
+    isLastSimplify ps
+        | null ps = False
+        | otherwise = last ps == Simplify
 
 simpleRewrite ::
     TermLike VariableName ->

--- a/kore/test/Test/Kore/Rewrite.hs
+++ b/kore/test/Test/Kore/Rewrite.hs
@@ -315,7 +315,7 @@ test_executionStrategy =
         pure (limitedExecutionStrategy depthLimit)
 
     hasRewrite :: [Prim] -> Bool
-    hasRewrite = any (== Rewrite)
+    hasRewrite = elem Rewrite
 
     isLastSimplify :: [Prim] -> Bool
     isLastSimplify ps
@@ -397,14 +397,14 @@ runStepWorker
         do
             result <-
                 simplifier Mock.env $
-                    runStrategy
+                    Strategy.runStrategy
                         breadthLimit
                         (transitionRule groupedRewrites execStrategy)
                         limitedDepth
                         (Step.Start $ mkRewritingPattern configuration)
             let finalResult =
                     fmap getRewritingPattern
-                        <$> pickFinal result
+                        <$> Strategy.pickFinal result
             return finalResult
       where
         groupedRewrites = groupRewritesByPriority rules

--- a/kore/test/Test/Kore/Rewrite.hs
+++ b/kore/test/Test/Kore/Rewrite.hs
@@ -46,6 +46,7 @@ import Kore.Rewrite.RulePattern (
 import Kore.Rewrite.RulePattern as RulePattern (
     rulePattern,
  )
+import Kore.Rewrite.Strategy (Step)
 import Kore.Rewrite.Strategy qualified as Strategy
 import Kore.Syntax.Variable
 import Prelude.Kore
@@ -308,16 +309,16 @@ test_executionStrategy =
             Hedgehog.assert (isLastSimplify strategy)
     ]
   where
-    genStrategies :: Gen [[Prim]]
+    genStrategies :: Gen [Step Prim]
     genStrategies = do
         let range = Hedgehog.Gen.integral (Hedgehog.Range.linear 1 16)
         depthLimit <- Limit <$> range
         pure (limitedExecutionStrategy depthLimit)
 
-    hasRewrite :: [Prim] -> Bool
+    hasRewrite :: Step Prim -> Bool
     hasRewrite = elem Rewrite
 
-    isLastSimplify :: [Prim] -> Bool
+    isLastSimplify :: Step Prim -> Bool
     isLastSimplify ps
         | null ps = False
         | otherwise = last ps == Simplify

--- a/kore/test/Test/Kore/Rewrite/Strategy.hs
+++ b/kore/test/Test/Kore/Rewrite/Strategy.hs
@@ -23,6 +23,7 @@ import Data.Limit qualified as Limit
 import Data.Sequence qualified as Seq
 import Kore.Rewrite.Strategy (
     ExecutionGraph (..),
+    Step,
     TransitionT,
  )
 import Kore.Rewrite.Strategy qualified as Strategy
@@ -62,7 +63,7 @@ transitionPrim rule n = do
         Throw -> empty
 
 runStrategy ::
-    [[Prim]] ->
+    [Step Prim] ->
     Natural ->
     ExecutionGraph Natural Prim
 runStrategy strategy z =


### PR DESCRIPTION
Fixes #3243 

### Scope:

Removes type `Strategy` from the codebase. For readability, is replaced by an alias `type Step action = [action]`.
Some exports and re-exports  are removed from `Kore.Rewrite.Strategy` and `Kore.Rewrite` modules, too.

### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
