### PR TITLE
3294 - add AC matching case (excess concrete elements in pattern)

### DIFF
--- a/kore/src/Kore/Rewrite/Axiom/Matcher.hs
+++ b/kore/src/Kore/Rewrite/Axiom/Matcher.hs
@@ -553,12 +553,13 @@ matchNormalizedAc ::
     NormalizedAc normalized ->
     Simplifier (Either Text (MatchResult RewritingVariableName))
 matchNormalizedAc decomposeList unwrapValues unwrapElementToTermLike wrapTermLike normalized1 normalized2
+    -- all concrete elements in the AC pattern must appear in the AC subject
+    | not (null excessConcrete1) =
+        failMatch "AC collection missing concrete elements"
     -- Case for when all symbolic elements in normalized1 appear in normalized2:
     | [] <- excessAbstract1 =
-        -- All concrete elements in normalized1 appear in normalized2
-        if not $ null excessConcrete1
-            then failMatch "AC collection missing concrete elements"
-            else case opaque1 of
+        do
+            case opaque1 of
                 -- Without opaques and syntactically equal
                 [] ->
                     if not (null opaque2) || not (null excessConcrete2) || not (null excessAbstract2)

--- a/kore/test/Test/Kore/Rewrite/Axiom/Matcher.hs
+++ b/kore/test/Test/Kore/Rewrite/Axiom/Matcher.hs
@@ -1012,6 +1012,10 @@ test_matching_Set =
         (mkSet [mkInt 0] [])
         (mkSet [] [])
     , doesn'tMatch
+        "[0] does not match [1]"
+        (mkSet [mkInt 0] [])
+        (mkSet [mkInt 1] [])
+    , doesn'tMatch
         "[x:Int] does not match [0]"
         (mkSet [mkElemVar xInt] [])
         (mkSet [mkInt 0] [])
@@ -1044,6 +1048,10 @@ test_matching_Set =
         "[y:Int, 1] doesn't match [x:Int]"
         (mkSet [mkElemVar yInt, mkInt 1] [])
         (mkSet [mkElemVar xInt] [])
+    , doesn'tMatch
+        "[0, y:Int] doesn't match [1, x:Int]"
+        (mkSet [mkInt 0, mkElemVar yInt] [])
+        (mkSet [mkInt 1, mkElemVar xInt] [])
     , matches
         "[y:Int, 1] matches [1, x:Int]"
         (mkSet [mkElemVar yInt, mkInt 1] [])

--- a/test/issue-3294/Makefile
+++ b/test/issue-3294/Makefile
@@ -1,0 +1,3 @@
+DEF = test
+include $(CURDIR)/../include.mk
+KORE_EXEC_OPTS += --disable-stuck-check

--- a/test/issue-3294/test-spec.k
+++ b/test/issue-3294/test-spec.k
@@ -1,0 +1,5 @@
+module TEST-SPEC
+  imports TEST
+
+  claim <k> intersect ( intersectSet( SetItem(_X) SetItem(a), SetItem(b))) => . </k>
+endmodule

--- a/test/issue-3294/test-spec.k.out.golden
+++ b/test/issue-3294/test-spec.k.out.golden
@@ -1,0 +1,10 @@
+  #Not ( {
+    _X
+  #Equals
+    a
+  } )
+#And
+  <k>
+    result ( intersectSet ( SetItem ( _X )
+    SetItem ( a ) , SetItem ( b ) ) ) ~> .
+  </k>

--- a/test/issue-3294/test.k
+++ b/test/issue-3294/test.k
@@ -1,0 +1,16 @@
+module TEST
+  imports SET
+  imports BOOL
+
+  syntax Thing ::= "a" | "b"
+
+  syntax Test ::= intersect ( Set ) | result ( Set )
+
+  rule intersectSet ( S SetItem(X), S) => S
+                    ensures notBool (X in S) [simplification]
+
+  configuration <k> $PGM:Test </k>
+
+  rule <k> intersect(E) => result(E) </k>
+
+endmodule


### PR DESCRIPTION
Refute matches where the pattern contains concrete elements that are not in the subject.

This crucially depends on the fact that we are _matching_, not _unifying_, so any variables in the subject will be treated as opaque constants.

The new test case checks that pattern `SetItem(0) SetItem(Y)` does not match subject `SetItem(1) SetItem(X)` even though these two terms would of course _unify_ with substitution `X = 0 /\ Y = 1`.

Fixes #3294

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
