### PR TITLE
`kore-rpc` now uses aeson-pretty for encoding JSON messages

### DIFF
--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -133,6 +133,7 @@ common library
   build-depends: co-log >=0.4
   build-depends: comonad >=5.0
   build-depends: compact >= 0.2.0.0
+  build-depends: conduit >= 1.3
   build-depends: conduit-extra >=1.3
   build-depends: containers >=0.5.8
   build-depends: cryptonite >=0.25
@@ -178,6 +179,7 @@ common library
   build-depends: semialign >=1
   build-depends: sqlite-simple >=0.4
   build-depends: stm >=2.5
+  build-depends: stm-conduit >= 4.0
   build-depends: streams
   build-depends: tar >=0.5
   build-depends: template-haskell >=2.14
@@ -186,6 +188,7 @@ common library
   build-depends: these >=1.0
   build-depends: time >=1.9.3
   build-depends: transformers >=0.4
+  build-depends: unliftio >= 0.2
   build-depends: unordered-containers >=0.2
   build-depends: vector >=0.12
   build-depends: witherable ==0.3.*
@@ -410,6 +413,7 @@ library
     Kore.ModelChecker.Bounded
     Kore.ModelChecker.Simplification
     Kore.ModelChecker.Step
+    Kore.Network.JSONRPC
     Kore.Options
     Kore.Parser
     Kore.Parser.CString

--- a/kore/src/Kore/JsonRpc.hs
+++ b/kore/src/Kore/JsonRpc.hs
@@ -13,8 +13,8 @@ import Control.Monad.Except (runExceptT)
 import Control.Monad.Logger (MonadLoggerIO, askLoggerIO, runLoggingT)
 import Control.Monad.Reader (ask, runReaderT)
 import Control.Monad.STM (atomically)
-import Data.Aeson.Types (FromJSON (..), ToJSON (..), Value (..))
 import Data.Aeson.Encode.Pretty as Json
+import Data.Aeson.Types (FromJSON (..), ToJSON (..), Value (..))
 import Data.Conduit.Network (serverSettings)
 import Data.Limit (Limit (..))
 import Data.Text (Text)
@@ -470,8 +470,8 @@ runServer port solverSetup loggerEnv@Log.LoggerEnv{logAction} serializedModule =
             Json.defConfig{Json.confIndent = Spaces 0, confCompare}
             V2
             False
-            srvSettings $
-            srv loggerEnv runSMT serializedModule
+            srvSettings
+            $ srv loggerEnv runSMT serializedModule
   where
     srvSettings = serverSettings port "*"
     confCompare =

--- a/kore/src/Kore/JsonRpc.hs
+++ b/kore/src/Kore/JsonRpc.hs
@@ -467,7 +467,7 @@ runServer :: Int -> SMT.SolverSetup -> Log.LoggerEnv IO -> Exec.SerializedModule
 runServer port solverSetup loggerEnv@Log.LoggerEnv{logAction} serializedModule = do
     flip runLoggingT logFun $
         jsonrpcTCPServer
-            Json.defConfig{Json.confIndent = Spaces 0, confCompare}
+            Json.defConfig{confCompare}
             V2
             False
             srvSettings

--- a/kore/src/Kore/JsonRpc.hs
+++ b/kore/src/Kore/JsonRpc.hs
@@ -475,7 +475,7 @@ runServer port solverSetup loggerEnv@Log.LoggerEnv{logAction} serializedModule =
   where
     srvSettings = serverSettings port "*"
     confCompare =
-        Json.keyOrder -- retains the field order in all constructors
+        Json.keyOrder
             [ "format"
             , "version"
             , "term"

--- a/kore/src/Kore/Network/JSONRPC.hs
+++ b/kore/src/Kore/Network/JSONRPC.hs
@@ -1,0 +1,56 @@
+module Kore.Network.JSONRPC where
+
+import Control.Monad.Logger (MonadLoggerIO)
+import Control.Monad.Reader (runReaderT)
+import Data.Aeson (ToJSON)
+import Data.Aeson.Encode.Pretty as Json
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy.Char8 qualified as L8
+import Data.Conduit (ConduitT, Void, runConduit, (.|))
+import Data.Conduit.List qualified as CL
+import Data.Conduit.TMChan (closeTBMChan, sinkTBMChan, sourceTBMChan)
+import Data.Conduit.Network (ServerSettings, runGeneralTCPServer, appSink, appSource)
+import Network.JSONRPC(JSONRPCT, Session(..), Ver, decodeConduit, initSession, processIncoming)
+import Prelude.Kore
+import UnliftIO (MonadUnliftIO, atomically, withAsync, wait)
+
+-- Conduit to encode JSON to ByteString.
+encodeConduit :: (ToJSON j, Monad m) => Json.Config -> ConduitT j ByteString m ()
+encodeConduit encodeOpts = CL.mapM $ \m -> return . L8.toStrict $ encodePretty' encodeOpts m
+
+-- | Create JSON-RPC session around conduits from transport layer.  When
+-- context exits session disappears.
+runJSONRPCT ::
+       (MonadLoggerIO m, MonadUnliftIO m)
+    => Json.Config -- ^ aeson-pretty Config
+    -> Ver -- ^ JSON-RPC version
+    -> Bool -- ^ Ignore incoming requests/notifs
+    -> ConduitT ByteString Void m () -- ^ Sink to send messages
+    -> ConduitT () ByteString m () -- ^ Source to receive messages from
+    -> JSONRPCT m a -- ^ JSON-RPC action
+    -> m a -- ^ Output of action
+runJSONRPCT encodeOpts ver ignore snk src f = do
+    qs <- liftIO . atomically $ initSession ver ignore
+    let inSnk  = sinkTBMChan (inCh qs)
+        outSrc = sourceTBMChan (outCh qs)
+    withAsync (runConduit $ src .| decodeConduit ver .| inSnk) $ const $
+        withAsync (runConduit $ outSrc .| encodeConduit encodeOpts .| snk) $ \o ->
+            withAsync (runReaderT processIncoming qs) $ const $ do
+                a <- runReaderT f qs
+                liftIO $ do
+                    atomically . closeTBMChan $ outCh qs
+                    _ <- wait o
+                    return a
+
+
+-- | TCP server transport for JSON-RPC.
+jsonrpcTCPServer
+    :: (MonadLoggerIO m, MonadUnliftIO m)
+    => Json.Config     -- ^ aeson-pretty Config
+    -> Ver             -- ^ JSON-RPC version
+    -> Bool            -- ^ Ignore incoming requests or notifications
+    -> ServerSettings  -- ^ Connection settings
+    -> JSONRPCT m ()   -- ^ Action to perform on connecting client thread
+    -> m a
+jsonrpcTCPServer encodeOpts ver ignore ss f = runGeneralTCPServer ss $ \cl ->
+    runJSONRPCT encodeOpts{Json.confTrailingNewline = True} ver ignore (appSink cl) (appSource cl) f

--- a/kore/src/Kore/Network/JSONRPC.hs
+++ b/kore/src/Kore/Network/JSONRPC.hs
@@ -1,4 +1,4 @@
-module Kore.Network.JSONRPC where
+module Kore.Network.JSONRPC (jsonrpcTCPServer) where
 
 import Control.Monad.Logger (MonadLoggerIO)
 import Control.Monad.Reader (runReaderT)
@@ -66,5 +66,14 @@ jsonrpcTCPServer ::
     -- | Action to perform on connecting client thread
     JSONRPCT m () ->
     m a
-jsonrpcTCPServer encodeOpts ver ignore ss f = runGeneralTCPServer ss $ \cl ->
-    runJSONRPCT encodeOpts{Json.confTrailingNewline = True} ver ignore (appSink cl) (appSource cl) f
+jsonrpcTCPServer encodeOpts ver ignore serverSettings action =
+    runGeneralTCPServer serverSettings $ \cl ->
+        runJSONRPCT
+            -- we have to ensure that the returned messages contain no newlines
+            -- inside the message and have a trailing newline, which is used as the delimiter
+            encodeOpts{Json.confIndent = Spaces 0, Json.confTrailingNewline = True}
+            ver
+            ignore
+            (appSink cl)
+            (appSource cl)
+            action

--- a/kore/src/Kore/Network/JSONRPC.hs
+++ b/kore/src/Kore/Network/JSONRPC.hs
@@ -8,49 +8,63 @@ import Data.ByteString (ByteString)
 import Data.ByteString.Lazy.Char8 qualified as L8
 import Data.Conduit (ConduitT, Void, runConduit, (.|))
 import Data.Conduit.List qualified as CL
+import Data.Conduit.Network (ServerSettings, appSink, appSource, runGeneralTCPServer)
 import Data.Conduit.TMChan (closeTBMChan, sinkTBMChan, sourceTBMChan)
-import Data.Conduit.Network (ServerSettings, runGeneralTCPServer, appSink, appSource)
-import Network.JSONRPC(JSONRPCT, Session(..), Ver, decodeConduit, initSession, processIncoming)
+import Network.JSONRPC (JSONRPCT, Session (..), Ver, decodeConduit, initSession, processIncoming)
 import Prelude.Kore
-import UnliftIO (MonadUnliftIO, atomically, withAsync, wait)
+import UnliftIO (MonadUnliftIO, atomically, wait, withAsync)
 
 -- Conduit to encode JSON to ByteString.
 encodeConduit :: (ToJSON j, Monad m) => Json.Config -> ConduitT j ByteString m ()
 encodeConduit encodeOpts = CL.mapM $ \m -> return . L8.toStrict $ encodePretty' encodeOpts m
 
--- | Create JSON-RPC session around conduits from transport layer.  When
--- context exits session disappears.
+{- | Create JSON-RPC session around conduits from transport layer.  When
+ context exits session disappears.
+-}
 runJSONRPCT ::
-       (MonadLoggerIO m, MonadUnliftIO m)
-    => Json.Config -- ^ aeson-pretty Config
-    -> Ver -- ^ JSON-RPC version
-    -> Bool -- ^ Ignore incoming requests/notifs
-    -> ConduitT ByteString Void m () -- ^ Sink to send messages
-    -> ConduitT () ByteString m () -- ^ Source to receive messages from
-    -> JSONRPCT m a -- ^ JSON-RPC action
-    -> m a -- ^ Output of action
+    (MonadLoggerIO m, MonadUnliftIO m) =>
+    -- | aeson-pretty Config
+    Json.Config ->
+    -- | JSON-RPC version
+    Ver ->
+    -- | Ignore incoming requests/notifs
+    Bool ->
+    -- | Sink to send messages
+    ConduitT ByteString Void m () ->
+    -- | Source to receive messages from
+    ConduitT () ByteString m () ->
+    -- | JSON-RPC action
+    JSONRPCT m a ->
+    -- | Output of action
+    m a
 runJSONRPCT encodeOpts ver ignore snk src f = do
     qs <- liftIO . atomically $ initSession ver ignore
-    let inSnk  = sinkTBMChan (inCh qs)
+    let inSnk = sinkTBMChan (inCh qs)
         outSrc = sourceTBMChan (outCh qs)
-    withAsync (runConduit $ src .| decodeConduit ver .| inSnk) $ const $
-        withAsync (runConduit $ outSrc .| encodeConduit encodeOpts .| snk) $ \o ->
-            withAsync (runReaderT processIncoming qs) $ const $ do
-                a <- runReaderT f qs
-                liftIO $ do
-                    atomically . closeTBMChan $ outCh qs
-                    _ <- wait o
-                    return a
-
+    withAsync (runConduit $ src .| decodeConduit ver .| inSnk) $
+        const $
+            withAsync (runConduit $ outSrc .| encodeConduit encodeOpts .| snk) $ \o ->
+                withAsync (runReaderT processIncoming qs) $
+                    const $ do
+                        a <- runReaderT f qs
+                        liftIO $ do
+                            atomically . closeTBMChan $ outCh qs
+                            _ <- wait o
+                            return a
 
 -- | TCP server transport for JSON-RPC.
-jsonrpcTCPServer
-    :: (MonadLoggerIO m, MonadUnliftIO m)
-    => Json.Config     -- ^ aeson-pretty Config
-    -> Ver             -- ^ JSON-RPC version
-    -> Bool            -- ^ Ignore incoming requests or notifications
-    -> ServerSettings  -- ^ Connection settings
-    -> JSONRPCT m ()   -- ^ Action to perform on connecting client thread
-    -> m a
+jsonrpcTCPServer ::
+    (MonadLoggerIO m, MonadUnliftIO m) =>
+    -- | aeson-pretty Config
+    Json.Config ->
+    -- | JSON-RPC version
+    Ver ->
+    -- | Ignore incoming requests or notifications
+    Bool ->
+    -- | Connection settings
+    ServerSettings ->
+    -- | Action to perform on connecting client thread
+    JSONRPCT m () ->
+    m a
 jsonrpcTCPServer encodeOpts ver ignore ss f = runGeneralTCPServer ss $ \cl ->
     runJSONRPCT encodeOpts{Json.confTrailingNewline = True} ver ignore (appSink cl) (appSource cl) f

--- a/nix/kore-ghc8107.nix.d/kore.nix
+++ b/nix/kore-ghc8107.nix.d/kore.nix
@@ -41,6 +41,7 @@
         (hsPkgs."co-log" or (errorHandler.buildDepError "co-log"))
         (hsPkgs."comonad" or (errorHandler.buildDepError "comonad"))
         (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
+        (hsPkgs."conduit" or (errorHandler.buildDepError "conduit"))
         (hsPkgs."conduit-extra" or (errorHandler.buildDepError "conduit-extra"))
         (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
         (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
@@ -92,6 +93,7 @@
         (hsPkgs."semialign" or (errorHandler.buildDepError "semialign"))
         (hsPkgs."sqlite-simple" or (errorHandler.buildDepError "sqlite-simple"))
         (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+        (hsPkgs."stm-conduit" or (errorHandler.buildDepError "stm-conduit"))
         (hsPkgs."streams" or (errorHandler.buildDepError "streams"))
         (hsPkgs."tar" or (errorHandler.buildDepError "tar"))
         (hsPkgs."template-haskell" or (errorHandler.buildDepError
@@ -101,6 +103,7 @@
         (hsPkgs."these" or (errorHandler.buildDepError "these"))
         (hsPkgs."time" or (errorHandler.buildDepError "time"))
         (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+        (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
         (hsPkgs."unordered-containers" or (errorHandler.buildDepError
           "unordered-containers"))
         (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
@@ -328,6 +331,7 @@
         "Kore/ModelChecker/Bounded"
         "Kore/ModelChecker/Simplification"
         "Kore/ModelChecker/Step"
+        "Kore/Network/JSONRPC"
         "Kore/Options"
         "Kore/Parser"
         "Kore/Parser/CString"
@@ -695,6 +699,7 @@
           (hsPkgs."co-log" or (errorHandler.buildDepError "co-log"))
           (hsPkgs."comonad" or (errorHandler.buildDepError "comonad"))
           (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
+          (hsPkgs."conduit" or (errorHandler.buildDepError "conduit"))
           (hsPkgs."conduit-extra" or (errorHandler.buildDepError
             "conduit-extra"))
           (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
@@ -749,6 +754,7 @@
           (hsPkgs."sqlite-simple" or (errorHandler.buildDepError
             "sqlite-simple"))
           (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+          (hsPkgs."stm-conduit" or (errorHandler.buildDepError "stm-conduit"))
           (hsPkgs."streams" or (errorHandler.buildDepError "streams"))
           (hsPkgs."tar" or (errorHandler.buildDepError "tar"))
           (hsPkgs."template-haskell" or (errorHandler.buildDepError
@@ -758,6 +764,7 @@
           (hsPkgs."these" or (errorHandler.buildDepError "these"))
           (hsPkgs."time" or (errorHandler.buildDepError "time"))
           (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+          (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
           (hsPkgs."unordered-containers" or (errorHandler.buildDepError
             "unordered-containers"))
           (hsPkgs."vector" or (errorHandler.buildDepError "vector"))

--- a/nix/kore-ghc923.nix.d/kore.nix
+++ b/nix/kore-ghc923.nix.d/kore.nix
@@ -41,6 +41,7 @@
         (hsPkgs."co-log" or (errorHandler.buildDepError "co-log"))
         (hsPkgs."comonad" or (errorHandler.buildDepError "comonad"))
         (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
+        (hsPkgs."conduit" or (errorHandler.buildDepError "conduit"))
         (hsPkgs."conduit-extra" or (errorHandler.buildDepError "conduit-extra"))
         (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
         (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
@@ -92,6 +93,7 @@
         (hsPkgs."semialign" or (errorHandler.buildDepError "semialign"))
         (hsPkgs."sqlite-simple" or (errorHandler.buildDepError "sqlite-simple"))
         (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+        (hsPkgs."stm-conduit" or (errorHandler.buildDepError "stm-conduit"))
         (hsPkgs."streams" or (errorHandler.buildDepError "streams"))
         (hsPkgs."tar" or (errorHandler.buildDepError "tar"))
         (hsPkgs."template-haskell" or (errorHandler.buildDepError
@@ -101,6 +103,7 @@
         (hsPkgs."these" or (errorHandler.buildDepError "these"))
         (hsPkgs."time" or (errorHandler.buildDepError "time"))
         (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+        (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
         (hsPkgs."unordered-containers" or (errorHandler.buildDepError
           "unordered-containers"))
         (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
@@ -328,6 +331,7 @@
         "Kore/ModelChecker/Bounded"
         "Kore/ModelChecker/Simplification"
         "Kore/ModelChecker/Step"
+        "Kore/Network/JSONRPC"
         "Kore/Options"
         "Kore/Parser"
         "Kore/Parser/CString"
@@ -695,6 +699,7 @@
           (hsPkgs."co-log" or (errorHandler.buildDepError "co-log"))
           (hsPkgs."comonad" or (errorHandler.buildDepError "comonad"))
           (hsPkgs."compact" or (errorHandler.buildDepError "compact"))
+          (hsPkgs."conduit" or (errorHandler.buildDepError "conduit"))
           (hsPkgs."conduit-extra" or (errorHandler.buildDepError
             "conduit-extra"))
           (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
@@ -749,6 +754,7 @@
           (hsPkgs."sqlite-simple" or (errorHandler.buildDepError
             "sqlite-simple"))
           (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+          (hsPkgs."stm-conduit" or (errorHandler.buildDepError "stm-conduit"))
           (hsPkgs."streams" or (errorHandler.buildDepError "streams"))
           (hsPkgs."tar" or (errorHandler.buildDepError "tar"))
           (hsPkgs."template-haskell" or (errorHandler.buildDepError
@@ -758,6 +764,7 @@
           (hsPkgs."these" or (errorHandler.buildDepError "these"))
           (hsPkgs."time" or (errorHandler.buildDepError "time"))
           (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+          (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
           (hsPkgs."unordered-containers" or (errorHandler.buildDepError
             "unordered-containers"))
           (hsPkgs."vector" or (errorHandler.buildDepError "vector"))


### PR DESCRIPTION
Part of #3287

This PR modifies the `kore-rpc` server to use `aeson-pretty` for encoding the JSON responses. This means we can sort the object keys for better readability. e.g. message before the change:

```json
{
  "result": {
    "state": {
      "term": {
        "format": "KORE",
        "term": {
          "args": [
            {
              "args": [...],
              "tag": "App",
              "sorts": [],
              "name": "Lbl'-LT-'T'-GT-'"
            },
            {...}
          ],
          "tag": "App",
          "sorts": [],
          "name": "Lbl'-LT-'generatedTop'-GT-'"
        },
        "version": 1
      }
    },
    "next-states": [...],
    "reason": "branching",
    "depth": 0
  },
  "jsonrpc": "2.0",
  "id": 1
}
```

vs the new version:

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "reason": "branching",
    "depth": 0,
    "state": {
      "term": {
        "format": "KORE",
        "version": 1,
        "term": {
          "tag": "App",
          "name": "Lbl'-LT-'generatedTop'-GT-'",
          "sorts": [],
          "args": [
            {
              "tag": "App",
              "name": "Lbl'-LT-'T'-GT-'",
              "sorts": [],
              "args": [...]
            },
            {...}
          ]
        }
      }
    },
    "next-states": [...]
  }
}
```