### PR TITLE
Stop using msplit

### DIFF
--- a/kore/src/Kore/Unification/UnifierT.hs
+++ b/kore/src/Kore/Unification/UnifierT.hs
@@ -12,6 +12,7 @@ module Kore.Unification.UnifierT (
     module Kore.Unification.Unify,
 ) where
 
+import Control.Monad.Logic.Class qualified as LC
 import Control.Monad.Reader (
     MonadReader (..),
  )
@@ -56,6 +57,7 @@ instance MonadTrans UnifierT where
 
 deriving newtype instance MonadLog m => MonadLog (UnifierT m)
 
+deriving newtype instance Monad m => LC.MonadLogic (UnifierT m)
 deriving newtype instance Monad m => MonadLogic (UnifierT m)
 
 deriving newtype instance

--- a/kore/src/Logic.hs
+++ b/kore/src/Logic.hs
@@ -15,14 +15,15 @@ module Logic (
 import Control.Applicative
 import Control.Monad
 import Control.Monad.Logic hiding (MonadLogic)
-import qualified Control.Monad.Logic as LC
+import Control.Monad.Logic qualified as LC
 import Control.Monad.Reader (ReaderT (..))
 import Control.Monad.Trans
 import Prelude
 
--- | A version of
--- @"Control.Monad.Logic".'Control.Monad.Logic.MonadLogic'@
--- augmented with an efficient 'gather' method.
+{- | A version of
+ @"Control.Monad.Logic".'Control.Monad.Logic.MonadLogic'@
+ augmented with an efficient 'gather' method.
+-}
 class LC.MonadLogic m => MonadLogic m where
     -- Gather all the results of a logic computation within
     -- a logic computation.


### PR DESCRIPTION
`Control.Monad.Logic.msplit` is well known to be slow. See, most notably, the [Reflection without Remorse](https://okmij.org/ftp/Haskell/zseq.pdf) paper. Use a custom variant of `MonadLogic` with a `gather` method to avoid needing it. The `ReaderT` and `LogicT` instances (at least) can be written to avoid the expensive "reflection" where the rest of the computation is rebuilt after each element is produced.

Fixes #nnnn

### Scope:

### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
