### PR TITLE
Minor cleanups in Kore.Unification.NewUnifier

### DIFF
--- a/kore/src/Kore/Equation/Application.hs
+++ b/kore/src/Kore/Equation/Application.hs
@@ -297,7 +297,7 @@ applyMatchResult equation matchResult@(predicate, substitution) = do
         Set.member someVariableName equationVariableNames
 
     equationVariableNames =
-        Set.map variableName (FreeVariables.toSet equationVariables)
+        Set.mapMonotonic variableName (FreeVariables.toSet equationVariables)
 
     errors =
         concatMap checkVariable (FreeVariables.toList equationVariables)

--- a/kore/src/Kore/Internal/MultiExists.hs
+++ b/kore/src/Kore/Internal/MultiExists.hs
@@ -132,7 +132,7 @@ refresh ::
 refresh extraAvoiding multiExists@MultiExists{existsVariables, existsChild} =
     MultiExists
         { existsVariables = expectElementVariable <$> someVariables'
-        , existsChild = rename (Map.mapKeys variableName refreshing) existsChild
+        , existsChild = rename (Map.mapKeysMonotonic variableName refreshing) existsChild
         }
   where
     avoiding = freeVariableNames multiExists <> extraAvoiding

--- a/kore/src/Kore/Internal/Substitution.hs
+++ b/kore/src/Kore/Internal/Substitution.hs
@@ -387,13 +387,12 @@ See also: 'fromMap'
 -}
 toMap ::
     HasCallStack =>
-    Ord variable =>
     Substitution variable ->
     Map (SomeVariableName variable) (TermLike variable)
 toMap (Substitution _) =
     error "Cannot convert a denormalized substitution to a map!"
 toMap (NormalizedSubstitution norm) =
-    Map.mapKeys variableName norm
+    Map.mapKeysMonotonic variableName norm
 
 toMultiMap ::
     InternalVariable variable =>

--- a/kore/src/Kore/ModelChecker/Simplification.hs
+++ b/kore/src/Kore/ModelChecker/Simplification.hs
@@ -58,7 +58,7 @@ checkImplicationIsTop lhs rhs =
     case stripForallQuantifiers rhs of
         (forallQuantifiers, Implies_ _ implicationLHS implicationRHS) -> do
             let rename' = refreshVariablesSet lhsFreeVariables forallQuantifiers
-                subst = mkElemVar <$> Map.mapKeys inject rename'
+                subst = mkElemVar <$> Map.mapKeysMonotonic inject rename'
                 implicationLHS' = substitute subst implicationLHS
                 implicationRHS' = substitute subst implicationRHS
                 resultTerm =

--- a/kore/src/Kore/Rewrite/Axiom/Matcher.hs
+++ b/kore/src/Kore/Rewrite/Axiom/Matcher.hs
@@ -429,15 +429,15 @@ patternMatch' sideCondition ((MatchItem pat subject boundVars boundSet) : rest) 
                         | List.isSymbolConcat symbol ->
                             if length l1 <= length l2
                                 then
-                                    let l2' = Seq.drop (length l1) l2
-                                     in decomposeList $ (var, List.asInternal tools sort l2') : zip (toList l1) (toList (Seq.take (length l1) l2))
+                                    let (start, l2') = Seq.splitAt (length l1) l2
+                                     in decomposeList $ (var, List.asInternal tools sort l2') : zip (toList l1) (toList start)
                                 else failMatch "subject list is too short"
                     (App_ symbol [var@(ElemVar_ _), InternalList_ InternalList{internalListChild = l1}], InternalList_ InternalList{internalListChild = l2})
                         | List.isSymbolConcat symbol ->
                             if length l1 <= length l2
                                 then
-                                    let l2' = Seq.take (length l2 - length l1) l2
-                                     in decomposeList $ (var, List.asInternal tools sort l2') : zip (toList l1) (toList (Seq.drop (length l2 - length l1) l2))
+                                    let (l2', end) = Seq.splitAt (length l2 - length l1) l2
+                                     in decomposeList $ (var, List.asInternal tools sort l2') : zip (toList l1) (toList end)
                                 else failMatch "subject list is too short"
                     _ -> failMatch "unimplemented list matching case"
         (InternalMap_ _, InternalMap_ _) ->

--- a/kore/src/Kore/Rewrite/ClaimPattern.hs
+++ b/kore/src/Kore/Rewrite/ClaimPattern.hs
@@ -382,7 +382,7 @@ instance UnifyingRule ClaimPattern where
         refreshVariables' variables = do
             staleNames <- State.get
             let renaming = refreshVariablesSet staleNames variables
-                staleNames' = Set.map variableName variables
+                staleNames' = Set.mapMonotonic variableName variables
                 staleNames'' =
                     Map.elems renaming
                         & foldMap FreeVariables.freeVariable

--- a/kore/src/Kore/Rewrite/Implication.hs
+++ b/kore/src/Kore/Rewrite/Implication.hs
@@ -374,7 +374,7 @@ instance UnifyingRule (Implication modality) where
         refreshVariables' variables = do
             staleNames <- State.get
             let renaming = refreshVariablesSet staleNames variables
-                staleNames' = Set.map variableName variables
+                staleNames' = Set.mapMonotonic variableName variables
                 staleNames'' =
                     Map.elems renaming
                         & foldMap FreeVariables.freeVariable

--- a/kore/src/Kore/Rewrite/RewritingVariable.hs
+++ b/kore/src/Kore/Rewrite/RewritingVariable.hs
@@ -256,7 +256,7 @@ resetResultPattern initial config@Conditional{substitution} =
             . FreeVariables.toSet
             $ freeVariables filtered
     renaming =
-        Map.mapKeys (fmap RuleVariableName)
+        Map.mapKeysMonotonic (fmap RuleVariableName)
             . Map.map (TermLike.mkVar . mkUnifiedConfigVariable)
             $ refreshVariablesSet avoiding introduced
     renamed :: Pattern RewritingVariableName

--- a/kore/src/Kore/Rewrite/Rule/Expand.hs
+++ b/kore/src/Kore/Rewrite/Rule/Expand.hs
@@ -131,7 +131,7 @@ instance ExpandSingleConstructors ClaimPattern where
                                 Substitution.toPredicate
                                     . from @(Map _ _) @(Substitution _)
                                     $ expansion
-                            subst = Map.mapKeys variableName expansion
+                            subst = Map.mapKeysMonotonic variableName expansion
                          in rule
                                 { left =
                                     Pattern.andCondition

--- a/kore/src/Kore/Rewrite/RulePattern.hs
+++ b/kore/src/Kore/Rewrite/RulePattern.hs
@@ -593,7 +593,7 @@ instance UnifyingRule (RulePattern variable) where
         refreshVariables' variables = do
             staleNames <- State.get
             let renaming = refreshVariablesSet staleNames variables
-                staleNames' = Set.map variableName variables
+                staleNames' = Set.mapMonotonic variableName variables
                 staleNames'' =
                     Map.elems renaming
                         & foldMap FreeVariables.freeVariable

--- a/kore/src/Kore/Syntax/Variable.hs
+++ b/kore/src/Kore/Syntax/Variable.hs
@@ -257,6 +257,9 @@ The @variable@ parameter is the type of variable names.
 Every occurrence of a variable carries the 'Sort' of the variable.
 -}
 data Variable variable = Variable
+    -- Note: we sometimes use mapKeysMonotonic with variableName, so
+    -- any changes to this representation may require modifications to
+    -- those use sites.
     { variableName :: !variable
     , variableSort :: !Sort
     }

--- a/kore/src/Kore/Unification/NewUnifier.hs
+++ b/kore/src/Kore/Unification/NewUnifier.hs
@@ -1103,10 +1103,10 @@ makeAcSubstitution ::
     Map (SomeVariable RewritingVariableName) AcTerm
 makeAcSubstitution sort vars basis =
     Map.fromDistinctAscList
-      [ (ui, acTerm)
-      | (i, ui) <- zip [0..] (Set.toAscList vars)
-      , let !acTerm = makeAcSubstitutionTerm sort basis i
-      ]
+        [ (ui, acTerm)
+        | (i, ui) <- zip [0 ..] (Set.toAscList vars)
+        , let !acTerm = makeAcSubstitutionTerm sort basis i
+        ]
 
 makeAcSubstitutionTerm ::
     Sort ->

--- a/kore/src/Kore/Unification/NewUnifier.hs
+++ b/kore/src/Kore/Unification/NewUnifier.hs
@@ -21,7 +21,6 @@ module Kore.Unification.NewUnifier (
     -- exported for debugging and testing
     solveDiophantineEquations,
     allSuitableSolutions',
-    combine,
 ) where
 
 import Control.Monad.State.Strict (
@@ -52,9 +51,6 @@ import Data.IntSet (
     IntSet,
  )
 import Data.IntSet qualified as IntSet
-import Data.List (
-    elemIndex,
- )
 import Data.Map.Strict (
     Map,
  )
@@ -216,36 +212,21 @@ data Binding
 
 type NewUnifier a = LogicT (StateT (HashMap (TermLike RewritingVariableName) (OrPattern RewritingVariableName)) Simplifier) a
 
-fromFree :: Binding -> TermLike RewritingVariableName
-fromFree (Free a) = a
-fromFree (Ac _) = error "fromFree"
+fromFree :: Binding -> Maybe (TermLike RewritingVariableName)
+fromFree (Free a) = Just a
+fromFree (Ac _) = Nothing
 
-fromAc :: Binding -> AcTerm
-fromAc (Ac a) = a
-fromAc (Free _) = error "fromAc"
-
-isFree :: Binding -> Bool
-isFree (Free _) = True
-isFree (Ac _) = False
-
-isAc :: Binding -> Bool
-isAc (Ac _) = True
-isAc (Free _) = False
+fromAc :: Binding -> Maybe AcTerm
+fromAc (Ac a) = Just a
+fromAc (Free _) = Nothing
 
 isVar :: TermLike RewritingVariableName -> Bool
 isVar (ElemVar_ _) = True
 isVar _ = False
 
-elemVar :: TermLike RewritingVariableName -> SomeVariable RewritingVariableName
-elemVar (ElemVar_ var) = inject var
-elemVar _ = error "elemVar"
-
-combine :: [[a]] -> [[a]]
-combine [] = []
-combine [x] = map (: []) x
-combine (x : xs) =
-    let combined = combine xs
-     in [a : as | a <- x, as <- combined]
+elemVar :: TermLike RewritingVariableName -> Either (TermLike RewritingVariableName) (SomeVariable RewritingVariableName)
+elemVar (ElemVar_ var) = Right $! inject var
+elemVar not_var = Left not_var
 
 union :: HasCallStack => Ord k => Map k v -> Map k v -> Map k v
 union m1 m2 = Map.unionWith (error "duplicate binding") m1 m2
@@ -303,7 +284,7 @@ combineTheories ::
     NewUnifier ([(TermLike RewritingVariableName, TermLike RewritingVariableName)], Map (SomeVariable RewritingVariableName) Binding)
 combineTheories acBindings freeBindings origVars = do
     let withoutPureImproperBindings = map (map preprocessTheory) acBindings
-        combinations = combine withoutPureImproperBindings
+        combinations = sequence withoutPureImproperBindings
     solution <- Logic.scatter combinations
     return $ varRep (freeBindings : solution) Map.empty [] origVars
   where
@@ -383,7 +364,7 @@ unifyTerms ::
     SideCondition RewritingVariableName ->
     NewUnifier (Condition RewritingVariableName)
 unifyTerms first second sideCondition =
-    let vars = Set.map variableName $ FreeVariables.toSet $ freeVariables (first, second)
+    let vars = Set.fromDistinctAscList $ map variableName $ FreeVariables.toList $ freeVariables (first, second)
      in unifyTerms' (termLikeSort first) sideCondition vars vars [(first, second)] Map.empty Condition.topCondition Map.empty
 
 unifyTerms' ::
@@ -399,9 +380,9 @@ unifyTerms' ::
     NewUnifier (Condition RewritingVariableName)
 unifyTerms' rootSort _ origVars _ [] bindings constraints acEquations
     | Map.null acEquations = do
-        let freeBindings = Map.map fromFree $ Map.filter isFree bindings
+        let freeBindings = Map.mapMaybe fromFree bindings
             (origBindings, acVarBindings) = Map.partitionWithKey isOrigVar freeBindings
-            acVarSubst = Map.mapKeys variableName acVarBindings
+            acVarSubst = Map.mapKeysMonotonic variableName acVarBindings
             finalBindings = Map.map (substitute acVarSubst) origBindings
         case normalize finalBindings of
             Nothing -> empty
@@ -416,7 +397,7 @@ unifyTerms' rootSort _ origVars _ [] bindings constraints acEquations
 unifyTerms' rootSort sideCondition origVars vars [] bindings constraints acEquations = do
     tools <- askMetadataTools
     let (acSolutions, newVars) = Map.foldrWithKey' (solveAcEquations' tools) (Map.empty, vars) acEquations
-        freeBindings = Map.map fromFree $ Map.filter isFree bindings
+        freeBindings = Map.mapMaybe fromFree bindings
     (newEqs, newBindings) <- combineTheories (Map.elems acSolutions) freeBindings origVars
     unifyTerms' rootSort sideCondition origVars newVars newEqs newBindings constraints Map.empty
   where
@@ -593,14 +574,14 @@ unifyTerms' rootSort sideCondition origVars vars ((first, second) : rest) bindin
                         | List.isSymbolConcat symbol1
                           , List.isSymbolConcat symbol2 ->
                             let (l1', var1', l2', var2') = if length l1 <= length l2 then (l1, var1, l2, var2) else (l2, var2, l1, var1)
-                                left = Seq.drop (length l1') l2'
-                             in decomposeList $ (var1', mkApplySymbol symbol1 [List.asInternal tools sort left, var2']) : zip (toList l1') (toList (Seq.take (length l1') l2'))
+                                (start, left) = Seq.splitAt (length l1') l2'
+                             in decomposeList $ (var1', mkApplySymbol symbol1 [List.asInternal tools sort left, var2']) : zip (toList l1') (toList start)
                     (App_ symbol1 [var1@(ElemVar_ _), InternalList_ InternalList{internalListChild = l1}], App_ symbol2 [var2@(ElemVar_ _), InternalList_ InternalList{internalListChild = l2}])
                         | List.isSymbolConcat symbol1
                           , List.isSymbolConcat symbol2 ->
                             let (l1', var1', l2', var2') = if length l1 <= length l2 then (l1, var1, l2, var2) else (l2, var2, l1, var1)
-                                left = Seq.take (length l2' - length l1') l2'
-                             in decomposeList $ (var1', mkApplySymbol symbol1 [var2', List.asInternal tools sort left]) : zip (toList l1') (toList (Seq.drop (length l2' - length l1') l2'))
+                                (left, end) = Seq.splitAt (length l2' - length l1') l2'
+                             in decomposeList $ (var1', mkApplySymbol symbol1 [var2', List.asInternal tools sort left]) : zip (toList l1') (toList end)
                     (InternalList_ InternalList{internalListChild = l1}, InternalList_ InternalList{internalListChild = l2}) ->
                         if length l1 == length l2
                             then decomposeList $ zip (toList l1) (toList l2)
@@ -609,29 +590,29 @@ unifyTerms' rootSort sideCondition origVars vars ((first, second) : rest) bindin
                         | List.isSymbolConcat symbol ->
                             if length l2 <= length l1
                                 then
-                                    let l1' = Seq.drop (length l2) l1
-                                     in decomposeList $ (List.asInternal tools sort l1', var) : zip (toList (Seq.take (length l2) l1)) (toList l2)
+                                    let (start, l1') = Seq.splitAt (length l2) l1
+                                     in decomposeList $ (List.asInternal tools sort l1', var) : zip (toList start) (toList l2)
                                 else failUnify "Lists of different length"
                     (App_ symbol [InternalList_ InternalList{internalListChild = l1}, var@(ElemVar_ _)], InternalList_ InternalList{internalListChild = l2})
                         | List.isSymbolConcat symbol ->
                             if length l1 <= length l2
                                 then
-                                    let l2' = Seq.drop (length l1) l2
-                                     in decomposeList $ (var, List.asInternal tools sort l2') : zip (toList l1) (toList (Seq.take (length l1) l2))
+                                    let (start, l2') = Seq.splitAt (length l1) l2
+                                     in decomposeList $ (var, List.asInternal tools sort l2') : zip (toList l1) (toList start)
                                 else failUnify "Lists of different length"
                     (InternalList_ InternalList{internalListChild = l1}, App_ symbol [var@(ElemVar_ _), InternalList_ InternalList{internalListChild = l2}])
                         | List.isSymbolConcat symbol ->
                             if length l2 <= length l1
                                 then
-                                    let l1' = Seq.take (length l1 - length l2) l1
-                                     in decomposeList $ (List.asInternal tools sort l1', var) : zip (toList (Seq.drop (length l1 - length l2) l1)) (toList l2)
+                                    let (l1', end) = Seq.splitAt (length l1 - length l2) l1
+                                     in decomposeList $ (List.asInternal tools sort l1', var) : zip (toList end) (toList l2)
                                 else failUnify "Lists of different length"
                     (App_ symbol [var@(ElemVar_ _), InternalList_ InternalList{internalListChild = l1}], InternalList_ InternalList{internalListChild = l2})
                         | List.isSymbolConcat symbol ->
                             if length l1 <= length l2
                                 then
-                                    let l2' = Seq.take (length l2 - length l1) l2
-                                     in decomposeList $ (var, List.asInternal tools sort l2') : zip (toList l1) (toList (Seq.drop (length l2 - length l1) l2))
+                                    let (l2', end) = Seq.splitAt (length l2 - length l1) l2
+                                     in decomposeList $ (var, List.asInternal tools sort l2') : zip (toList l1) (toList end)
                                 else failUnify "Lists of different length"
                     (_, _) -> constrainEquals first second
             -- in theory we could now implement these cases as simplification rules
@@ -775,7 +756,7 @@ unifyTerms' rootSort sideCondition origVars vars ((first, second) : rest) bindin
         TermLike RewritingVariableName ->
         NewUnifier (TermLike RewritingVariableName, Condition RewritingVariableName)
     substAndSimplify constraints' term = do
-        let currentSubstitution = Map.mapKeys variableName $ Map.map fromFree $ Map.filter isFree bindings
+        let currentSubstitution = Map.mapKeysMonotonic variableName $ Map.mapMaybe fromFree bindings
             substituted = substitute currentSubstitution term
         if substituted /= term
             then do
@@ -823,9 +804,10 @@ unifyTerms' rootSort sideCondition origVars vars ((first, second) : rest) bindin
             } =
             let normalElementsWithVariables = map getMapElement elementsWithVariables
                 normalConcreteElements = map normalizeConcreteMapElement $ HashMap.toList concreteElements
-                variables = MultiSet.fromList $ map elemVar $ filter isVar opaque
-                functions = MultiSet.fromList $ filter (not . isVar) opaque
-                elements = Set.map (reconstructMapElement element) $ Set.fromList $ normalElementsWithVariables ++ normalConcreteElements
+                (!variables, !functions) = (MultiSet.fromList vrs, MultiSet.fromList fns)
+                  where
+                    (fns, vrs) = partitionEithers (map elemVar opaque)
+                elements = Set.fromList $ map (reconstructMapElement element) $ normalElementsWithVariables ++ normalConcreteElements
              in AcCollection{elements, variables, functions}
 
     reconstructMapElement element (key, val) = mkApplySymbol element [key, val]
@@ -844,9 +826,10 @@ unifyTerms' rootSort sideCondition origVars vars ((first, second) : rest) bindin
             } =
             let normalElementsWithVariables = map getSetElement elementsWithVariables
                 normalConcreteElements = map normalizeConcreteSetElement $ HashMap.toList concreteElements
-                variables = MultiSet.fromList $ map elemVar $ filter isVar opaque
-                functions = MultiSet.fromList $ filter (not . isVar) opaque
-                elements = Set.map (reconstructSetElement element) $ Set.fromList $ normalElementsWithVariables ++ normalConcreteElements
+                (!variables, !functions) = (MultiSet.fromList vrs, MultiSet.fromList fns)
+                  where
+                    (fns, vrs) = partitionEithers (map elemVar opaque)
+                elements = Set.fromList $ map (reconstructSetElement element) $ normalElementsWithVariables ++ normalConcreteElements
              in AcCollection{elements, variables, functions}
 
     reconstructSetElement element key = mkApplySymbol element [key]
@@ -947,27 +930,28 @@ solveAcEquations ::
     [AcEquation] ->
     ([Map (SomeVariable RewritingVariableName) (TermLike RewritingVariableName)], Set (SomeVariableName RewritingVariableName))
 solveAcEquations tools bindings vars sort [] =
-    let acBindings = Map.filter (\acTerm -> acSort acTerm == sort) $ Map.map fromAc $ Map.filter isAc bindings
-     in ([Map.map (remakeMapTerms tools) acBindings], vars)
+    let acBindings = Map.mapMaybe (fromAc >=> \acTerm -> remakeMapTerms tools acTerm <$ guard (acSort acTerm == sort)) bindings
+     in ([acBindings], vars)
 solveAcEquations tools bindings vars sort acEquations =
-    let newAcEquations = map (substituteAcVars bindings) acEquations
+    let newAcEquations = Vector.fromList (map (substituteAcVars bindings) acEquations)
         p = length newAcEquations
         u = acVars newAcEquations
-        n = length u
-        constrainedVars = foldr unionConstrainedVars Set.empty acEquations
-        constrainedIndices = IntSet.fromDistinctAscList $ map fromJust $ Set.toAscList $ Set.map (flip elemIndex $ map variableName u) constrainedVars
-        system = Matrix.matrix p n (defect' newAcEquations u)
+        u_vec = Vector.fromListN (Set.size u) (Set.toList u)
+        n = Set.size u
+        constrainedVars = foldl' unionConstrainedVars Set.empty acEquations
+        constrainedIndices = IntSet.fromList $ map (flip Set.findIndex $ Set.mapMonotonic variableName u) (Set.toAscList constrainedVars)
+        system = Matrix.matrix p n (defect' newAcEquations u_vec)
         solved = solveDiophantineEquations system
         (newVars, vars') = mkVars sort (length solved) [] vars
         basis = zip solved newVars
         suitable = allSuitableSolutions basis constrainedIndices n
-        acSubst = map (makeAcSubstitution sort 0 u) suitable
-        acBindings = Map.filter (\acTerm -> acSort acTerm == sort) $ Map.map fromAc $ Map.filter isAc bindings
+        acSubst = map (makeAcSubstitution sort u) suitable
+        acBindings = Map.mapMaybe (fromAc >=> \acTerm -> acTerm <$ guard (acSort acTerm == sort)) bindings
         allAcBindings = map (union acBindings) acSubst
      in (map (Map.map (remakeMapTerms tools)) allAcBindings, vars')
   where
-    defect' eqs u (i, j) = defect (eqs !! (i - 1)) (u !! (j - 1))
-    unionConstrainedVars (AcEquation AcTerm{elementVars = elementVars1} AcTerm{elementVars = elementVars2}) set = Set.union set $ Set.union elementVars1 elementVars2
+    defect' eqs u_vec (i, j) = defect (eqs ! (i - 1)) (u_vec ! (j - 1))
+    unionConstrainedVars set (AcEquation AcTerm{elementVars = elementVars1} AcTerm{elementVars = elementVars2}) = Set.union set $ Set.union elementVars1 elementVars2
 
 allSuitableSolutions ::
     [(Vector Int, ElementVariable RewritingVariableName)] ->
@@ -988,10 +972,10 @@ allSuitableSolutions' ::
 allSuitableSolutions' basis constrained n =
     let legal = foldl' makeLegal BDD.true [0 .. n - 1]
         maximal = foldl' (makeMaximal legal) legal indexedBasis
-        sat = BDD.allSatComplete (IntSet.fromDistinctAscList [0 .. length basis - 1]) maximal
+        sat = BDD.allSatComplete (IntSet.fromDistinctAscList (zipWith const [0 ..] basis)) maximal
      in map toSolution sat
   where
-    indexedBasis = zip basis [0 .. length basis - 1]
+    indexedBasis = zipWith (flip (,)) [0 ..] basis -- The flip is for list fusion
     nonNullBasis i = filter (\v -> fst v ! i /= 0) indexedBasis
     toSolution ::
         IntMap Bool ->
@@ -1051,14 +1035,12 @@ remakeMapTerms tools AcTerm{acElements, acSort} =
     normalizedAc opaque = NormalizedAc{elementsWithVariables = [], concreteElements = HashMap.empty, opaque}
 
 acVars ::
-    [AcEquation] ->
-    [SomeVariable RewritingVariableName]
-acVars [] = []
-acVars eqs = go eqs Set.empty
+    Vector AcEquation ->
+    Set (SomeVariable RewritingVariableName)
+acVars = foldl' go Set.empty
   where
-    go [] set = Set.toList set
-    go (AcEquation term1 term2 : eqs') set =
-        go eqs' $ collectAcVars term1 $ collectAcVars term2 set
+    go set (AcEquation term1 term2) =
+        collectAcVars term1 $ collectAcVars term2 set
     collectAcVars AcTerm{acElements} set =
         Set.union set (Set.fromList acElements)
 
@@ -1080,14 +1062,13 @@ solveDiophantineEquations system =
      in Set.toList $ computeStep vk (makeMk vk)
   where
     m = Matrix.ncols system
-    n = Matrix.nrows system
     v1 :: Int -> Set (Vector Int)
     v1 0 = Set.empty
     v1 i = Set.insert (e i) $ v1 (i - 1)
     e :: Int -> Vector Int
     e i = Vector.generate m (\j -> if j + 1 == i then 1 else 0)
     makeMk :: Set (Vector Int) -> Set (Vector Int)
-    makeMk vk = Set.filter (\v -> defect' v == Vector.replicate n 0) vk
+    makeMk vk = Set.filter (all (== 0) . defect') vk
     defect' :: Vector Int -> Vector Int
     defect' v = Matrix.getCol 1 $ Matrix.multStd system $ Matrix.colVector v
 
@@ -1117,14 +1098,15 @@ solveDiophantineEquations system =
 
 makeAcSubstitution ::
     Sort ->
-    Int ->
-    [SomeVariable RewritingVariableName] ->
+    Set (SomeVariable RewritingVariableName) ->
     [(Vector Int, ElementVariable RewritingVariableName)] ->
     Map (SomeVariable RewritingVariableName) AcTerm
-makeAcSubstitution _ _ [] _ = Map.empty
-makeAcSubstitution sort i (ui : u) basis =
-    let acTerm = makeAcSubstitutionTerm sort basis i
-     in Map.insert ui acTerm $ makeAcSubstitution sort (i + 1) u basis
+makeAcSubstitution sort vars basis =
+    Map.fromDistinctAscList
+      [ (ui, acTerm)
+      | (i, ui) <- zip [0..] (Set.toAscList vars)
+      , let !acTerm = makeAcSubstitutionTerm sort basis i
+      ]
 
 makeAcSubstitutionTerm ::
     Sort ->

--- a/kore/src/Kore/Variables/Fresh.hs
+++ b/kore/src/Kore/Variables/Fresh.hs
@@ -265,7 +265,7 @@ refreshVariables ::
     Map variable (Variable variable)
 refreshVariables avoid variables =
     let (_, refreshed) = refreshVariables' avoid variables
-     in Map.mapKeys variableName refreshed
+     in Map.mapKeysMonotonic variableName refreshed
 
 refreshVariablesSet ::
     FreshName variable =>

--- a/kore/test/Test/Kore/Internal/MultiExists.hs
+++ b/kore/test/Test/Kore/Internal/MultiExists.hs
@@ -33,7 +33,7 @@ test_refresh :: [TestTree]
 test_refresh =
     [ testCase "refresh relevant variables" $ do
         let input = quantify x (unquantified $ mkElemVar x)
-            avoid = (Set.map (inject . variableName) . Set.fromList) [x]
+            avoid = Set.singleton . inject . variableName $ x
             actual = refresh avoid input
             expect = quantify x' (unquantified $ mkElemVar x')
         assertEqual "" expect actual


### PR DESCRIPTION
* Use `sequence` instead of a custom `combine` function to take repeated Cartesian products.
* Use `partitionEithers` rather than filtering and mapping to avoid using partial functions unnecessarily and to (potentially) collect some garbage more eagerly.

Fixes #nnnn

### Scope:

### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [x] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [x] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [x] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [x] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
