### PR TITLE
Use a stricter version of AccumT

### DIFF
--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -203,6 +203,7 @@ library
   exposed-modules:
     Changed
     Control.Monad.Counter
+    Control.Monad.Trans.Accum.Stricter
     Data.Graph.TopologicalSort
     Data.InternedText
     Data.Limit

--- a/kore/src/Control/Monad/Trans/Accum/Stricter.hs
+++ b/kore/src/Control/Monad/Trans/Accum/Stricter.hs
@@ -1,19 +1,22 @@
-{-# LANGUAGE ImplicitPrelude #-}
 {-# LANGUAGE NoStrict #-}
 {-# LANGUAGE NoStrictData #-}
------------------------------------------------------------------------------
--- |
--- Module      :  Control.Monad.Trans.Accum.Stricter
--- Copyright   :  (c) Nickolay Kudasov 2016
--- License     :  BSD-style (see the file LICENSE)
---
--- Stability   :  experimental
--- Portability :  portable
---
--- A very strict version of @AccumT@, which accumulates its
--- state strictly.
+{-# LANGUAGE ImplicitPrelude #-}
+
 -----------------------------------------------------------------------------
 
+-----------------------------------------------------------------------------
+
+{- |
+ Module      :  Control.Monad.Trans.Accum.Stricter
+ Copyright   :  (c) Nickolay Kudasov 2016
+ License     :  BSD-style (see the file LICENSE)
+
+ Stability   :  experimental
+ Portability :  portable
+
+ A very strict version of @AccumT@, which accumulates its
+ state strictly.
+-}
 module Control.Monad.Trans.Accum.Stricter (
     -- * The Accum monad
     Accum,
@@ -22,17 +25,19 @@ module Control.Monad.Trans.Accum.Stricter (
     execAccum,
     evalAccum,
     mapAccum,
+
     -- * The AccumT monad transformer
-    AccumT(AccumT),
+    AccumT (AccumT),
     runAccumT,
     execAccumT,
     evalAccumT,
     mapAccumT,
+
     -- * Accum operations
     look,
     looks,
     add,
-  ) where
+) where
 
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
@@ -40,128 +45,140 @@ import Data.Functor.Identity
 
 import Control.Applicative
 import Control.Monad
-import qualified Control.Monad.Fail as Fail
+import Control.Monad.Fail qualified as Fail
 import Control.Monad.Fix
 import GHC.Generics (Generic)
 
 -- ---------------------------------------------------------------------------
--- | An accumulation monad parameterized by the type @w@ of output to accumulate.
---
--- The 'return' function produces the output 'mempty', while @>>=@
--- combines the outputs of the subcomputations using 'mappend'.
+
+{- | An accumulation monad parameterized by the type @w@ of output to accumulate.
+
+ The 'return' function produces the output 'mempty', while @>>=@
+ combines the outputs of the subcomputations using 'mappend'.
+-}
 type Accum w = AccumT w Identity
 
--- | Construct an accumulation computation from a (result, output) pair.
--- (The inverse of 'runAccum'.)
+{- | Construct an accumulation computation from a (result, output) pair.
+ (The inverse of 'runAccum'.)
+-}
 accum :: (Monad m) => (w -> (a, w)) -> AccumT w m a
 accum f = AccumT $ \ !w -> pure (f w)
 {-# INLINE accum #-}
 
--- | Unwrap an accumulation computation as a (result, output) pair.
--- (The inverse of 'accum'.)
+{- | Unwrap an accumulation computation as a (result, output) pair.
+ (The inverse of 'accum'.)
+-}
 runAccum :: Accum w a -> w -> (a, w)
 runAccum m = runIdentity . runAccumT m
 {-# INLINE runAccum #-}
 
--- | Extract the output from an accumulation computation.
---
--- * @'execAccum' m w = 'snd' ('runAccum' m w)@
+{- | Extract the output from an accumulation computation.
+
+ * @'execAccum' m w = 'snd' ('runAccum' m w)@
+-}
 execAccum :: Accum w a -> w -> w
 execAccum m w = snd (runAccum m w)
 {-# INLINE execAccum #-}
 
--- | Evaluate an accumulation computation with the given initial output history
--- and return the final value, discarding the final output.
---
--- * @'evalAccum' m w = 'fst' ('runAccum' m w)@
+{- | Evaluate an accumulation computation with the given initial output history
+ and return the final value, discarding the final output.
+
+ * @'evalAccum' m w = 'fst' ('runAccum' m w)@
+-}
 evalAccum :: Accum w a -> w -> a
 evalAccum m w = fst (runAccum m w)
 {-# INLINE evalAccum #-}
 
--- | Map both the return value and output of a computation using
--- the given function.
---
--- * @'runAccum' ('mapAccum' f m) = f . 'runAccum' m@
+{- | Map both the return value and output of a computation using
+ the given function.
+
+ * @'runAccum' ('mapAccum' f m) = f . 'runAccum' m@
+-}
 mapAccum :: ((a, w) -> (b, w)) -> Accum w a -> Accum w b
 mapAccum f = mapAccumT (Identity . f . runIdentity)
 {-# INLINE mapAccum #-}
 
 -- ---------------------------------------------------------------------------
--- | An accumulation monad parameterized by:
---
---   * @w@ - the output to accumulate.
---
---   * @m@ - The inner monad.
---
--- The 'return' function produces the output 'mempty', while @>>=@
--- combines the outputs of the subcomputations using 'mappend'.
---
--- This monad transformer is similar to both state and writer monad transformers.
--- Thus it can be seen as
---
---  * a restricted append-only version of a state monad transformer or
---
---  * a writer monad transformer with the extra ability to read all previous output.
+
+{- | An accumulation monad parameterized by:
+
+   * @w@ - the output to accumulate.
+
+   * @m@ - The inner monad.
+
+ The 'return' function produces the output 'mempty', while @>>=@
+ combines the outputs of the subcomputations using 'mappend'.
+
+ This monad transformer is similar to both state and writer monad transformers.
+ Thus it can be seen as
+
+  * a restricted append-only version of a state monad transformer or
+
+  * a writer monad transformer with the extra ability to read all previous output.
+-}
 newtype AccumT w m a = AccumT (w -> m (a, w))
-    deriving stock Generic
+    deriving stock (Generic)
 
 -- | Unwrap an accumulation computation.
 runAccumT :: AccumT w m a -> w -> m (a, w)
 runAccumT (AccumT f) = f
 {-# INLINE runAccumT #-}
 
--- | Extract the output from an accumulation computation.
---
--- * @'execAccumT' m w = 'liftM' 'snd' ('runAccumT' m w)@
+{- | Extract the output from an accumulation computation.
+
+ * @'execAccumT' m w = 'liftM' 'snd' ('runAccumT' m w)@
+-}
 execAccumT :: (Monad m) => AccumT w m a -> w -> m w
 execAccumT m w = do
     (_, !w') <- runAccumT m w
     pure w'
 {-# INLINE execAccumT #-}
 
--- | Evaluate an accumulation computation with the given initial output history
--- and return the final value, discarding the final output.
---
--- * @'evalAccumT' m w = 'liftM' 'fst' ('runAccumT' m w)@
+{- | Evaluate an accumulation computation with the given initial output history
+ and return the final value, discarding the final output.
+
+ * @'evalAccumT' m w = 'liftM' 'fst' ('runAccumT' m w)@
+-}
 evalAccumT :: Monad m => AccumT w m a -> w -> m a
 evalAccumT m w = do
     (a, _) <- runAccumT m w
     pure a
 {-# INLINE evalAccumT #-}
 
--- | Map both the return value and output of a computation using
--- the given function.
---
--- * @'runAccumT' ('mapAccumT' f m) = f . 'runAccumT' m@
---
--- This function does not itself force either initial or result
--- accumulators!
+{- | Map both the return value and output of a computation using
+ the given function.
+
+ * @'runAccumT' ('mapAccumT' f m) = f . 'runAccumT' m@
+
+ This function does not itself force either initial or result
+ accumulators!
+-}
 mapAccumT :: (m (a, w) -> n (b, w)) -> AccumT w m a -> AccumT w n b
 mapAccumT f m = AccumT (f . runAccumT m)
 {-# INLINE mapAccumT #-}
 
 instance Monad m => Functor (AccumT w m) where
-    fmap f = mapAccumT  (>>= \ (a, !w) -> pure (f a, w))
+    fmap f = mapAccumT (>>= \(a, !w) -> pure (f a, w))
     {-# INLINE fmap #-}
 
 instance (Monoid w, Functor m, Monad m) => Applicative (AccumT w m) where
-    pure a  = AccumT $ \ !_ -> pure (a, mempty)
+    pure a = AccumT $ \ !_ -> pure (a, mempty)
     {-# INLINE pure #-}
-    mf <*> mv = AccumT $ \ w -> do
-      (f, !w')  <- runAccumT mf w
-      (v, !w'') <- runAccumT mv $! w `mappend` w'
-      pure (f v, w' `mappend` w'')
+    mf <*> mv = AccumT $ \w -> do
+        (f, !w') <- runAccumT mf w
+        (v, !w'') <- runAccumT mv $! w `mappend` w'
+        pure (f v, w' `mappend` w'')
     {-# INLINE (<*>) #-}
 
 instance (Monoid w, Functor m, MonadPlus m) => Alternative (AccumT w m) where
-    empty   = AccumT $ \ !_ -> mzero
+    empty = AccumT $ \ !_ -> mzero
     {-# INLINE empty #-}
-    m <|> n = AccumT $ \ w -> runAccumT m w `mplus` runAccumT n w
+    m <|> n = AccumT $ \w -> runAccumT m w `mplus` runAccumT n w
     {-# INLINE (<|>) #-}
 
 instance (Monoid w, Functor m, Monad m) => Monad (AccumT w m) where
-    m >>= k  = AccumT $ \ !w -> do
-        (a, !w')  <- runAccumT m w
+    m >>= k = AccumT $ \ !w -> do
+        (a, !w') <- runAccumT m w
         (b, !w'') <- runAccumT (k a) (w `mappend` w')
         pure (b, w' `mappend` w'')
     {-# INLINE (>>=) #-}
@@ -171,7 +188,7 @@ instance (Monoid w, Fail.MonadFail m) => Fail.MonadFail (AccumT w m) where
     {-# INLINE fail #-}
 
 instance (Monoid w, Functor m, MonadPlus m) => MonadPlus (AccumT w m) where
-    mzero       = AccumT $ \ !_ -> mzero
+    mzero = AccumT $ \ !_ -> mzero
     {-# INLINE mzero #-}
     m `mplus` n = AccumT $ \ !w -> runAccumT m w `mplus` runAccumT n w
     {-# INLINE mplus #-}

--- a/kore/src/Control/Monad/Trans/Accum/Stricter.hs
+++ b/kore/src/Control/Monad/Trans/Accum/Stricter.hs
@@ -1,0 +1,204 @@
+{-# LANGUAGE ImplicitPrelude #-}
+{-# LANGUAGE NoStrict #-}
+{-# LANGUAGE NoStrictData #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Control.Monad.Trans.Accum.Stricter
+-- Copyright   :  (c) Nickolay Kudasov 2016
+-- License     :  BSD-style (see the file LICENSE)
+--
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- A very strict version of @AccumT@, which accumulates its
+-- state strictly.
+-----------------------------------------------------------------------------
+
+module Control.Monad.Trans.Accum.Stricter (
+    -- * The Accum monad
+    Accum,
+    accum,
+    runAccum,
+    execAccum,
+    evalAccum,
+    mapAccum,
+    -- * The AccumT monad transformer
+    AccumT(AccumT),
+    runAccumT,
+    execAccumT,
+    evalAccumT,
+    mapAccumT,
+    -- * Accum operations
+    look,
+    looks,
+    add,
+  ) where
+
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Class
+import Data.Functor.Identity
+
+import Control.Applicative
+import Control.Monad
+import qualified Control.Monad.Fail as Fail
+import Control.Monad.Fix
+import GHC.Generics (Generic)
+
+-- ---------------------------------------------------------------------------
+-- | An accumulation monad parameterized by the type @w@ of output to accumulate.
+--
+-- The 'return' function produces the output 'mempty', while @>>=@
+-- combines the outputs of the subcomputations using 'mappend'.
+type Accum w = AccumT w Identity
+
+-- | Construct an accumulation computation from a (result, output) pair.
+-- (The inverse of 'runAccum'.)
+accum :: (Monad m) => (w -> (a, w)) -> AccumT w m a
+accum f = AccumT $ \ !w -> pure (f w)
+{-# INLINE accum #-}
+
+-- | Unwrap an accumulation computation as a (result, output) pair.
+-- (The inverse of 'accum'.)
+runAccum :: Accum w a -> w -> (a, w)
+runAccum m = runIdentity . runAccumT m
+{-# INLINE runAccum #-}
+
+-- | Extract the output from an accumulation computation.
+--
+-- * @'execAccum' m w = 'snd' ('runAccum' m w)@
+execAccum :: Accum w a -> w -> w
+execAccum m w = snd (runAccum m w)
+{-# INLINE execAccum #-}
+
+-- | Evaluate an accumulation computation with the given initial output history
+-- and return the final value, discarding the final output.
+--
+-- * @'evalAccum' m w = 'fst' ('runAccum' m w)@
+evalAccum :: Accum w a -> w -> a
+evalAccum m w = fst (runAccum m w)
+{-# INLINE evalAccum #-}
+
+-- | Map both the return value and output of a computation using
+-- the given function.
+--
+-- * @'runAccum' ('mapAccum' f m) = f . 'runAccum' m@
+mapAccum :: ((a, w) -> (b, w)) -> Accum w a -> Accum w b
+mapAccum f = mapAccumT (Identity . f . runIdentity)
+{-# INLINE mapAccum #-}
+
+-- ---------------------------------------------------------------------------
+-- | An accumulation monad parameterized by:
+--
+--   * @w@ - the output to accumulate.
+--
+--   * @m@ - The inner monad.
+--
+-- The 'return' function produces the output 'mempty', while @>>=@
+-- combines the outputs of the subcomputations using 'mappend'.
+--
+-- This monad transformer is similar to both state and writer monad transformers.
+-- Thus it can be seen as
+--
+--  * a restricted append-only version of a state monad transformer or
+--
+--  * a writer monad transformer with the extra ability to read all previous output.
+newtype AccumT w m a = AccumT (w -> m (a, w))
+    deriving stock Generic
+
+-- | Unwrap an accumulation computation.
+runAccumT :: AccumT w m a -> w -> m (a, w)
+runAccumT (AccumT f) = f
+{-# INLINE runAccumT #-}
+
+-- | Extract the output from an accumulation computation.
+--
+-- * @'execAccumT' m w = 'liftM' 'snd' ('runAccumT' m w)@
+execAccumT :: (Monad m) => AccumT w m a -> w -> m w
+execAccumT m w = do
+    (_, !w') <- runAccumT m w
+    pure w'
+{-# INLINE execAccumT #-}
+
+-- | Evaluate an accumulation computation with the given initial output history
+-- and return the final value, discarding the final output.
+--
+-- * @'evalAccumT' m w = 'liftM' 'fst' ('runAccumT' m w)@
+evalAccumT :: Monad m => AccumT w m a -> w -> m a
+evalAccumT m w = do
+    (a, _) <- runAccumT m w
+    pure a
+{-# INLINE evalAccumT #-}
+
+-- | Map both the return value and output of a computation using
+-- the given function.
+--
+-- * @'runAccumT' ('mapAccumT' f m) = f . 'runAccumT' m@
+--
+-- This function does not itself force either initial or result
+-- accumulators!
+mapAccumT :: (m (a, w) -> n (b, w)) -> AccumT w m a -> AccumT w n b
+mapAccumT f m = AccumT (f . runAccumT m)
+{-# INLINE mapAccumT #-}
+
+instance Monad m => Functor (AccumT w m) where
+    fmap f = mapAccumT  (>>= \ (a, !w) -> pure (f a, w))
+    {-# INLINE fmap #-}
+
+instance (Monoid w, Functor m, Monad m) => Applicative (AccumT w m) where
+    pure a  = AccumT $ \ !_ -> pure (a, mempty)
+    {-# INLINE pure #-}
+    mf <*> mv = AccumT $ \ w -> do
+      (f, !w')  <- runAccumT mf w
+      (v, !w'') <- runAccumT mv $! w `mappend` w'
+      pure (f v, w' `mappend` w'')
+    {-# INLINE (<*>) #-}
+
+instance (Monoid w, Functor m, MonadPlus m) => Alternative (AccumT w m) where
+    empty   = AccumT $ \ !_ -> mzero
+    {-# INLINE empty #-}
+    m <|> n = AccumT $ \ w -> runAccumT m w `mplus` runAccumT n w
+    {-# INLINE (<|>) #-}
+
+instance (Monoid w, Functor m, Monad m) => Monad (AccumT w m) where
+    m >>= k  = AccumT $ \ !w -> do
+        (a, !w')  <- runAccumT m w
+        (b, !w'') <- runAccumT (k a) (w `mappend` w')
+        pure (b, w' `mappend` w'')
+    {-# INLINE (>>=) #-}
+
+instance (Monoid w, Fail.MonadFail m) => Fail.MonadFail (AccumT w m) where
+    fail msg = AccumT $ \ !_ -> Fail.fail msg
+    {-# INLINE fail #-}
+
+instance (Monoid w, Functor m, MonadPlus m) => MonadPlus (AccumT w m) where
+    mzero       = AccumT $ \ !_ -> mzero
+    {-# INLINE mzero #-}
+    m `mplus` n = AccumT $ \ !w -> runAccumT m w `mplus` runAccumT n w
+    {-# INLINE mplus #-}
+
+instance (Monoid w, Functor m, MonadFix m) => MonadFix (AccumT w m) where
+    mfix m = AccumT $ \ !w -> mfix $ \ ~(a, _) -> runAccumT (m a) w
+    {-# INLINE mfix #-}
+
+instance (Monoid w) => MonadTrans (AccumT w) where
+    lift m = AccumT $ \ !_ -> do
+        a <- m
+        pure (a, mempty)
+    {-# INLINE lift #-}
+
+instance (Monoid w, Functor m, MonadIO m) => MonadIO (AccumT w m) where
+    liftIO = lift . liftIO
+    {-# INLINE liftIO #-}
+
+-- | @'look'@ is an action that fetches all the previously accumulated output.
+look :: (Monoid w, Monad m) => AccumT w m w
+look = AccumT $ \ !w -> pure (w, mempty)
+
+-- | @'look'@ is an action that retrieves a function of the previously accumulated output.
+looks :: (Monoid w, Monad m) => (w -> a) -> AccumT w m a
+looks f = AccumT $ \ !w -> pure (f w, mempty)
+
+-- | @'add' w@ is an action that produces the output @w@.
+add :: (Monad m) => w -> AccumT w m ()
+add !w = accum $ \ !_ -> ((), w)
+{-# INLINE add #-}

--- a/kore/src/Kore/Rewrite/Transition.hs
+++ b/kore/src/Kore/Rewrite/Transition.hs
@@ -31,12 +31,12 @@ import Control.Monad.Except (
     MonadError (..),
  )
 import Control.Monad.Reader
-import Control.Monad.Trans.Accum (
+import Control.Monad.Trans.Accum.Stricter (
     AccumT (..),
     mapAccumT,
     runAccumT,
  )
-import Control.Monad.Trans.Accum qualified as Accum
+import Control.Monad.Trans.Accum.Stricter qualified as Accum
 import Data.Functor.Identity (
     Identity,
     runIdentity,

--- a/kore/src/Kore/Simplify/Simplify.hs
+++ b/kore/src/Kore/Simplify/Simplify.hs
@@ -66,7 +66,7 @@ import Control.Monad.Morph qualified as Monad.Morph
 import Control.Monad.RWS.Strict (RWST)
 import Control.Monad.Reader
 import Control.Monad.State.Strict
-import Control.Monad.Trans.Accum
+import Control.Monad.Trans.Accum.Stricter
 import Control.Monad.Trans.Except
 import Control.Monad.Trans.Identity
 import Control.Monad.Trans.Maybe

--- a/kore/src/Log.hs
+++ b/kore/src/Log.hs
@@ -59,7 +59,7 @@ import Control.Monad.Morph qualified as Monad.Morph
 import Control.Monad.RWS.Strict (
     RWST,
  )
-import Control.Monad.Trans.Accum (
+import Control.Monad.Trans.Accum.Stricter (
     AccumT,
     mapAccumT,
  )

--- a/kore/src/SMT.hs
+++ b/kore/src/SMT.hs
@@ -98,7 +98,7 @@ import Control.Monad.State.Strict (
  )
 import Control.Monad.State.Strict qualified as State.Strict
 import Control.Monad.Trans qualified as Trans
-import Control.Monad.Trans.Accum
+import Control.Monad.Trans.Accum.Stricter
 import Control.Monad.Trans.Except
 import Control.Monad.Trans.Identity
 import Control.Monad.Trans.Maybe qualified as Maybe

--- a/kore/src/SQL/Query.hs
+++ b/kore/src/SQL/Query.hs
@@ -16,11 +16,11 @@ module SQL.Query (
     withParens,
 ) where
 
-import Control.Monad.Trans.Accum (
+import Control.Monad.Trans.Accum.Stricter (
     AccumT,
     execAccumT,
  )
-import Control.Monad.Trans.Accum qualified as Accum
+import Control.Monad.Trans.Accum.Stricter qualified as Accum
 import Data.String (
     fromString,
  )

--- a/nix/kore-ghc8107.nix.d/kore.nix
+++ b/nix/kore-ghc8107.nix.d/kore.nix
@@ -121,6 +121,7 @@
       modules = [
         "Changed"
         "Control/Monad/Counter"
+        "Control/Monad/Trans/Accum/Stricter"
         "Data/Graph/TopologicalSort"
         "Data/InternedText"
         "Data/Limit"

--- a/nix/kore-ghc923.nix.d/kore.nix
+++ b/nix/kore-ghc923.nix.d/kore.nix
@@ -121,6 +121,7 @@
       modules = [
         "Changed"
         "Control/Monad/Counter"
+        "Control/Monad/Trans/Accum/Stricter"
         "Data/Graph/TopologicalSort"
         "Data/InternedText"
         "Data/Limit"


### PR DESCRIPTION
The standard `AccumT` is *extremely* lazy, both in the accumulator and (potentially) in previous actions. That doesn't really seem so great for our purposes. Use a strict version instead.

Fixes #nnnn

### Scope:

### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
