### PR TITLE
KEVM performance timing run triggered by comments + fix profiling run

### DIFF
--- a/.github/workflows/kevm-performance-test.yaml
+++ b/.github/workflows/kevm-performance-test.yaml
@@ -1,0 +1,94 @@
+---
+name: KEVM Performance Test
+on:
+  # Trigger when commenting on an issue or PR, or editing a comment
+  # Issue/PR MUST already be labeled properly
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  Prepare:
+    if: |
+      contains(github.event.issue.labels.*.name, 'performance') &&
+      ( contains(github.event.comment.body, '/ KEVM-perf-run') )
+    # Comment must contain this exact string to trigger a run
+    runs-on: [Linux, flyweight]
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check User Org Association
+        run: |
+          set -euo pipefail
+          echo $(pwd)
+
+          echo "Testing User Org Relationship: $GITHUB_ACTOR"
+          gh auth status
+          if ! gh api -H "Accept: application/vnd.github+json" /orgs/runtimeverification/members/$GITHUB_ACTOR; then
+            exit 1
+          fi
+      - name: Check that we are on a PR
+        run: [ -n "${{ github.even.issue.pull_request }}" ] && echo "OK, we are on a PR"
+
+  Profiling:
+    needs: Prepare
+    runs-on: [Linux, performance]
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Clean _work Folder
+        run: |
+          echo "Cleaning Folder"
+          rm -rf ./*
+      - name: Determine commit to use
+        id: determine-commit
+        run: |
+          echo "PR_HEAD=$(curl -s ${{ github.event.issue.pull_request.url }} | jq '.head.sha' | xargs echo)" | tee -a $GITHUB_OUTPUT
+      - name: Run Tests
+        run: |
+          set -euo pipefail
+          ISSUE_NUMBER=$(cat ${GITHUB_EVENT_PATH} | jq '.issue.number')
+          PR_HEAD=${{ steps.determine-commit.outputs.PR_HEAD }}
+          TIMESTAMP=$(date +"%Y%m%dT%H%M%S")
+
+          # FIXME can we use a reaction emoji instead?
+          gh issue comment ${ISSUE_NUMBER} --body "Running KEVM test with ${PR_HEAD:-master} as ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          . /home/github-runner/.nix-profile/etc/profile.d/nix.sh
+          echo "Starting Test Execution"
+          echo "RUNNING TEST"
+          nix build github:runtimeverification/evm-semantics#profile \
+              --override-input k-framework/haskell-backend github:runtimeverification/haskell-backend/${PR_HEAD} \
+              -o KEVM-timing-${TIMESTAMP}-${PR_HEAD}.data
+
+          echo "Comparing with current master"
+          nix build github:runtimeverification/evm-semantics#profile \
+              --override-input k-framework/haskell-backend github:runtimeverification/haskell-backend/$GITHUB_SHA \
+              -o KEVM-timing-${TIMESTAMP}-master.data
+
+          nix run github:runtimeverification/evm-semantics#compare-profiles -- KEVM-timing-$TIMESTAMP-${PR_HEAD}.data KEVM-timing-$TIMESTAMP-master.data | tee KEVM-timing-comparison.data
+
+      - name: Publish Results
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          path: ./KEVM-timing*.data
+
+  on-success:
+    needs: Profiling
+    runs-on: [Linux, flyweight]
+    if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - run: |
+          ISSUE_NUMBER=$(cat ${GITHUB_EVENT_PATH} | jq '.issue.number')
+          gh issue -R ${{ github.repository }} comment ${ISSUE_NUMBER} --body "KEVM test finished: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+  on-failure:
+    needs: Profiling
+    runs-on: [Linux, flyweight]
+    if: ${{ always() && contains(join(needs.*.result, ','), 'failure') }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - run: |
+          ISSUE_NUMBER=$(cat ${GITHUB_EVENT_PATH} | jq '.issue.number')
+          gh issue -R ${{ github.repository }} comment ${ISSUE_NUMBER} --body "KEVM test FAILED: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/profiling.yaml
+++ b/.github/workflows/profiling.yaml
@@ -6,7 +6,7 @@ on:
   issue_comment:
     types: [created, edited]
 
-jobs: 
+jobs:
   Prepare:
     if: |
       contains(github.event.issue.labels.*.name, 'performance') &&
@@ -27,9 +27,6 @@ jobs:
           if ! gh api -H "Accept: application/vnd.github+json" /orgs/runtimeverification/members/$GITHUB_ACTOR; then
             exit 1
           fi
-          echo "Github Ref: '${{ env.GITHUB_REF }}', PR head: '${{ github.event.pull_request.head.sha }}'"
-          echo "Context: "
-          cat ${GITHUB_EVENT_PATH}
       - name: Check File Downloadable
         # Note that the reg.ex will only match a URL within parentheses
         # (perl reg.ex context) while the guard above uses a simple substring
@@ -50,17 +47,22 @@ jobs:
         run: |
           echo "Cleaning Folder"
           rm -rf ./*
+      - name: Determine commit to use
+        id: determine-commit
+        run: |
+          echo "PR_HEAD=$(curl -s ${{ github.event.issue.pull_request.url }} | jq '.head.sha' | xargs echo)" | tee -a $GITHUB_OUTPUT
       - name: Check out code
         uses: actions/checkout@v3
         with:
-          ref: '${{ env.GITHUB_REF }}'
+          ref: '${{ steps.determine-commit.outputs.PR_HEAD }}'
       - name: Run Tests
         run: |
           set -euo pipefail
           ISSUE_NUMBER=$(cat ${GITHUB_EVENT_PATH} | jq '.issue.number')
+          PR_HEAD=${{ steps.determine-commit.outputs.PR_HEAD }}
           DOWNLOAD_URL=$(jq '.comment.body' ${GITHUB_EVENT_PATH} | (grep -oP '(?<=\()https://github\.com/${{ github.repository }}/files/[A-Za-z0-9._~!$&*+,;=@%/-]*\.tar\.gz(?=\))' || echo "No-valid-URL-found") | head -1 )
           FILE_NAME=$(basename ${DOWNLOAD_URL})
-          gh issue comment ${ISSUE_NUMBER} --body "Running test with ${GITHUB_REF:-master} and ${FILE_NAME} as ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          gh issue comment ${ISSUE_NUMBER} --body "Running test with ${PR_HEAD:-master} and ${FILE_NAME} as ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           echo "Download Test File from ${DOWNLOAD_URL}"
           curl -LOsS ${DOWNLOAD_URL}
@@ -70,7 +72,7 @@ jobs:
           mkdir -p profile/tests/$(echo ${FILE_NAME} | cut -d '.' -f 1)
           echo "RUNNING PROFILE: ${FILE_NAME}"
           nix run .#profile ./${FILE_NAME}
-   
+
       - name: Publish Profile Results
         uses: actions/upload-artifact@v3.1.0
         with:


### PR DESCRIPTION
* Adds a new KEVM performance run triggered by PR comments containing the string `/ KEVM-perf-run`. This currently runs a test with code from the PR as well as code from master (the branch point of the PR, `GITHUB_SHA`).
* Corrects the existing profiling run (triggered by comments linking to an attached `*.tar.gz`) to use code from the PR head if triggered from a PR.

Explanation for how we check out the code::

When triggering actions from an `issue_comment`, the pull_request context items that online references refer to for `actions/checkout` are not available. Instead:
* If the issue that received the trigger comment was a PR, the context `event.issue.pull_request` is filled. It contains a `url` where PR meta-data can be downloaded.
* The PR meta-data contains the current head SHA of the PR under `head.sha`.
* If the issue is not a pull request, the context `event.issue.pull_request` is not filled. A download-attempt with URL `null` will fail, and the SHA will be the empty string.

Fixes #3323, and fixes the profiling trigger to use code from a PR
