### PR TITLE
Use correct token to post comment, avoid checkout work

### DIFF
--- a/.github/workflows/profiling.yaml
+++ b/.github/workflows/profiling.yaml
@@ -28,6 +28,7 @@ jobs:
           if ! gh api -H "Accept: application/vnd.github+json" /orgs/runtimeverification/members/$GITHUB_ACTOR; then
             exit 1
           fi
+          echo "Github Ref: '${{ env.GITHUB_REF }}'"
           echo "Context: "
           cat ${GITHUB_EVENT_PATH}
       - name: Check File Downloadable
@@ -52,13 +53,15 @@ jobs:
           rm -rf ./*
       - name: Check out code
         uses: actions/checkout@v3
+        with:
+          ref: '${{ env.GITHUB_REF }}'
       - name: Run Tests
         run: |
           set -euo pipefail
           ISSUE_NUMBER=$(cat ${GITHUB_EVENT_PATH} | jq '.issue.number')
           DOWNLOAD_URL=$(jq '.comment.body' ${GITHUB_EVENT_PATH} | (grep -oP '(?<=\()https://github\.com/${{ github.repository }}/files/[A-Za-z0-9._~!$&*+,;=@%/-]*\.tar\.gz(?=\))' || echo "No-valid-URL-found") | head -1 )
           FILE_NAME=$(basename ${DOWNLOAD_URL})
-          gh issue comment ${ISSUE_NUMBER} --body "Running ${FILE_NAME} as ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          gh issue comment ${ISSUE_NUMBER} --body "Running test with ${GITHUB_REF:-master} and ${FILE_NAME} as ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           echo "Download Test File from ${DOWNLOAD_URL}"
           curl -LOsS ${DOWNLOAD_URL}

--- a/.github/workflows/profiling.yaml
+++ b/.github/workflows/profiling.yaml
@@ -28,7 +28,7 @@ jobs:
           if ! gh api -H "Accept: application/vnd.github+json" /orgs/runtimeverification/members/$GITHUB_ACTOR; then
             exit 1
           fi
-          echo "Github Ref: '${{ env.GITHUB_REF }}'"
+          echo "Github Ref: '${{ env.GITHUB_REF }}', PR head: '${{ github.event.pull_request.head.sha }}'"
           echo "Context: "
           cat ${GITHUB_EVENT_PATH}
       - name: Check File Downloadable

--- a/.github/workflows/profiling.yaml
+++ b/.github/workflows/profiling.yaml
@@ -78,22 +78,18 @@ jobs:
     runs-on: [Linux, flyweight]
     if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
     env:
-      GH_TOKEN: ${{ secrets.ORG_PAT }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Check out code
-        uses: actions/checkout@v3.0.2
       - run: |
           ISSUE_NUMBER=$(cat ${GITHUB_EVENT_PATH} | jq '.issue.number')
-          gh issue comment ${ISSUE_NUMBER} --body "PASSED: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          gh issue -R ${{ github.repository }} comment ${ISSUE_NUMBER} --body "PASSED: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
   on-failure:
     needs: Profiling
     runs-on: [Linux, flyweight]
     if: ${{ always() && contains(join(needs.*.result, ','), 'failure') }}
     env:
-      GH_TOKEN: ${{ secrets.ORG_PAT }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Check out code
-        uses: actions/checkout@v3.0.2    
       - run: |
           ISSUE_NUMBER=$(cat ${GITHUB_EVENT_PATH} | jq '.issue.number')
-          gh issue comment ${ISSUE_NUMBER} --body "FAILED: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          gh issue -R ${{ github.repository }} comment ${ISSUE_NUMBER} --body "FAILED: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
Two more small adjustments to the profiling workflow.

Currently the final `on_success` and `on_failure` have the wrong token and fail to post a message, see https://github.com/runtimeverification/haskell-backend/actions/runs/3223960737/jobs/5274887739