### PR TITLE
Gather more efficiently

### DIFF
--- a/kore/src/Kore/Builtin/Builtin.hs
+++ b/kore/src/Kore/Builtin/Builtin.hs
@@ -118,9 +118,6 @@ import Kore.Simplify.Simplify (
     TermSimplifier,
     applicationAxiomSimplifier,
  )
-import Kore.Unification.Unify (
-    MonadUnify,
- )
 import Kore.Unification.Unify qualified as Unify
 import Kore.Unparser
 import Prelude.Kore
@@ -517,7 +514,7 @@ data UnifyEq = UnifyEq
 -- | Unification of @eq@ symbols
 unifyEq ::
     forall unifier.
-    MonadUnify unifier =>
+    Unify.MonadGather unifier =>
     TermSimplifier RewritingVariableName unifier ->
     NotSimplifier unifier ->
     UnifyEq ->

--- a/kore/src/Kore/Builtin/EqTerm.hs
+++ b/kore/src/Kore/Builtin/EqTerm.hs
@@ -52,7 +52,7 @@ This function is suitable only for equality simplification.
 -}
 unifyEqTerm ::
     forall unifier.
-    MonadUnify unifier =>
+    MonadGather unifier =>
     TermSimplifier RewritingVariableName unifier ->
     NotSimplifier unifier ->
     EqTerm (TermLike RewritingVariableName) ->

--- a/kore/src/Kore/Builtin/Map.hs
+++ b/kore/src/Kore/Builtin/Map.hs
@@ -712,7 +712,8 @@ matchUnifyNotInKeys first second
 
 unifyNotInKeys ::
     forall unifier.
-    MonadUnify unifier =>
+    Unify.MonadGather unifier =>
+    Unify.MonadUnify unifier =>
     Sort ->
     TermSimplifier RewritingVariableName unifier ->
     NotSimplifier unifier ->

--- a/kore/src/Kore/Internal/MultiOr.hs
+++ b/kore/src/Kore/Internal/MultiOr.hs
@@ -56,7 +56,7 @@ import Kore.Unparser (
 import Logic (
     Logic,
     LogicT,
-    MonadLogic,
+    MonadGather,
  )
 import Logic qualified
 import Prelude.Kore hiding (
@@ -246,7 +246,7 @@ mergeAll ::
     MultiOr term
 mergeAll = foldl' (<>) mempty
 
-gather :: (Ord a, TopBottom a, MonadLogic m) => m a -> m (MultiOr a)
+gather :: (Ord a, TopBottom a, MonadGather m) => m a -> m (MultiOr a)
 gather act = make <$> Logic.gather act
 {-# INLINE gather #-}
 

--- a/kore/src/Kore/Simplify/AndTerms.hs
+++ b/kore/src/Kore/Simplify/AndTerms.hs
@@ -102,6 +102,7 @@ the special cases handled by this.
 -}
 termUnification ::
     forall unifier.
+    MonadGather unifier =>
     MonadUnify unifier =>
     HasCallStack =>
     NotSimplifier unifier ->
@@ -135,6 +136,7 @@ termUnification notSimplifier = \term1 term2 ->
             & return
 
 maybeTermEquals ::
+    MonadGather unifier =>
     MonadUnify unifier =>
     HasCallStack =>
     NotSimplifier unifier ->
@@ -220,6 +222,7 @@ maybeTermEquals notSimplifier childTransformers first second = do
         | otherwise = empty
 
 maybeTermAnd ::
+    MonadGather unifier =>
     MonadUnify unifier =>
     HasCallStack =>
     NotSimplifier unifier ->

--- a/kore/src/Kore/Simplify/Equals.hs
+++ b/kore/src/Kore/Simplify/Equals.hs
@@ -70,10 +70,8 @@ import Kore.Simplify.Or qualified as Or (
 import Kore.Simplify.Simplify
 import Kore.Sort (sameSort)
 import Kore.Unification.UnifierT (
+    UnifierT,
     runUnifierT,
- )
-import Kore.Unification.Unify (
-    MonadUnify,
  )
 import Logic (
     LogicT,
@@ -428,20 +426,18 @@ termEqualsAnd p1 p2 =
             >>= Logic.scatter
 
     maybeTermEqualsWorker ::
-        forall unifier.
-        MonadUnify unifier =>
         TermLike RewritingVariableName ->
         TermLike RewritingVariableName ->
-        MaybeT unifier (Pattern RewritingVariableName)
+        MaybeT (UnifierT (LogicT Simplifier))
+               (Pattern RewritingVariableName)
+
     maybeTermEqualsWorker =
         maybeTermEquals Not.notSimplifier termEqualsAndWorker
 
     termEqualsAndWorker ::
-        forall unifier.
-        MonadUnify unifier =>
         TermLike RewritingVariableName ->
         TermLike RewritingVariableName ->
-        unifier (Pattern RewritingVariableName)
+        UnifierT (LogicT Simplifier) (Pattern RewritingVariableName)
     termEqualsAndWorker first second =
         scatterResults
             =<< runMaybeT (maybeTermEqualsWorker first second)

--- a/kore/src/Kore/Simplify/Equals.hs
+++ b/kore/src/Kore/Simplify/Equals.hs
@@ -428,8 +428,9 @@ termEqualsAnd p1 p2 =
     maybeTermEqualsWorker ::
         TermLike RewritingVariableName ->
         TermLike RewritingVariableName ->
-        MaybeT (UnifierT (LogicT Simplifier))
-               (Pattern RewritingVariableName)
+        MaybeT
+            (UnifierT (LogicT Simplifier))
+            (Pattern RewritingVariableName)
 
     maybeTermEqualsWorker =
         maybeTermEquals Not.notSimplifier termEqualsAndWorker

--- a/kore/src/Kore/Unification/SubstitutionSimplifier.hs
+++ b/kore/src/Kore/Unification/SubstitutionSimplifier.hs
@@ -65,6 +65,7 @@ uses 'Unifier.throwUnificationError'.
 -}
 substitutionSimplifier ::
     forall unifier.
+    MonadGather unifier =>
     MonadUnify unifier =>
     NotSimplifier unifier ->
     SubstitutionSimplifier unifier
@@ -101,6 +102,7 @@ substitutionSimplifier notSimplifier =
 
 unificationMakeAnd ::
     forall unifier.
+    MonadGather unifier =>
     MonadUnify unifier =>
     NotSimplifier unifier ->
     MakeAnd unifier

--- a/kore/src/Kore/Unification/UnifierT.hs
+++ b/kore/src/Kore/Unification/UnifierT.hs
@@ -12,6 +12,7 @@ module Kore.Unification.UnifierT (
     module Kore.Unification.Unify,
 ) where
 
+import Control.Monad.Logic.Class qualified as LC
 import Control.Monad.Reader (
     MonadReader (..),
  )
@@ -56,6 +57,7 @@ instance MonadTrans UnifierT where
 
 deriving newtype instance MonadLog m => MonadLog (UnifierT m)
 
+deriving newtype instance Monad m => LC.MonadLogic (UnifierT m)
 deriving newtype instance Monad m => MonadLogic (UnifierT m)
 
 deriving newtype instance

--- a/kore/src/Kore/Unification/UnifierT.hs
+++ b/kore/src/Kore/Unification/UnifierT.hs
@@ -12,7 +12,6 @@ module Kore.Unification.UnifierT (
     module Kore.Unification.Unify,
 ) where
 
-import Control.Monad.Logic.Class qualified as LC
 import Control.Monad.Reader (
     MonadReader (..),
  )
@@ -57,8 +56,8 @@ instance MonadTrans UnifierT where
 
 deriving newtype instance MonadLog m => MonadLog (UnifierT m)
 
-deriving newtype instance Monad m => LC.MonadLogic (UnifierT m)
 deriving newtype instance Monad m => MonadLogic (UnifierT m)
+deriving newtype instance Monad m => MonadGather (UnifierT m)
 
 deriving newtype instance
     MonadReader (ConditionSimplifier (UnifierT m)) (UnifierT m)

--- a/kore/src/Logic.hs
+++ b/kore/src/Logic.hs
@@ -6,7 +6,7 @@ module Logic (
     module Control.Monad.Logic,
     module Control.Monad.Trans,
     module Control.Monad,
-    MonadLogic (..),
+    MonadGather (..),
     scatter,
     mapLogicT,
     lowerLogicT,
@@ -14,16 +14,13 @@ module Logic (
 
 import Control.Applicative
 import Control.Monad
-import Control.Monad.Logic hiding (MonadLogic)
-import qualified Control.Monad.Logic as LC
+import Control.Monad.Logic
 import Control.Monad.Reader (ReaderT (..))
 import Control.Monad.Trans
 import Prelude
 
--- | A version of
--- @"Control.Monad.Logic".'Control.Monad.Logic.MonadLogic'@
--- augmented with an efficient 'gather' method.
-class LC.MonadLogic m => MonadLogic m where
+-- | A logic monad with an efficient 'gather' method.
+class MonadLogic m => MonadGather m where
     -- Gather all the results of a logic computation within
     -- a logic computation.
     --
@@ -35,11 +32,11 @@ class LC.MonadLogic m => MonadLogic m where
     -- @
     gather :: m a -> m [a]
 
-instance Monad m => MonadLogic (LogicT m) where
+instance Monad m => MonadGather (LogicT m) where
     gather m = lift (observeAllT m)
     {-# INLINE gather #-}
 
-instance MonadLogic m => MonadLogic (ReaderT e m) where
+instance MonadGather m => MonadGather (ReaderT e m) where
     gather m = ReaderT $ gather . runReaderT m
     {-# INLINE gather #-}
 

--- a/kore/test/Test/Kore/Unification/Unifier.hs
+++ b/kore/test/Test/Kore/Unification/Unifier.hs
@@ -168,6 +168,7 @@ data UnificationResult = UnificationResult
     }
 
 simplifyAnds ::
+    Monad.Unify.MonadGather unifier =>
     Monad.Unify.MonadUnify unifier =>
     NonEmpty (TermLike RewritingVariableName) ->
     unifier (Pattern RewritingVariableName)


### PR DESCRIPTION
`Control.Monad.Logic.msplit` is well known to be slow. See, most notably, the
[Reflection without Remorse](https://okmij.org/ftp/Haskell/zseq.pdf) paper. Use a custom variant of `MonadLogic` with a `gather` method to implement `gather` more efficiently.

Fixes #nnnn

### Scope:

### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
