### PR TITLE
Monomorphization of Simplifier, leg #3

### DIFF
--- a/kore/src/Kore/Builtin/Map.hs
+++ b/kore/src/Kore/Builtin/Map.hs
@@ -753,7 +753,7 @@ unifyNotInKeys resultSort unifyChildren (NotSimplifier notSimplifier) unifyData 
         TermLike RewritingVariableName ->
         unifier (Condition RewritingVariableName)
     defineTerm term =
-        makeEvaluateTermCeil SideCondition.topTODO term
+        liftSimplifier (makeEvaluateTermCeil SideCondition.topTODO term)
             >>= Unify.scatter
 
     eraseTerm =

--- a/kore/src/Kore/Rewrite/Function/Evaluator.hs
+++ b/kore/src/Kore/Rewrite/Function/Evaluator.hs
@@ -379,7 +379,7 @@ maybeEvaluatePattern
             | toSimplify == unchangedPatt =
                 return (OrPattern.fromPattern unchangedPatt)
             | otherwise =
-                simplifyPattern sideCondition toSimplify
+                liftSimplifier $ simplifyPattern sideCondition toSimplify
 
 evaluateSortInjection ::
     InternalVariable variable =>

--- a/kore/src/Kore/Simplify/AndTerms.hs
+++ b/kore/src/Kore/Simplify/AndTerms.hs
@@ -745,8 +745,9 @@ overloadedConstructorSortInjectionAndEquals termMerger unifyData =
                 ) -> do
                 boundPattern <- do
                     merged <- termMerger firstTerm' secondTerm'
-                    liftSimplifier $ Exists.makeEvaluate SideCondition.topTODO narrowingVars $
-                        merged `Pattern.andCondition` narrowingSubst
+                    liftSimplifier $
+                        Exists.makeEvaluate SideCondition.topTODO narrowingVars $
+                            merged `Pattern.andCondition` narrowingSubst
                 case OrPattern.toPatterns boundPattern of
                     [result] -> return result
                     [] ->

--- a/kore/src/Kore/Simplify/AndTerms.hs
+++ b/kore/src/Kore/Simplify/AndTerms.hs
@@ -451,7 +451,7 @@ bottomTermEquals
     unifyData =
         do
             -- MonadUnify
-            secondCeil <- makeEvaluateTermCeil sideCondition term
+            secondCeil <- liftSimplifier $ makeEvaluateTermCeil sideCondition term
             case toList secondCeil of
                 [] -> return (Pattern.topOf resultSort)
                 [Conditional{predicate = PredicateTrue, substitution}]
@@ -562,7 +562,7 @@ variableFunctionEquals
         do
             -- MonadUnify
             predicate <- do
-                resultOr <- makeEvaluateTermCeil SideCondition.topTODO term2
+                resultOr <- liftSimplifier $ makeEvaluateTermCeil SideCondition.topTODO term2
                 case toList resultOr of
                     [] ->
                         debugUnifyBottomAndReturnBottom
@@ -745,7 +745,7 @@ overloadedConstructorSortInjectionAndEquals termMerger unifyData =
                 ) -> do
                 boundPattern <- do
                     merged <- termMerger firstTerm' secondTerm'
-                    Exists.makeEvaluate SideCondition.topTODO narrowingVars $
+                    liftSimplifier $ Exists.makeEvaluate SideCondition.topTODO narrowingVars $
                         merged `Pattern.andCondition` narrowingSubst
                 case OrPattern.toPatterns boundPattern of
                     [result] -> return result

--- a/kore/src/Kore/Simplify/Ceil.hs
+++ b/kore/src/Kore/Simplify/Ceil.hs
@@ -221,7 +221,7 @@ newBuiltinCeilSimplifier ceilSort = CeilSimplifier $ \input ->
     case ceilChild input of
         InternalList_ internal -> do
             sideCondition <- Reader.ask
-            makeEvaluateInternalList ceilSort sideCondition internal
+            liftSimplifier $ makeEvaluateInternalList ceilSort sideCondition internal
         InternalMap_ internalMap -> do
             sideCondition <- Reader.ask
             makeEvaluateInternalMap ceilSort sideCondition internalMap
@@ -303,12 +303,10 @@ makeEvaluateInternalSet resultSort sideCondition internalSet =
     InternalAc{builtinAcSort} = internalSet
 
 makeEvaluateInternalList ::
-    forall simplifier.
-    MonadSimplify simplifier =>
     Sort ->
     SideCondition RewritingVariableName ->
     InternalList (TermLike RewritingVariableName) ->
-    simplifier NormalForm
+    Simplifier NormalForm
 makeEvaluateInternalList _ _ internal =
     return . NormalForm.fromPredicates $
         fromCeil_ <$> toList internal

--- a/kore/src/Kore/Simplify/Equals.hs
+++ b/kore/src/Kore/Simplify/Equals.hs
@@ -209,13 +209,15 @@ simplifyEvaluated sort sideCondition first second
                     liftSimplifier $ makeEvaluateFunctionalOr sideCondition secondP firstPatterns
             _
                 | OrPattern.isPredicate first && OrPattern.isPredicate second ->
-                    liftSimplifier $ Iff.simplifyEvaluated sort sideCondition first second
-                        & fmap (MultiOr.map Pattern.withoutTerm)
+                    liftSimplifier $
+                        Iff.simplifyEvaluated sort sideCondition first second
+                            & fmap (MultiOr.map Pattern.withoutTerm)
                 | otherwise ->
-                    liftSimplifier $ makeEvaluate
-                        (OrPattern.toPattern sort first)
-                        (OrPattern.toPattern sort second)
-                        sideCondition
+                    liftSimplifier $
+                        makeEvaluate
+                            (OrPattern.toPattern sort first)
+                            (OrPattern.toPattern sort second)
+                            sideCondition
   where
     firstPatterns = toList first
     secondPatterns = toList second

--- a/kore/src/Kore/Simplify/Iff.hs
+++ b/kore/src/Kore/Simplify/Iff.hs
@@ -52,10 +52,9 @@ Right now this has special cases only for top and bottom children
 and for children with top terms.
 -}
 simplify ::
-    MonadSimplify simplifier =>
     SideCondition RewritingVariableName ->
     Iff Sort (OrPattern RewritingVariableName) ->
-    simplifier (OrPattern RewritingVariableName)
+    Simplifier (OrPattern RewritingVariableName)
 simplify sideCondition Iff{iffFirst = first, iffSecond = second, iffSort = sort} =
     simplifyEvaluated sort sideCondition first second
 
@@ -78,12 +77,11 @@ carry around.
 
 -}
 simplifyEvaluated ::
-    MonadSimplify simplifier =>
     Sort ->
     SideCondition RewritingVariableName ->
     OrPattern RewritingVariableName ->
     OrPattern RewritingVariableName ->
-    simplifier (OrPattern RewritingVariableName)
+    Simplifier (OrPattern RewritingVariableName)
 simplifyEvaluated sort sideCondition first second
     | OrPattern.isTrue first = return second
     | OrPattern.isFalse first =

--- a/kore/src/Kore/Simplify/Implies.hs
+++ b/kore/src/Kore/Simplify/Implies.hs
@@ -54,10 +54,9 @@ Right now this uses the following simplifications:
 and it has a special case for children with top terms.
 -}
 simplify ::
-    MonadSimplify simplifier =>
     SideCondition RewritingVariableName ->
     Implies Sort (OrPattern RewritingVariableName) ->
-    simplifier (OrPattern RewritingVariableName)
+    Simplifier (OrPattern RewritingVariableName)
 simplify
     sideCondition
     Implies{impliesFirst = first, impliesSecond = second, impliesSort = sort} =
@@ -83,12 +82,11 @@ carry around.
 
 -}
 simplifyEvaluated ::
-    MonadSimplify simplifier =>
     Sort ->
     SideCondition RewritingVariableName ->
     OrPattern RewritingVariableName ->
     OrPattern RewritingVariableName ->
-    simplifier (OrPattern RewritingVariableName)
+    Simplifier (OrPattern RewritingVariableName)
 simplifyEvaluated sort sideCondition first second
     | OrPattern.isTrue first = return second
     | OrPattern.isFalse first = return (OrPattern.topOf sort)

--- a/kore/src/Kore/Simplify/Overloading.hs
+++ b/kore/src/Kore/Simplify/Overloading.hs
@@ -49,7 +49,7 @@ import Kore.Rewrite.RewritingVariable (
  )
 import Kore.Simplify.OverloadSimplifier
 import Kore.Simplify.Simplify as Simplifier (
-    MonadSimplify (..),
+    Simplifier,
     askOverloadSimplifier,
  )
 import Pair
@@ -133,9 +133,8 @@ throwBottom :: String -> Maybe MatchResult
 throwBottom = Just . ClashResult
 
 matchOverloading ::
-    MonadSimplify unifier =>
     Pair (TermLike RewritingVariableName) ->
-    MatchOverloadingResult unifier RewritingVariableName
+    MatchOverloadingResult Simplifier RewritingVariableName
 matchOverloading termPair = do
     overloadSimplifier <- askOverloadSimplifier
     case unifyOverloading overloadSimplifier termPair of

--- a/kore/src/Kore/Simplify/Pattern.hs
+++ b/kore/src/Kore/Simplify/Pattern.hs
@@ -46,6 +46,7 @@ import Kore.Rewrite.RewritingVariable (
 import Kore.Simplify.Simplify (
     MonadSimplify,
     Simplifier,
+    liftSimplifier,
     simplifyCondition,
     simplifyTerm,
  )
@@ -139,7 +140,7 @@ makeEvaluate sideCondition =
                         simplifiedCondition
                         sideCondition
             simplifiedTerm <-
-                simplifyTerm termSideCondition term'
+                liftSimplifier (simplifyTerm termSideCondition term')
                     >>= Logic.scatter
             let simplifiedPattern =
                     Conditional.andCondition simplifiedTerm simplifiedCondition

--- a/kore/src/Kore/Simplify/Pattern.hs
+++ b/kore/src/Kore/Simplify/Pattern.hs
@@ -45,6 +45,7 @@ import Kore.Rewrite.RewritingVariable (
  )
 import Kore.Simplify.Simplify (
     MonadSimplify,
+    Simplifier,
     simplifyCondition,
     simplifyTerm,
  )
@@ -65,9 +66,8 @@ simplifyTopConfiguration =
 and removes the exists quantifiers at the top.
 -}
 simplifyTopConfigurationDefined ::
-    MonadSimplify simplifier =>
     Pattern RewritingVariableName ->
-    simplifier (OrPattern RewritingVariableName)
+    Simplifier (OrPattern RewritingVariableName)
 simplifyTopConfigurationDefined configuration =
     maybe
         (return OrPattern.bottom)

--- a/kore/src/Kore/Simplify/Simplify.hs
+++ b/kore/src/Kore/Simplify/Simplify.hs
@@ -235,20 +235,18 @@ askMetadataTools :: MonadSimplify m => m (SmtMetadataTools Attribute.Symbol)
 askMetadataTools = liftSimplifier $ asks metadataTools
 
 simplifyPattern ::
-    MonadSimplify m =>
     SideCondition RewritingVariableName ->
     Pattern RewritingVariableName ->
-    m (OrPattern RewritingVariableName)
+    Simplifier (OrPattern RewritingVariableName)
 simplifyPattern sideCondition patt =
     liftSimplifier $ do
         simplifier <- asks simplifierPattern
         simplifier sideCondition patt
 
 simplifyTerm ::
-    MonadSimplify m =>
     SideCondition RewritingVariableName ->
     TermLike RewritingVariableName ->
-    m (OrPattern RewritingVariableName)
+    Simplifier (OrPattern RewritingVariableName)
 simplifyTerm sideCondition termLike =
     liftSimplifier $ do
         simplifier <- asks simplifierTerm
@@ -348,7 +346,7 @@ simplifyPatternScatter ::
     simplifier (Pattern RewritingVariableName)
 simplifyPatternScatter sideCondition patt =
     Logic.scatter
-        =<< simplifyPattern sideCondition patt
+        =<< liftSimplifier (simplifyPattern sideCondition patt)
 -- * Predicate simplifiers
 
 {- | 'ConditionSimplifier' wraps a function that simplifies
@@ -703,19 +701,17 @@ applicationAxiomSimplifier applicationSimplifier =
 
 -- | Checks whether a symbol is a constructor or is overloaded.
 isConstructorOrOverloaded ::
-    MonadSimplify unifier =>
     Symbol ->
-    unifier Bool
+    Simplifier Bool
 isConstructorOrOverloaded s =
     do
         OverloadSimplifier{isOverloaded} <- askOverloadSimplifier
         return (isConstructor s || isOverloaded s)
 
 makeEvaluateTermCeil ::
-    MonadSimplify simplifier =>
     SideCondition RewritingVariableName ->
     TermLike RewritingVariableName ->
-    simplifier (OrCondition RewritingVariableName)
+    Simplifier (OrCondition RewritingVariableName)
 makeEvaluateTermCeil sideCondition child =
     Predicate.makeCeilPredicate child
         & Condition.fromPredicate
@@ -723,11 +719,10 @@ makeEvaluateTermCeil sideCondition child =
         & OrCondition.observeAllT
 
 makeEvaluateCeil ::
-    MonadSimplify simplifier =>
     Sort ->
     SideCondition RewritingVariableName ->
     Pattern RewritingVariableName ->
-    simplifier (OrPattern RewritingVariableName)
+    Simplifier (OrPattern RewritingVariableName)
 makeEvaluateCeil sort sideCondition child =
     do
         let (childTerm, childCondition) = Pattern.splitTerm child

--- a/kore/src/Kore/Simplify/SubstitutionSimplifier.hs
+++ b/kore/src/Kore/Simplify/SubstitutionSimplifier.hs
@@ -85,6 +85,7 @@ import Kore.Rewrite.RewritingVariable (
  )
 import Kore.Simplify.Simplify (
     MonadSimplify,
+    Simplifier,
     simplifyPattern,
     simplifyPatternScatter,
  )
@@ -112,16 +113,14 @@ denormalized part into the predicate, but returns the normalized part as a
 substitution.
 -}
 substitutionSimplifier ::
-    forall simplifier.
-    MonadSimplify simplifier =>
-    SubstitutionSimplifier simplifier
+    SubstitutionSimplifier Simplifier
 substitutionSimplifier =
     SubstitutionSimplifier wrapper
   where
     wrapper ::
         SideCondition RewritingVariableName ->
         Substitution RewritingVariableName ->
-        simplifier (OrCondition RewritingVariableName)
+        Simplifier (OrCondition RewritingVariableName)
     wrapper sideCondition substitution =
         OrCondition.observeAllT $ do
             (predicate, result) <- worker substitution & maybeT empty return
@@ -146,7 +145,7 @@ newtype MakeAnd monad = MakeAnd
     }
 
 simplificationMakeAnd ::
-    MonadSimplify simplifier => MakeAnd (LogicT simplifier)
+    MakeAnd (LogicT Simplifier)
 simplificationMakeAnd =
     MakeAnd{makeAnd}
   where

--- a/kore/src/Kore/Simplify/SubstitutionSimplifier.hs
+++ b/kore/src/Kore/Simplify/SubstitutionSimplifier.hs
@@ -86,6 +86,7 @@ import Kore.Rewrite.RewritingVariable (
 import Kore.Simplify.Simplify (
     MonadSimplify,
     Simplifier,
+    liftSimplifier,
     simplifyPattern,
     simplifyPatternScatter,
  )
@@ -368,7 +369,7 @@ simplifySubstitutionWorker sideCondition makeAnd' = \substitution -> do
             simplifier
             (TermLike RewritingVariableName)
     simplifyTermLike termLike = do
-        orPattern <- simplifyPattern sideCondition (Pattern.fromTermLike termLike)
+        orPattern <- liftSimplifier $ simplifyPattern sideCondition (Pattern.fromTermLike termLike)
         case OrPattern.toPatterns orPattern of
             [] -> do
                 addCondition Condition.bottom

--- a/kore/src/Kore/Unification/NewUnifier.hs
+++ b/kore/src/Kore/Unification/NewUnifier.hs
@@ -176,6 +176,7 @@ import Kore.Simplify.Simplify (
     askInjSimplifier,
     askMetadataTools,
     askOverloadSimplifier,
+    liftSimplifier,
     simplifyTerm,
  )
 import Kore.Substitute
@@ -773,7 +774,7 @@ unifyTerms' rootSort sideCondition origVars vars ((first, second) : rest) bindin
         cache <- get
         case HashMap.lookup term cache of
             Nothing -> do
-                simplified <- simplifyTerm sideCondition term
+                simplified <- liftSimplifier $ simplifyTerm sideCondition term
                 let cache' = HashMap.insert term simplified cache
                 put cache'
                 return simplified

--- a/kore/src/Kore/Unification/Procedure.hs
+++ b/kore/src/Kore/Unification/Procedure.hs
@@ -33,6 +33,7 @@ import Kore.Rewrite.RewritingVariable (
  )
 import Kore.Simplify.Simplify (
     Simplifier,
+    liftSimplifier,
     makeEvaluateTermCeil,
     simplifyCondition,
  )
@@ -67,7 +68,7 @@ unificationProcedure sideCondition p1 p2
         TopBottom.guardAgainstBottom condition
         marker "unify" "MakeCeil"
         let term = unifiedTermAnd p1 p2 condition
-        orCeil <- makeEvaluateTermCeil sideCondition term
+        orCeil <- liftSimplifier $ makeEvaluateTermCeil sideCondition term
         marker "unify" "CombineCeil"
         ceil' <- Monad.Unify.scatter orCeil
         lowerLogicT . simplifyCondition sideCondition $

--- a/kore/test/Test/Kore/Builtin/Builtin.hs
+++ b/kore/test/Test/Kore/Builtin/Builtin.hs
@@ -214,8 +214,7 @@ verifyPattern expectedSort termLike =
 testMetadataTools :: SmtMetadataTools StepperAttributes
 testMetadataTools = MetadataTools.build verifiedModule
 
-testConditionSimplifier ::
-    MonadSimplify simplifier => ConditionSimplifier simplifier
+testConditionSimplifier :: ConditionSimplifier Simplifier
 testConditionSimplifier =
     Simplifier.Condition.create SubstitutionSimplifier.substitutionSimplifier
 
@@ -255,7 +254,7 @@ simplify =
         . runNoSMT
         . runSimplifier testEnv
         . Logic.observeAllT
-        . (simplifyTerm SideCondition.top >=> Logic.scatter)
+        . (liftSimplifier . simplifyTerm SideCondition.top >=> Logic.scatter)
 
 evaluateTerm ::
     TermLike RewritingVariableName ->

--- a/kore/test/Test/Kore/Rewrite/Function/Integration.hs
+++ b/kore/test/Test/Kore/Rewrite/Function/Integration.hs
@@ -1153,8 +1153,7 @@ Just verifiedModule = Map.lookup testModuleName verifiedModules
 testMetadataTools :: SmtMetadataTools Attribute.Symbol
 testMetadataTools = MetadataTools.build verifiedModule
 
-testConditionSimplifier ::
-    MonadSimplify simplifier => ConditionSimplifier simplifier
+testConditionSimplifier :: ConditionSimplifier Simplifier
 testConditionSimplifier =
     Simplifier.Condition.create SubstitutionSimplifier.substitutionSimplifier
 

--- a/kore/test/Test/Kore/Rewrite/MockSymbols.hs
+++ b/kore/test/Test/Kore/Rewrite/MockSymbols.hs
@@ -105,7 +105,7 @@ import Kore.Simplify.Pattern qualified as Pattern
 import Kore.Simplify.Simplify (
     ConditionSimplifier,
     Env (..),
-    MonadSimplify,
+    Simplifier,
  )
 import Kore.Simplify.SubstitutionSimplifier qualified as SubstitutionSimplifier
 import Kore.Simplify.TermLike qualified as TermLike
@@ -2286,8 +2286,7 @@ metadataTools =
 axiomEquations :: Map AxiomIdentifier [Equation RewritingVariableName]
 axiomEquations = Map.empty
 
-predicateSimplifier ::
-    MonadSimplify simplifier => ConditionSimplifier simplifier
+predicateSimplifier :: ConditionSimplifier Simplifier
 predicateSimplifier =
     Simplifier.Condition.create SubstitutionSimplifier.substitutionSimplifier
 


### PR DESCRIPTION
Work on https://github.com/runtimeverification/haskell-backend/issues/3325 (partially fixes this issue)
### Scope:
The 3rd leg of the Simplifier monomorphization.
Modules affected:
`Kore.Builtin.Map`
`Kore.Reachability.Claim`
`Kore.Rewrite.Function.Evaluator`
`Kore.Simplify.AndTerms`
`Kore.Simplify.Ceil`
`Kore.Simplify.Equals`
`Kore.Simplify.Exists`
`Kore.Simplify.Iff`
`Kore.Simplify.Implies`
`Kore.Simplify.OrPattern`
`Kore.Simplify.Overloading`
`Kore.Simplify.Pattern`
`Kore.Simplify.Predicate`
`Kore.Simplify.Simplify`
`Kore.Simplify.SubstitutionSimplifier`
`Kore.Unification.NewUnifier`
`Kore.Unification.Procedure`
### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
