### PR TITLE
Streamline addElementDisjoint

### DIFF
--- a/kore/src/Kore/Builtin/AssociativeCommutative.hs
+++ b/kore/src/Kore/Builtin/AssociativeCommutative.hs
@@ -508,24 +508,22 @@ instance
 otherwise.
 -}
 addToMapDisjoint ::
-    (Ord a, Traversable t, Hashable a) =>
+    (Ord a, Foldable t, Hashable a) =>
     HashMap a b ->
     t (a, b) ->
     Maybe (HashMap a b)
-addToMapDisjoint existing traversable = do
-    (_, mapResult) <- Monad.foldM addElementDisjoint ([], existing) traversable
-    return mapResult
+addToMapDisjoint = Monad.foldM addElementDisjoint
 
 addElementDisjoint ::
     Ord a =>
     Hashable a =>
-    ([(a, b)], HashMap a b) ->
+    HashMap a b ->
     (a, b) ->
-    Maybe ([(a, b)], HashMap a b)
-addElementDisjoint (list, existing) (key, value) =
+    Maybe (HashMap a b)
+addElementDisjoint existing (key, value) =
     if key `HashMap.member` existing
         then Nothing
-        else return ((key, value) : list, HashMap.insert key value existing)
+        else return (HashMap.insert key value existing)
 
 -- | Given a @NormalizedAc@, returns it as a function result.
 returnAc ::
@@ -640,12 +638,7 @@ evalConcatNormalizedOrBottom
             concatNormalized normalized1 normalized2
 
 disjointMap :: Ord a => Hashable a => [(a, b)] -> Maybe (HashMap a b)
-disjointMap input =
-    if length input == HashMap.size asMap
-        then Just asMap
-        else Nothing
-  where
-    asMap = HashMap.fromList input
+disjointMap = addToMapDisjoint HashMap.empty
 
 splitVariableConcrete ::
     forall variable a.


### PR DESCRIPTION
`addToMapDisjoint` uses an unexported helper function `addElementDisjoint` to insert elements into a `HashMap`. For some reason, these were written to accumulate a (reversed) list of the elements inserted along with the actual `HashMap`, and then throw the list away. This was both wasteful and confusing. Stop doing it.

Fixes #nnnn

### Scope:

### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
