### PR TITLE
Clean up some Template Haskell quoting

### DIFF
--- a/kore/src/Kore/Log/DecidePredicateUnknown.hs
+++ b/kore/src/Kore/Log/DecidePredicateUnknown.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TemplateHaskellQuotes #-}
 {-# LANGUAGE NoStrict #-}
 {-# LANGUAGE NoStrictData #-}
 
@@ -29,9 +29,9 @@ import Kore.Internal.Predicate (
  )
 import Kore.Internal.Predicate qualified as Predicate
 import Kore.Internal.Variable
-import Language.Haskell.TH.Syntax (Exp, Lift (lift), Loc (..), Q, qLocation)
+import Language.Haskell.TH.Syntax (Exp, Loc (..), Q, qLocation)
 import Log
-import Prelude.Kore hiding (lift)
+import Prelude.Kore
 import Pretty (
     Pretty (..),
  )
@@ -45,17 +45,10 @@ data OnDecidePredicateUnknown
 
 liftLoc :: Loc -> Q Exp
 liftLoc (Loc a b c (d1, d2) (e1, e2)) =
-    [|
-        Loc
-            $(lift a)
-            $(lift b)
-            $(lift c)
-            ($(lift d1), $(lift d2))
-            ($(lift e1), $(lift e2))
-        |]
+    [|Loc a b c (d1, d2) (e1, e2)|]
 
 srcLoc :: Q Exp
-srcLoc = [|$(qLocation >>= liftLoc)|]
+srcLoc = qLocation >>= liftLoc
 
 data DecidePredicateUnknown = DecidePredicateUnknown
     { action :: OnDecidePredicateUnknown


### PR DESCRIPTION
* Use quoting sugar fully to avoid manual lifts.
* Remove redundant quoting.
* Use `TemplateHaskellQuotes` instead of `TemplateHaskell` where it is sufficient.

Fixes #nnnn

### Scope:

### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
