### PR TITLE
Remove `ActualEntry` and refactor logging/throwing pretty printing

### DIFF
--- a/kore/app/repl/Main.hs
+++ b/kore/app/repl/Main.hs
@@ -297,7 +297,7 @@ mainWithOptions LocalOptions{execOptions} = do
     someExceptionHandler :: SomeException -> Main ExitCode
     someExceptionHandler someException = do
         case fromException someException of
-            Just (SomeEntry entry) -> logEntry entry
+            Just entry@(SomeEntry _ _) -> logEntry entry
             Nothing -> errorException someException
         throwM someException
 

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -666,7 +666,7 @@ proveWithRepl ::
     VerifiedModule StepperAttributes ->
     -- | The module containing the claims that were proven in a previous run.
     Maybe (VerifiedModule StepperAttributes) ->
-    MVar (Log.LogAction IO Log.ActualEntry) ->
+    MVar (Log.LogAction IO Log.SomeEntry) ->
     -- | Optional script
     Repl.Data.ReplScript ->
     -- | Run in a specific repl mode

--- a/kore/src/Kore/Log.hs
+++ b/kore/src/Kore/Log.hs
@@ -63,7 +63,7 @@ import System.FilePath (
  )
 
 -- | Internal type used to add timestamps to a 'LogMessage'.
-data WithTimestamp = WithTimestamp ActualEntry TimeSpec
+data WithTimestamp = WithTimestamp SomeEntry TimeSpec
 
 {- | Generates an appropriate logger for the given 'KoreLogOptions'. It uses
  the CPS style because some outputters require cleanup (e.g. files).
@@ -71,7 +71,7 @@ data WithTimestamp = WithTimestamp ActualEntry TimeSpec
 withLogger ::
     FilePath ->
     KoreLogOptions ->
-    (LogAction IO ActualEntry -> IO a) ->
+    (LogAction IO SomeEntry -> IO a) ->
     IO a
 withLogger reportDirectory koreLogOptions = runContT $ do
     mainLogger <- ContT $ withMainLogger reportDirectory koreLogOptions
@@ -84,7 +84,7 @@ withLogger reportDirectory koreLogOptions = runContT $ do
 withMainLogger ::
     FilePath ->
     KoreLogOptions ->
-    (LogAction IO ActualEntry -> IO a) ->
+    (LogAction IO SomeEntry -> IO a) ->
     IO a
 withMainLogger reportDirectory koreLogOptions = runContT $ do
     let KoreLogOptions{exeName, startTime} = koreLogOptions
@@ -104,7 +104,7 @@ withMainLogger reportDirectory koreLogOptions = runContT $ do
     pure logAction
 
 withSmtSolverLogger ::
-    DebugSolverOptions -> (LogAction IO ActualEntry -> IO a) -> IO a
+    DebugSolverOptions -> (LogAction IO SomeEntry -> IO a) -> IO a
 withSmtSolverLogger DebugSolverOptions{logFile} continue =
     case logFile of
         Nothing -> continue mempty
@@ -116,8 +116,8 @@ withSmtSolverLogger DebugSolverOptions{logFile} continue =
 
 koreLogTransformer ::
     KoreLogOptions ->
-    LogAction m ActualEntry ->
-    LogAction m ActualEntry
+    LogAction m SomeEntry ->
+    LogAction m SomeEntry
 koreLogTransformer koreLogOptions baseLogger =
     Colog.cmap
         (toErrors warningSwitch)
@@ -125,20 +125,20 @@ koreLogTransformer koreLogOptions baseLogger =
   where
     KoreLogOptions{turnedIntoErrors, warningSwitch} = koreLogOptions
 
-    toErrors :: WarningSwitch -> ActualEntry -> ActualEntry
-    toErrors AsError ActualEntry{actualEntry}
-        | entrySeverity actualEntry == Warning =
-            error . show . longDoc $ actualEntry
-    toErrors _ entry@ActualEntry{actualEntry}
-        | typeOfSomeEntry actualEntry `elem` turnedIntoErrors =
-            error . show . longDoc $ actualEntry
+    toErrors :: WarningSwitch -> SomeEntry -> SomeEntry
+    toErrors AsError entry
+        | entrySeverity entry == Warning =
+            error . show . longDoc $ entry
+    toErrors _ entry
+        | typeOfSomeEntry entry `elem` turnedIntoErrors =
+            error . show . longDoc $ entry
         | otherwise = entry
 
 koreLogFilters ::
     Applicative m =>
     KoreLogOptions ->
-    LogAction m ActualEntry ->
-    LogAction m ActualEntry
+    LogAction m SomeEntry ->
+    LogAction m SomeEntry
 koreLogFilters koreLogOptions baseLogger =
     Colog.cfilter
         ( \entry ->
@@ -158,17 +158,17 @@ koreLogFilters koreLogOptions baseLogger =
 -- | Select the log entry types present in the active set.
 filterEntry ::
     EntryTypes ->
-    ActualEntry ->
+    SomeEntry ->
     Bool
-filterEntry logEntries ActualEntry{actualEntry} =
-    typeOfSomeEntry actualEntry `elem` logEntries
+filterEntry logEntries entry =
+    typeOfSomeEntry entry `elem` logEntries
 
 -- | Select log entries with 'Severity' greater than or equal to the level.
 filterSeverity ::
     Severity ->
-    ActualEntry ->
+    SomeEntry ->
     Bool
-filterSeverity level ActualEntry{actualEntry = SomeEntry entry} =
+filterSeverity level entry =
     entrySeverity entry >= level
 
 -- | Run a 'LoggerT' with the given options.
@@ -190,7 +190,7 @@ makeKoreLogger ::
     TimestampsSwitch ->
     KoreLogFormat ->
     LogAction io Text ->
-    LogAction io ActualEntry
+    LogAction io SomeEntry
 makeKoreLogger exeName startTime timestampSwitch koreLogFormat logActionText =
     logActionText
         & contramap render
@@ -210,14 +210,14 @@ makeKoreLogger exeName startTime timestampSwitch koreLogFormat logActionText =
                         toMicroSecs (diffTimeSpec startTime entryTime)
         toMicroSecs = (`div` 1000) . toNanoSecs
     exeName' = Pretty.pretty exeName <> Pretty.colon
-    prettyActualEntry timestamp ActualEntry{actualEntry, entryContext}
+    prettyActualEntry timestamp entry@(SomeEntry entryContext actualEntry)
         | OneLine <- koreLogFormat =
             Pretty.hsep [header, oneLineDoc actualEntry]
         | otherwise =
             (Pretty.vsep . concat)
                 [ [header]
-                , indent <$> context'
                 , indent <$> [longDoc actualEntry]
+                , context'
                 ]
       where
         header =
@@ -225,30 +225,36 @@ makeKoreLogger exeName startTime timestampSwitch koreLogFormat logActionText =
                 [ Just exeName'
                 , timestamp
                 , Just severity'
-                , Just (Pretty.parens $ type' actualEntry)
+                , Just (Pretty.parens $ type' entry)
                 ]
                 <> Pretty.colon
         severity' = prettySeverity (entrySeverity actualEntry)
-        type' entry =
+        type' e =
             Pretty.pretty $
                 lookupTextFromTypeWithError $
-                    typeOfSomeEntry entry
+                    typeOfSomeEntry e
         context' =
-            entryContext
-                & mapMaybe prettyContext
+            (entry : entryContext)
                 & reverse
-        prettyContext someEntry' =
-            contextDoc someEntry'
-                & fmap
-                    ( \doc ->
-                        Pretty.hsep [Pretty.parens typeName, doc <> Pretty.colon]
-                    )
-          where
-            typeName = type' someEntry'
+                & map (\e -> (,type' e) <$> contextDoc e)
+                & catMaybes
+                & prettyContext
+        prettyContext =
+            \case
+                [] -> []
+                xs -> ("Context" <> Pretty.colon) : (indent <$> mkContext xs)
+
+        mkContext =
+            \case
+                [] -> []
+                [(doc, typeName)] ->
+                    [Pretty.hsep [Pretty.parens typeName, doc]]
+                (doc, typeName) : xs -> (Pretty.hsep [Pretty.parens typeName, doc]) : (indent <$> (mkContext xs))
+
     indent = Pretty.indent 4
 
 -- | Adds the current timestamp to a log entry.
-withTimestamp :: MonadIO io => ActualEntry -> io WithTimestamp
+withTimestamp :: MonadIO io => SomeEntry -> io WithTimestamp
 withTimestamp msg = liftIO $ do
     currentTime <- getTime Monotonic
     pure $ WithTimestamp msg currentTime
@@ -262,7 +268,7 @@ stderrLogger ::
     TimeSpec ->
     TimestampsSwitch ->
     KoreLogFormat ->
-    LogAction io ActualEntry
+    LogAction io SomeEntry
 stderrLogger exeName startTime timestampsSwitch logFormat =
     makeKoreLogger exeName startTime timestampsSwitch logFormat Colog.logTextStderr
 

--- a/kore/src/Kore/Log.hs
+++ b/kore/src/Kore/Log.hs
@@ -236,8 +236,7 @@ makeKoreLogger exeName startTime timestampSwitch koreLogFormat logActionText =
         context' =
             (entry : entryContext)
                 & reverse
-                & map (\e -> (,type' e) <$> contextDoc e)
-                & catMaybes
+                & mapMaybe (\e -> (,type' e) <$> contextDoc e)
                 & prettyContext
         prettyContext =
             \case

--- a/kore/src/Kore/Log/DebugSolver.hs
+++ b/kore/src/Kore/Log/DebugSolver.hs
@@ -23,11 +23,10 @@ import Data.Text (
 import Data.Text.Lazy qualified as Text.Lazy
 import Data.Text.Lazy.Builder qualified as Text.Lazy.Builder
 import Log (
-    ActualEntry (..),
     Entry (..),
     LogAction (..),
     Severity (Debug),
-    SomeEntry,
+    SomeEntry (..),
     logWith,
  )
 import Options.Applicative (
@@ -90,14 +89,14 @@ logDebugSolverRecvWith logger smtText =
 solverTranscriptLogger ::
     Applicative m =>
     LogAction m Text ->
-    LogAction m ActualEntry
+    LogAction m SomeEntry
 solverTranscriptLogger textLogger =
     LogAction action
   where
-    action ActualEntry{actualEntry}
-        | Just sendEntry <- matchDebugSolverSend actualEntry =
+    action entry
+        | Just sendEntry <- matchDebugSolverSend entry =
             unLogAction textLogger (sentText sendEntry)
-        | Just recvEntry <- matchDebugSolverRecv actualEntry =
+        | Just recvEntry <- matchDebugSolverRecv entry =
             unLogAction textLogger (receivedText recvEntry)
         | otherwise =
             pure ()

--- a/kore/src/Kore/Log/ErrorBottomTotalFunction.hs
+++ b/kore/src/Kore/Log/ErrorBottomTotalFunction.hs
@@ -48,7 +48,7 @@ instance Pretty ErrorBottomTotalFunction where
             ]
 
 instance Exception ErrorBottomTotalFunction where
-    toException = toException . SomeEntry
+    toException = toException . SomeEntry []
     fromException exn =
         fromException exn >>= fromEntry
 

--- a/kore/src/Kore/Log/ErrorDecidePredicateUnknown.hs
+++ b/kore/src/Kore/Log/ErrorDecidePredicateUnknown.hs
@@ -32,7 +32,7 @@ newtype ErrorDecidePredicateUnknown = ErrorDecidePredicateUnknown
     deriving stock (Show)
 
 instance Exception ErrorDecidePredicateUnknown where
-    toException = toException . SomeEntry
+    toException = toException . SomeEntry []
     fromException exn =
         fromException exn >>= fromEntry
 

--- a/kore/src/Kore/Log/ErrorEquationRightFunction.hs
+++ b/kore/src/Kore/Log/ErrorEquationRightFunction.hs
@@ -60,7 +60,7 @@ instance Pretty ErrorEquationRightFunction where
             ]
 
 instance Exception ErrorEquationRightFunction where
-    toException = toException . SomeEntry
+    toException = toException . SomeEntry []
     fromException exn =
         fromException exn >>= fromEntry
 

--- a/kore/src/Kore/Log/ErrorEquationsSameMatch.hs
+++ b/kore/src/Kore/Log/ErrorEquationsSameMatch.hs
@@ -64,7 +64,7 @@ instance Pretty ErrorEquationsSameMatch where
             ]
 
 instance Exception ErrorEquationsSameMatch where
-    toException = toException . SomeEntry
+    toException = toException . SomeEntry []
     fromException exn =
         fromException exn >>= fromEntry
 

--- a/kore/src/Kore/Log/ErrorException.hs
+++ b/kore/src/Kore/Log/ErrorException.hs
@@ -66,6 +66,6 @@ handleSomeException ::
     m a
 handleSomeException someException = do
     case fromException someException of
-        Just (SomeEntry entry) -> logEntry entry
+        Just entry@(SomeEntry _ _) -> logEntry entry
         Nothing -> errorException someException
     throwM someException

--- a/kore/src/Kore/Log/ErrorOutOfDate.hs
+++ b/kore/src/Kore/Log/ErrorOutOfDate.hs
@@ -23,7 +23,7 @@ newtype ErrorOutOfDate = ErrorOutOfDate {message :: String}
     deriving stock (Show)
 
 instance Exception ErrorOutOfDate where
-    toException = toException . SomeEntry
+    toException = toException . SomeEntry []
     fromException exn = fromException exn >>= fromEntry
     displayException = message
 

--- a/kore/src/Kore/Log/ErrorParse.hs
+++ b/kore/src/Kore/Log/ErrorParse.hs
@@ -23,7 +23,7 @@ newtype ErrorParse = ErrorParse {message :: String}
     deriving stock (Show)
 
 instance Exception ErrorParse where
-    toException = toException . SomeEntry
+    toException = toException . SomeEntry []
     fromException exn = fromException exn >>= fromEntry
     displayException = message
 

--- a/kore/src/Kore/Log/ErrorRewriteLoop.hs
+++ b/kore/src/Kore/Log/ErrorRewriteLoop.hs
@@ -44,7 +44,7 @@ data ErrorRewriteLoop = ErrorRewriteLoop
     deriving stock (Show)
 
 instance Exception ErrorRewriteLoop where
-    toException = toException . SomeEntry
+    toException = toException . SomeEntry []
     fromException exn =
         fromException exn >>= fromEntry
 

--- a/kore/src/Kore/Log/ErrorRewritesInstantiation.hs
+++ b/kore/src/Kore/Log/ErrorRewritesInstantiation.hs
@@ -83,7 +83,7 @@ data SubstitutionCoverageError = SubstitutionCoverageError
     deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
 
 instance Exception ErrorRewritesInstantiation where
-    toException = toException . SomeEntry
+    toException = toException . SomeEntry []
     fromException exn =
         fromException exn >>= fromEntry
 

--- a/kore/src/Kore/Log/ErrorVerify.hs
+++ b/kore/src/Kore/Log/ErrorVerify.hs
@@ -27,7 +27,7 @@ newtype ErrorVerify = ErrorVerify {koreError :: Kore.Error VerifyError}
     deriving stock (Show)
 
 instance Exception ErrorVerify where
-    toException = toException . SomeEntry
+    toException = toException . SomeEntry []
     fromException exn = fromException exn >>= fromEntry
     displayException = Kore.printError . koreError
 

--- a/kore/src/Kore/Log/KoreLogOptions.hs
+++ b/kore/src/Kore/Log/KoreLogOptions.hs
@@ -333,10 +333,10 @@ parseDebugApplyEquationOptions =
 
 selectDebugApplyEquation ::
     DebugApplyEquationOptions ->
-    ActualEntry ->
+    SomeEntry ->
     Bool
-selectDebugApplyEquation options ActualEntry{actualEntry}
-    | Just (DebugApplyEquation equation _) <- fromEntry actualEntry =
+selectDebugApplyEquation options entry
+    | Just (DebugApplyEquation equation _) <- fromEntry entry =
         any (flip HashSet.member selected) (Equation.identifiers equation)
     | otherwise = False
   where
@@ -374,15 +374,15 @@ parseDebugAttemptEquationOptions =
 
 selectDebugAttemptEquation ::
     DebugAttemptEquationOptions ->
-    ActualEntry ->
+    SomeEntry ->
     Bool
-selectDebugAttemptEquation options ActualEntry{actualEntry}
+selectDebugAttemptEquation options entry
     | Just equation <- getEquation =
         any (flip HashSet.member selected) (Equation.identifiers equation)
     | otherwise = False
   where
     getEquation = do
-        debugAttemptEquation <- fromEntry actualEntry
+        debugAttemptEquation <- fromEntry entry
         case debugAttemptEquation of
             DebugAttemptEquation equation _ -> pure equation
             DebugAttemptEquationResult equation _ -> pure equation
@@ -419,7 +419,7 @@ parseDebugEquationOptions =
 
 selectDebugEquation ::
     DebugEquationOptions ->
-    ActualEntry ->
+    SomeEntry ->
     Bool
 selectDebugEquation DebugEquationOptions{selected} =
     (fmap or . sequence)

--- a/kore/src/Kore/Log/Registry.hs
+++ b/kore/src/Kore/Log/Registry.hs
@@ -291,7 +291,7 @@ toSomeEntryType =
 
 -- | The entry type underlying the 'SomeEntry' wrapper.
 typeOfSomeEntry :: SomeEntry -> SomeTypeRep
-typeOfSomeEntry (SomeEntry entry) = SomeTypeRep (typeOf entry)
+typeOfSomeEntry (SomeEntry _ entry) = SomeTypeRep (typeOf entry)
 
 getEntryTypesAsText :: [String]
 getEntryTypesAsText = getNoErrEntryTypesAsText <> getErrEntryTypesAsText

--- a/kore/src/Kore/Log/SQLite.hs
+++ b/kore/src/Kore/Log/SQLite.hs
@@ -34,12 +34,10 @@ import Kore.Log.WarnSymbolSMTRepresentation (
     WarnSymbolSMTRepresentation,
  )
 import Log (
-    ActualEntry,
     Entry,
     LogAction (..),
     SomeEntry,
     fromEntry,
-    fromLogAction,
  )
 import Options.Applicative qualified as Options
 import Prelude.Kore
@@ -84,7 +82,7 @@ automatically.
 withLogSQLite ::
     LogSQLiteOptions ->
     -- | Continuation
-    (LogAction IO ActualEntry -> IO a) ->
+    (LogAction IO SomeEntry -> IO a) ->
     IO a
 withLogSQLite options cont =
     case sqlog of
@@ -134,9 +132,9 @@ If the 'Entry' cannot be entered in the database, it is ignored.
 database is already connected. See 'withLogSQLite' to obtain a 'LogAction' in
 'IO'.
 -}
-logSQLite :: LogAction SQL ActualEntry
+logSQLite :: LogAction SQL SomeEntry
 logSQLite =
-    foldMapEntries (fromLogAction @SomeEntry . logEntry)
+    foldMapEntries logEntry
   where
     logEntry ::
         forall entry.

--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -110,7 +110,7 @@ runRepl ::
     [Axiom] ->
     -- | list of claims to be proven
     [SomeClaim] ->
-    MVar (Log.LogAction IO Log.ActualEntry) ->
+    MVar (Log.LogAction IO Log.SomeEntry) ->
     -- | optional script
     ReplScript ->
     -- | mode to run in
@@ -284,7 +284,7 @@ runRepl
         someExceptionHandler :: a -> Exception.SomeException -> Simplifier a
         someExceptionHandler a someException = do
             case Exception.fromException someException of
-                Just (Log.SomeEntry entry) ->
+                Just entry@(Log.SomeEntry _ _) ->
                     Log.logEntry entry
                 Nothing ->
                     errorException someException

--- a/kore/src/Kore/Repl/Data.hs
+++ b/kore/src/Kore/Repl/Data.hs
@@ -81,8 +81,8 @@ import Kore.Internal.TermLike (
     TermLike,
  )
 import Kore.Log (
-    ActualEntry (..),
     LogAction (..),
+    SomeEntry (..),
  )
 import Kore.Log qualified as Log
 import Kore.Log.Registry qualified as Log
@@ -591,7 +591,7 @@ data Config = Config
         TermLike RewritingVariableName ->
         UnifierT Simplifier (Condition RewritingVariableName)
     , -- | Logger function, see 'logging'.
-      logger :: MVar (LogAction IO ActualEntry)
+      logger :: MVar (LogAction IO SomeEntry)
     , -- | Output resulting pattern to this file.
       outputFile :: OutputFile
     , mainModuleName :: ModuleName

--- a/kore/src/Kore/Repl/State.hs
+++ b/kore/src/Kore/Repl/State.hs
@@ -510,7 +510,7 @@ liftSimplifierWithLogger ::
     forall a t.
     MonadState ReplState (t Simplifier) =>
     Monad.Trans.MonadTrans t =>
-    MVar (Log.LogAction IO Log.ActualEntry) ->
+    MVar (Log.LogAction IO Log.SomeEntry) ->
     Simplifier a ->
     t Simplifier a
 liftSimplifierWithLogger mLogger simplifier = do

--- a/kore/src/Log.hs
+++ b/kore/src/Log.hs
@@ -41,11 +41,10 @@ import Colog (
     cmap,
     (<&),
  )
-import Control.Lens qualified as Lens
 import Control.Monad.Catch (
-    MonadCatch,
+    MonadCatch (catch),
     MonadMask,
-    MonadThrow,
+    MonadThrow (throwM),
  )
 import Control.Monad.Counter (
     CounterT,
@@ -73,9 +72,6 @@ import Control.Monad.Trans.Maybe (
 import Control.Monad.Trans.Reader
 import Control.Monad.Trans.State.Strict qualified as Strict (
     StateT,
- )
-import Data.Generics.Product (
-    field,
  )
 import Data.Text (
     Text,
@@ -243,28 +239,26 @@ newtype LoggerT m a = LoggerT {getLoggerT :: ReaderT (LoggerEnv m) m a}
     deriving newtype (Functor, Applicative, Monad)
     deriving newtype (MonadIO, MonadThrow, MonadCatch, MonadMask)
 
-data LoggerEnv monad = LoggerEnv
-    { logAction :: !(LogAction monad ActualEntry)
-    , context :: ![SomeEntry]
+newtype LoggerEnv monad = LoggerEnv
+    { logAction :: LogAction monad SomeEntry
     }
     deriving stock (GHC.Generic)
 
 askLogAction :: Monad m => LoggerT m (LogAction m SomeEntry)
 askLogAction = LoggerT $ do
-    LoggerEnv{logAction, context = entryContext} <- ask
-    let mkActualEntry actualEntry = ActualEntry{actualEntry, entryContext}
-    pure (Colog.cmap mkActualEntry logAction)
+    LoggerEnv{logAction} <- ask
+    pure logAction
 {-# INLINE askLogAction #-}
 
 runLoggerT ::
     LoggerT monad a ->
-    LogAction monad ActualEntry ->
+    LogAction monad SomeEntry ->
     monad a
 runLoggerT LoggerT{getLoggerT} logAction =
-    runReaderT getLoggerT LoggerEnv{logAction, context = mempty}
+    runReaderT getLoggerT LoggerEnv{logAction}
 {-# INLINE runLoggerT #-}
 
-instance Monad m => MonadLog (LoggerT m) where
+instance (MonadCatch m, MonadThrow m) => MonadLog (LoggerT m) where
     logEntry entry = do
         someLogAction <- askLogAction
         lift $ someLogAction <& toEntry entry
@@ -272,9 +266,12 @@ instance Monad m => MonadLog (LoggerT m) where
 
     logWhile entry2 action = do
         logEntry entry2
-        LoggerT . addContext $ getLoggerT action
+        (LoggerT . addContext $ getLoggerT action)
+            `catch` (\(SomeEntry ctxt e) -> throwM $ SomeEntry (toEntry entry2 : ctxt) e)
       where
-        addContext = local $ Lens.over (field @"context") (toEntry entry2 :)
+        addContext = local $
+            \LoggerEnv{logAction} ->
+                LoggerEnv $ Colog.cmap (\(SomeEntry ctxt e) -> SomeEntry (toEntry entry2 : ctxt) e) logAction
     {-# INLINE logWhile #-}
 
 instance MonadTrans LoggerT where

--- a/kore/test/Test/Kore.hs
+++ b/kore/test/Test/Kore.hs
@@ -98,7 +98,7 @@ import Kore.Variables.Target (
     mkSetNonTarget,
     mkSetTarget,
  )
-import Log (LogAction (..), LoggerT, SomeEntry, actualEntry)
+import Log (LogAction (..), LoggerT, SomeEntry (..))
 import Prelude.Kore
 
 -- | @Context@ stores the variables and sort variables in scope.
@@ -776,7 +776,7 @@ runTestLoggerT action = do
     entriesRef <- newIORef []
     let logAction = LogAction $ \entry ->
             atomicModifyIORef' entriesRef $ \entries ->
-                (Log.actualEntry entry : entries, ())
+                (entry : entries, ())
     r <- Log.runLoggerT action logAction
     entries <- readIORef entriesRef
     return (r, entries)

--- a/kore/test/Test/Kore/Repl/Interpreter.hs
+++ b/kore/test/Test/Kore/Repl/Interpreter.hs
@@ -831,7 +831,7 @@ mkState startTime axioms claims claim =
     graph' = emptyExecutionGraph claim
 
 mkConfig ::
-    MVar (Log.LogAction IO Log.ActualEntry) ->
+    MVar (Log.LogAction IO Log.SomeEntry) ->
     Config
 mkConfig logger =
     Config


### PR DESCRIPTION
Pre-requisite for  #3238

This PR refactors the log entry types type by adding the context directly to the `SomeEntry` type, making `ActualEntry` redundant. This change also removes context from the environment and instead bundles context with each `SomeEntry` directly. This is necessary when throwing errors, since we want to re-throw errors with the bundled context at each `logWhile` call, mirroring what we do with the log messages in this method.

Finally, the format of the log and error messages has been re-factored, with the context being moved at the bottom of the message for (hopefully) better readability:

```
kore-exec: [167082] Error (ErrorDecidePredicateUnknown):
    Failed to decide predicate:
        /* Sfa */
        \not{_}(
            /* Spa */
            \equals{SortBool{}, _}(
                /* Fl Fn D Sfa */ VarB:SortBool{},
                /* Fl Fn D Sfa Cl */ \dv{SortBool{}}("false")
            )
        )
    with side condition:
        /* D Sfa */ \top{_}()
Context:
    (DebugEvaluateCondition) while evaluating predicate
        (DebugAttemptEquation) while applying equation at /build/kore/test/warn-decide-predicate-unknown/lemmas.k:8:10-8:53
```