### PR TITLE
3244 restrict `TermLike` test data generator

### DIFF
--- a/kore/test/Test/ConsistentKore.hs
+++ b/kore/test/Test/ConsistentKore.hs
@@ -399,15 +399,17 @@ _checkTermImplemented term@(Recursive.project -> _ :< termF) =
 termGenerators :: Gen (Map.Map SortRequirements [TermGenerator])
 termGenerators = do
     (setup, Context{onlyConstructorLike, allowTermConnectives}) <- Reader.ask
+    -- One problem seems to be that there is no way to generate `otherTopSort`
+    -- except this. However, there is also a loop in the generator recursion.
+    let topHack = Map.singleton AnySort [topGenerator]
     connectives <-
         if allowTermConnectives
             then
                 filterGeneratorsAndGroup
                     [ andGenerator
                     , orGenerator
-                    , topGenerator -- FIXME tests fail on a mem leak when removing this
                     ]
-            else pure $ Map.singleton AnySort [topGenerator]
+            else pure Map.empty
     literals <-
         filterGeneratorsAndGroup
             ( catMaybes
@@ -428,6 +430,7 @@ termGenerators = do
                 , variable
                 , allBuiltin
                 , connectives
+                , topHack
                 ]
 
 nullaryFreeSortOperatorGenerator ::

--- a/kore/test/Test/ConsistentKore.hs
+++ b/kore/test/Test/ConsistentKore.hs
@@ -1,5 +1,6 @@
 module Test.ConsistentKore (
     CollectionSorts (..),
+    MapSorts (..),
     Setup (..),
     runKoreGen,
     patternGen,
@@ -963,8 +964,7 @@ filterGenerators = Monad.filterM acceptGenerator
     acceptGenerator
         TermGenerator{attributes} =
             do
-                (_, context@(Context _ _ _ _ _)) <- Reader.ask
-                let Context{onlyConcrete, onlyConstructorLike} = context
+                Context{onlyConcrete, onlyConstructorLike} <- Reader.asks snd
                 return $ case attributes of
                     AttributeRequirements{isConcrete, isConstructorLike} ->
                         (not onlyConcrete || isConcrete)

--- a/kore/test/Test/ConsistentKore.hs
+++ b/kore/test/Test/ConsistentKore.hs
@@ -404,34 +404,31 @@ termGenerators = do
     let topHack = Map.singleton AnySort [topGenerator]
     connectives <-
         if allowTermConnectives
-            then
-                filterGeneratorsAndGroup
-                    [ andGenerator
-                    , orGenerator
-                    ]
+            then filterGeneratorsAndGroup [andGenerator, orGenerator]
             else pure Map.empty
     literals <-
         filterGeneratorsAndGroup
             ( catMaybes
                 [maybeStringLiteralGenerator setup]
             )
-    variable <- Map.map (:[]) <$> allVariableGenerators
+    variable <- Map.map (: []) <$> allVariableGenerators
     symbol <- symbolGenerators
     alias <- aliasGenerators
-    allBuiltin <- Map.map (:[]) <$> allBuiltinGenerators
+    allBuiltin <- Map.map (: []) <$> allBuiltinGenerators
     if onlyConstructorLike
         then return symbol
         else
             return $
-                Map.unionsWith (<>)
-                [ symbol
-                , alias
-                , literals
-                , variable
-                , allBuiltin
-                , connectives
-                , topHack
-                ]
+                Map.unionsWith
+                    (<>)
+                    [ symbol
+                    , alias
+                    , literals
+                    , variable
+                    , allBuiltin
+                    , connectives
+                    , topHack
+                    ]
 
 nullaryFreeSortOperatorGenerator ::
     (Sort -> TermLike VariableName) ->

--- a/kore/test/Test/ConsistentKore.hs
+++ b/kore/test/Test/ConsistentKore.hs
@@ -3,7 +3,6 @@ module Test.ConsistentKore (
     Setup (..),
     runKoreGen,
     patternGen,
-    termLikeGen,
 ) where
 
 import Control.Arrow qualified as Arrow
@@ -198,7 +197,7 @@ runKoreGen
 patternGen :: Gen (Pattern VariableName)
 patternGen =
     Pattern.fromTermAndPredicate
-        <$> termLikeGen
+        <$> termGen
         <*> predicateGen
 
 localContext :: (Context -> Context) -> Gen a -> Gen a
@@ -217,8 +216,8 @@ withoutConnectives :: Gen a -> Gen a
 withoutConnectives =
     localContext (\context -> context{allowTermConnectives = False})
 
-termLikeGen :: Gen (TermLike VariableName)
-termLikeGen =
+termGen :: Gen (TermLike VariableName)
+termGen =
     sortGen >>= termLikeGenWithSort
 
 termLikeGenWithSort :: Sort -> Gen (TermLike VariableName)
@@ -276,11 +275,11 @@ notPredicateGen =
 
 ceilGen :: Gen (Predicate VariableName)
 ceilGen =
-    fromCeil_ <$> withoutConnectives termLikeGen
+    fromCeil_ <$> withoutConnectives termGen
 
 floorGen :: Gen (Predicate VariableName)
 floorGen =
-    fromFloor_ <$> withoutConnectives termLikeGen
+    fromFloor_ <$> withoutConnectives termGen
 
 equalsGen :: Gen (Predicate VariableName)
 equalsGen = withoutConnectives $ do

--- a/kore/test/Test/ConsistentKore.hs
+++ b/kore/test/Test/ConsistentKore.hs
@@ -417,16 +417,8 @@ termGenerators = do
     generators <-
         filterGeneratorsAndGroup
             [ andGenerator
-            , bottomGenerator
-            , existsGenerator
-            , forallGenerator
-            , iffGenerator
-            , impliesGenerator
-            , notGenerator
             , orGenerator
-            , topGenerator
-            , nuGenerator
-            , muGenerator
+            , topGenerator -- FIXME tests fail on a mem leak when removing this
             ]
     literals <-
         filterGeneratorsAndGroup

--- a/kore/test/Test/Kore/Internal/TermLike.hs
+++ b/kore/test/Test/Kore/Internal/TermLike.hs
@@ -50,6 +50,7 @@ import Kore.Attribute.Synthetic (
 import Kore.Error qualified
 import Kore.Internal.ApplicationSorts
 import Kore.Internal.InternalInt
+import Kore.Internal.Pattern qualified as IPattern
 import Kore.Internal.Substitution (
     orientSubstitution,
  )
@@ -720,7 +721,8 @@ test_uninternalize =
 
 test_toSyntaxPattern :: TestTree
 test_toSyntaxPattern = Hedgehog.testProperty "convert a valid pattern to a Syntax.Pattern and back" . Hedgehog.property $ do
-    trmLike <- forAll (runKoreGen Mock.generatorSetup ConsistentKore.termLikeGen)
+    -- generate a consistent (internal) pattern to turn into a (general) term
+    trmLike <- IPattern.toTermLike <$> forAll (runKoreGen Mock.generatorSetup ConsistentKore.patternGen)
     let patt = fmap (const Attribute.Null) (from trmLike :: Pattern.Pattern VariableName (TermAttributes VariableName))
 
     case PatternVerifier.runPatternVerifier Mock.verifiedModuleContext $


### PR DESCRIPTION
Fixes #3244

### Scope:

Restricts the `TermLike` generator inside `ConsistentKore` to avoid generating terms that should only be present in a predicate (`\bottom`, `\exists`, `\forall`, `\iff`, `\implies`, `\not`, `\mu`, `\nu`). 
* `\top` was kept because otherwise the generator would fail on terms of sort `otherTopSort` and was at times looping (which should be investigated separately).
* (term-typed) `\and` and `\or` were kept as requested but are restricted to not occur within terms inside a predicate.

### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
