### PR TITLE
Make NotSimplifier a class

### DIFF
--- a/kore/src/Kore/Builtin/Builtin.hs
+++ b/kore/src/Kore/Builtin/Builtin.hs
@@ -519,13 +519,12 @@ data UnifyEq = UnifyEq
 unifyEq ::
     forall unifier.
     MonadUnify unifier =>
+    NotSimplifier Simplifier =>
     TermSimplifier RewritingVariableName unifier ->
-    NotSimplifier Simplifier ->
     UnifyEq ->
     unifier (Pattern RewritingVariableName)
 unifyEq
     unifyChildren
-    (NotSimplifier notSimplifier)
     unifyData =
         do
             solution <- OrPattern.gather $ unifyChildren operand1 operand2

--- a/kore/src/Kore/Builtin/EqTerm.hs
+++ b/kore/src/Kore/Builtin/EqTerm.hs
@@ -55,12 +55,12 @@ This function is suitable only for equality simplification.
 unifyEqTerm ::
     forall unifier.
     MonadUnify unifier =>
+    NotSimplifier Simplifier =>
     TermSimplifier RewritingVariableName unifier ->
-    NotSimplifier Simplifier ->
     EqTerm (TermLike RewritingVariableName) ->
     Bool ->
     unifier (Pattern RewritingVariableName)
-unifyEqTerm unifyChildren (NotSimplifier notSimplifier) eqTerm value =
+unifyEqTerm unifyChildren eqTerm value =
     do
         solution <- unifyChildren operand1 operand2 & OrPattern.gather
         let solution' = MultiOr.map eraseTerm solution

--- a/kore/src/Kore/Builtin/Map.hs
+++ b/kore/src/Kore/Builtin/Map.hs
@@ -713,12 +713,12 @@ matchUnifyNotInKeys first second
 unifyNotInKeys ::
     forall unifier.
     MonadUnify unifier =>
+    NotSimplifier Simplifier =>
     Sort ->
     TermSimplifier RewritingVariableName unifier ->
-    NotSimplifier Simplifier ->
     UnifyNotInKeysResult ->
     unifier (Pattern RewritingVariableName)
-unifyNotInKeys resultSort unifyChildren (NotSimplifier notSimplifier) unifyData =
+unifyNotInKeys resultSort unifyChildren unifyData =
     case unifyData of
         NullKeysNullOpaques -> return (Pattern.topOf resultSort)
         NonNullKeysOrMultipleOpaques unifyData' ->

--- a/kore/src/Kore/Simplify/And.hs
+++ b/kore/src/Kore/Simplify/And.hs
@@ -99,40 +99,40 @@ Also, we have
     the same for two string literals and two chars
 -}
 simplify ::
+    NotSimplifier Simplifier =>
     Sort ->
-    NotSimplifier Simplifier ->
     SideCondition RewritingVariableName ->
     MultiAnd (OrPattern RewritingVariableName) ->
     Simplifier (OrPattern RewritingVariableName)
-simplify resultSort notSimplifier sideCondition orPatterns =
+simplify resultSort sideCondition orPatterns =
     OrPattern.observeAllT $ do
         patterns <- MultiAnd.traverse scatter orPatterns
-        makeEvaluate resultSort notSimplifier sideCondition patterns
+        makeEvaluate resultSort sideCondition patterns
 
 {- | 'makeEvaluate' simplifies a 'MultiAnd' of 'Pattern's.
 See the comment for 'simplify' to find more details.
 -}
 makeEvaluate ::
+    NotSimplifier Simplifier =>
     Sort ->
-    NotSimplifier Simplifier ->
     SideCondition RewritingVariableName ->
     MultiAnd (Pattern RewritingVariableName) ->
     LogicT Simplifier (Pattern RewritingVariableName)
-makeEvaluate resultSort notSimplifier sideCondition patterns
+makeEvaluate resultSort sideCondition patterns
     | isBottom patterns = empty
     | Pattern.isTop patterns = return (Pattern.topOf resultSort)
-    | otherwise = makeEvaluateNonBool resultSort notSimplifier sideCondition patterns
+    | otherwise = makeEvaluateNonBool resultSort sideCondition patterns
 
 makeEvaluateNonBool ::
+    NotSimplifier Simplifier =>
     Sort ->
-    NotSimplifier Simplifier ->
     SideCondition RewritingVariableName ->
     MultiAnd (Pattern RewritingVariableName) ->
     LogicT Simplifier (Pattern RewritingVariableName)
-makeEvaluateNonBool resultSort notSimplifier sideCondition patterns = do
+makeEvaluateNonBool resultSort sideCondition patterns = do
     let unify pattern1 term2 = do
             let (term1, condition1) = Pattern.splitTerm pattern1
-            unified <- termAnd notSimplifier term1 term2
+            unified <- termAnd term1 term2
             pure (Pattern.andCondition unified condition1)
     unified <-
         foldlM
@@ -211,21 +211,21 @@ partitionWith f = partitionEithers . fmap f
 The comment for 'simplify' describes all the special cases handled by this.
 -}
 termAnd ::
+    NotSimplifier Simplifier =>
     HasCallStack =>
-    NotSimplifier Simplifier ->
     TermLike RewritingVariableName ->
     TermLike RewritingVariableName ->
     LogicT Simplifier (Pattern RewritingVariableName)
-termAnd notSimplifier p1 p2 =
+termAnd p1 p2 =
     Logic.scatter
-        =<< (lift . runUnifierT notSimplifier) (termAndWorker p1 p2)
+        =<< (lift . runUnifierT) (termAndWorker p1 p2)
   where
     termAndWorker ::
         TermLike RewritingVariableName ->
         TermLike RewritingVariableName ->
         UnifierT Simplifier (Pattern RewritingVariableName)
     termAndWorker first second =
-        maybeTermAnd notSimplifier termAndWorker first second
+        maybeTermAnd termAndWorker first second
             & runMaybeT
             & fmap (fromMaybe andPattern)
       where

--- a/kore/src/Kore/Simplify/Equals.hs
+++ b/kore/src/Kore/Simplify/Equals.hs
@@ -231,14 +231,14 @@ makeEvaluateFunctionalOr sideCondition first seconds = do
     secondNotCeils <- traverse mkNotSimplified secondCeils
     let oneNotBottom = foldl' Or.simplifyEvaluated OrPattern.bottom secondCeils
     allAreBottom <-
-            (And.simplify sort sideCondition)
+        (And.simplify sort sideCondition)
             (MultiAnd.make (firstNotCeil : secondNotCeils))
     firstEqualsSeconds <-
         mapM
             (makeEvaluateEqualsIfSecondNotBottom sort first)
             (zip seconds secondCeils)
     oneIsNotBottomEquals <-
-            (And.simplify sort sideCondition)
+        (And.simplify sort sideCondition)
             (MultiAnd.make (firstCeil : oneNotBottom : firstEqualsSeconds))
     MultiOr.merge allAreBottom oneIsNotBottomEquals
         & MultiOr.map Pattern.withoutTerm
@@ -298,10 +298,10 @@ makeEvaluate
             secondCeilNegation <- mkNotSimplified secondCeil
             termEquality <- makeEvaluateTermsAssumesNoBottom firstTerm secondTerm
             negationAnd <-
-                    (And.simplify sort sideCondition)
+                (And.simplify sort sideCondition)
                     (MultiAnd.make [firstCeilNegation, secondCeilNegation])
             equalityAnd <-
-                    (And.simplify sort sideCondition)
+                (And.simplify sort sideCondition)
                     (MultiAnd.make [termEquality, firstCeil, secondCeil])
             Or.simplifyEvaluated equalityAnd negationAnd
                 & MultiOr.map Pattern.withoutTerm

--- a/kore/src/Kore/Simplify/Equals.hs
+++ b/kore/src/Kore/Simplify/Equals.hs
@@ -60,7 +60,6 @@ import Kore.Simplify.Implies qualified as Implies (
     simplifyEvaluated,
  )
 import Kore.Simplify.Not qualified as Not (
-    notSimplifier,
     simplify,
     simplifyEvaluatedPredicate,
  )
@@ -232,14 +231,14 @@ makeEvaluateFunctionalOr sideCondition first seconds = do
     secondNotCeils <- traverse mkNotSimplified secondCeils
     let oneNotBottom = foldl' Or.simplifyEvaluated OrPattern.bottom secondCeils
     allAreBottom <-
-        (And.simplify sort Not.notSimplifier sideCondition)
+            (And.simplify sort sideCondition)
             (MultiAnd.make (firstNotCeil : secondNotCeils))
     firstEqualsSeconds <-
         mapM
             (makeEvaluateEqualsIfSecondNotBottom sort first)
             (zip seconds secondCeils)
     oneIsNotBottomEquals <-
-        (And.simplify sort Not.notSimplifier sideCondition)
+            (And.simplify sort sideCondition)
             (MultiAnd.make (firstCeil : oneNotBottom : firstEqualsSeconds))
     MultiOr.merge allAreBottom oneIsNotBottomEquals
         & MultiOr.map Pattern.withoutTerm
@@ -299,10 +298,10 @@ makeEvaluate
             secondCeilNegation <- mkNotSimplified secondCeil
             termEquality <- makeEvaluateTermsAssumesNoBottom firstTerm secondTerm
             negationAnd <-
-                (And.simplify sort Not.notSimplifier sideCondition)
+                    (And.simplify sort sideCondition)
                     (MultiAnd.make [firstCeilNegation, secondCeilNegation])
             equalityAnd <-
-                (And.simplify sort Not.notSimplifier sideCondition)
+                    (And.simplify sort sideCondition)
                     (MultiAnd.make [termEquality, firstCeil, secondCeil])
             Or.simplifyEvaluated equalityAnd negationAnd
                 & MultiOr.map Pattern.withoutTerm
@@ -413,7 +412,7 @@ termEqualsAnd p1 p2 =
     MaybeT $ run $ maybeTermEqualsWorker p1 p2
   where
     run it =
-        (lift . runUnifierT Not.notSimplifier . runMaybeT) it
+        (lift . runUnifierT . runMaybeT) it
             >>= Logic.scatter
 
     maybeTermEqualsWorker ::
@@ -421,7 +420,7 @@ termEqualsAnd p1 p2 =
         TermLike RewritingVariableName ->
         MaybeT (UnifierT Simplifier) (Pattern RewritingVariableName)
     maybeTermEqualsWorker =
-        maybeTermEquals Not.notSimplifier termEqualsAndWorker
+        maybeTermEquals termEqualsAndWorker
 
     termEqualsAndWorker ::
         TermLike RewritingVariableName ->

--- a/kore/src/Kore/Simplify/Iff.hs
+++ b/kore/src/Kore/Simplify/Iff.hs
@@ -39,7 +39,6 @@ import Kore.Simplify.Implies qualified as Implies (
  )
 import Kore.Simplify.Not qualified as Not (
     makeEvaluate,
-    notSimplifier,
     simplify,
  )
 import Kore.Simplify.Simplify
@@ -94,7 +93,7 @@ simplifyEvaluated sort sideCondition first second
         _ -> do
             fwd <- Implies.simplifyEvaluated sort sideCondition first second
             bwd <- Implies.simplifyEvaluated sort sideCondition second first
-            And.simplify sort Not.notSimplifier sideCondition $
+            And.simplify sort sideCondition $
                 MultiAnd.make [fwd, bwd]
   where
     firstPatterns = toList first

--- a/kore/src/Kore/Simplify/Implies.hs
+++ b/kore/src/Kore/Simplify/Implies.hs
@@ -30,7 +30,6 @@ import Kore.Rewrite.RewritingVariable (
 import Kore.Simplify.And qualified as And
 import Kore.Simplify.Not qualified as Not (
     makeEvaluate,
-    notSimplifier,
     simplify,
  )
 import Kore.Simplify.Simplify
@@ -124,7 +123,7 @@ distributeEvaluateImplies ::
     Pattern RewritingVariableName ->
     Simplifier (OrPattern RewritingVariableName)
 distributeEvaluateImplies sideCondition firsts second =
-    (And.simplify sort Not.notSimplifier sideCondition)
+    (And.simplify sort sideCondition)
         (MultiAnd.make implications)
   where
     sort = Pattern.patternSort second

--- a/kore/src/Kore/Simplify/In.hs
+++ b/kore/src/Kore/Simplify/In.hs
@@ -34,7 +34,7 @@ import Kore.Simplify.Ceil qualified as Ceil (
     makeEvaluate,
     simplifyEvaluated,
  )
-import Kore.Simplify.Not qualified as Not
+import Kore.Simplify.Not () -- For the (orphan) NotSimplifier instance
 import Kore.Simplify.Simplify
 import Logic qualified
 import Prelude.Kore
@@ -91,7 +91,7 @@ makeEvaluateIn sideCondition first second
     | Pattern.isBottom first || Pattern.isBottom second = return OrCondition.bottom
     | otherwise =
         liftSimplifier $
-            (And.makeEvaluate pattSort Not.notSimplifier sideCondition)
+            (And.makeEvaluate pattSort sideCondition)
                 (MultiAnd.make [first, second])
                 & OrPattern.observeAllT
                 >>= Ceil.simplifyEvaluated sideCondition

--- a/kore/src/Kore/Simplify/In.hs
+++ b/kore/src/Kore/Simplify/In.hs
@@ -34,7 +34,9 @@ import Kore.Simplify.Ceil qualified as Ceil (
     makeEvaluate,
     simplifyEvaluated,
  )
-import Kore.Simplify.Not () -- For the (orphan) NotSimplifier instance
+import Kore.Simplify.Not ()
+
+-- For the (orphan) NotSimplifier instance
 import Kore.Simplify.Simplify
 import Logic qualified
 import Prelude.Kore

--- a/kore/src/Kore/Simplify/Not.hs
+++ b/kore/src/Kore/Simplify/Not.hs
@@ -7,6 +7,11 @@ Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable
 -}
+
+-- We define the 'NotSimplifier' instance here to avoid an import
+-- loop. Unfortunately, that means it needs to be an orphan.
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Kore.Simplify.Not (
     makeEvaluate,
     makeEvaluatePredicate,
@@ -198,7 +203,7 @@ mkMultiAndPattern ::
     SideCondition RewritingVariableName ->
     MultiAnd (Pattern RewritingVariableName) ->
     LogicT Simplifier (Pattern RewritingVariableName)
-mkMultiAndPattern resultSort = And.makeEvaluate resultSort notSimplifier
+mkMultiAndPattern resultSort = And.makeEvaluate resultSort
 
 -- | Conjoin and simplify a 'MultiAnd' of 'Condition'.
 mkMultiAndPredicate ::
@@ -209,5 +214,5 @@ mkMultiAndPredicate predicates =
     -- implements And semantics.
     return $ fold predicates
 
-notSimplifier :: NotSimplifier Simplifier
-notSimplifier = NotSimplifier simplify
+instance simplifier ~ Simplifier => NotSimplifier simplifier where
+  notSimplifier = simplify

--- a/kore/src/Kore/Simplify/Not.hs
+++ b/kore/src/Kore/Simplify/Not.hs
@@ -1,3 +1,7 @@
+-- We define the 'NotSimplifier' instance here to avoid an import
+-- loop. Unfortunately, that means it needs to be an orphan.
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 {- |
 Module      : Kore.Simplify.Not
 Description : Tools for Not pattern simplification.
@@ -7,11 +11,6 @@ Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable
 -}
-
--- We define the 'NotSimplifier' instance here to avoid an import
--- loop. Unfortunately, that means it needs to be an orphan.
-{-# OPTIONS_GHC -Wno-orphans #-}
-
 module Kore.Simplify.Not (
     makeEvaluate,
     makeEvaluatePredicate,
@@ -215,4 +214,4 @@ mkMultiAndPredicate predicates =
     return $ fold predicates
 
 instance simplifier ~ Simplifier => NotSimplifier simplifier where
-  notSimplifier = simplify
+    notSimplifier = simplify

--- a/kore/src/Kore/Simplify/NotSimplifier.hs
+++ b/kore/src/Kore/Simplify/NotSimplifier.hs
@@ -20,9 +20,15 @@ import Kore.Syntax (
     Sort,
  )
 
-newtype NotSimplifier simplifier = NotSimplifier
-    { runNotSimplifier ::
-        SideCondition RewritingVariableName ->
-        Not Sort (OrPattern RewritingVariableName) ->
-        simplifier (OrPattern RewritingVariableName)
-    }
+-- | We use this class to break a module import loop. Its sole instance
+-- is in "Kore.Simplify.Not":
+--
+-- @
+-- instance simplifier ~ 'Kore.Simplify.Simplify.Simplifier' => NotSimplifier simplifier where
+--   notSimplifier = "Kore.Simplify.Not".'Kore.Simplify.Not.simplify'
+-- @
+class NotSimplifier simplifier | -> simplifier where
+  notSimplifier ::
+    SideCondition RewritingVariableName ->
+    Not Sort (OrPattern RewritingVariableName) ->
+    simplifier (OrPattern RewritingVariableName)

--- a/kore/src/Kore/Simplify/NotSimplifier.hs
+++ b/kore/src/Kore/Simplify/NotSimplifier.hs
@@ -20,15 +20,16 @@ import Kore.Syntax (
     Sort,
  )
 
--- | We use this class to break a module import loop. Its sole instance
--- is in "Kore.Simplify.Not":
---
--- @
--- instance simplifier ~ 'Kore.Simplify.Simplify.Simplifier' => NotSimplifier simplifier where
---   notSimplifier = "Kore.Simplify.Not".'Kore.Simplify.Not.simplify'
--- @
+{- | We use this class to break a module import loop. Its sole instance
+ is in "Kore.Simplify.Not":
+
+ @
+ instance simplifier ~ 'Kore.Simplify.Simplify.Simplifier' => NotSimplifier simplifier where
+   notSimplifier = "Kore.Simplify.Not".'Kore.Simplify.Not.simplify'
+ @
+-}
 class NotSimplifier simplifier | -> simplifier where
-  notSimplifier ::
-    SideCondition RewritingVariableName ->
-    Not Sort (OrPattern RewritingVariableName) ->
-    simplifier (OrPattern RewritingVariableName)
+    notSimplifier ::
+        SideCondition RewritingVariableName ->
+        Not Sort (OrPattern RewritingVariableName) ->
+        simplifier (OrPattern RewritingVariableName)

--- a/kore/src/Kore/Simplify/TermLike.hs
+++ b/kore/src/Kore/Simplify/TermLike.hs
@@ -90,7 +90,6 @@ import Kore.Simplify.Next qualified as Next (
     simplify,
  )
 import Kore.Simplify.Not qualified as Not (
-    notSimplifier,
     simplify,
  )
 import Kore.Simplify.Nu qualified as Nu (
@@ -198,7 +197,7 @@ simplify sideCondition =
                 AndF andF -> do
                     let conjuncts = foldMap MultiAnd.fromTermLike andF
                     -- MultiAnd doesn't preserve the sort so we need to send it as an external argument
-                    And.simplify sort Not.notSimplifier sideCondition
+                    And.simplify sort sideCondition
                         =<< MultiAnd.traverse worker conjuncts
                 OrF orF ->
                     Or.simplify <$> traverse worker orF

--- a/kore/src/Kore/Unification/SubstitutionSimplifier.hs
+++ b/kore/src/Kore/Unification/SubstitutionSimplifier.hs
@@ -67,9 +67,9 @@ uses 'Unifier.throwUnificationError'.
 substitutionSimplifier ::
     forall unifier.
     MonadUnify unifier =>
-    NotSimplifier Simplifier ->
+    NotSimplifier Simplifier =>
     SubstitutionSimplifier unifier
-substitutionSimplifier notSimplifier =
+substitutionSimplifier =
     SubstitutionSimplifier wrapper
   where
     wrapper ::
@@ -98,14 +98,14 @@ substitutionSimplifier notSimplifier =
         worker =
             simplifySubstitutionWorker
                 sideCondition
-                (unificationMakeAnd notSimplifier)
+                unificationMakeAnd
 
 unificationMakeAnd ::
     forall unifier.
     MonadUnify unifier =>
-    NotSimplifier Simplifier ->
+    NotSimplifier Simplifier =>
     MakeAnd unifier
-unificationMakeAnd notSimplifier =
+unificationMakeAnd =
     MakeAnd{makeAnd}
   where
     makeAnd ::
@@ -114,6 +114,6 @@ unificationMakeAnd notSimplifier =
         SideCondition RewritingVariableName ->
         unifier (Pattern RewritingVariableName)
     makeAnd termLike1 termLike2 sideCondition = do
-        unified <- termUnification notSimplifier termLike1 termLike2
+        unified <- termUnification termLike1 termLike2
         Simplifier.simplifyCondition sideCondition unified
             & Logic.lowerLogicT

--- a/kore/src/Kore/Unification/UnifierT.hs
+++ b/kore/src/Kore/Unification/UnifierT.hs
@@ -82,20 +82,18 @@ instance MonadSimplify m => MonadSimplify (UnifierT m) where
 instance MonadSimplify m => MonadUnify (UnifierT m)
 
 runUnifierT ::
-    NotSimplifier Simplifier ->
+    NotSimplifier Simplifier =>
     UnifierT Simplifier a ->
     Simplifier [a]
-runUnifierT notSimplifier =
-    observeAllT
-        . evalEnvUnifierT notSimplifier
+runUnifierT = observeAllT . evalEnvUnifierT
 
 evalEnvUnifierT ::
-    NotSimplifier Simplifier ->
+    NotSimplifier Simplifier =>
     UnifierT Simplifier a ->
     LogicT Simplifier a
-evalEnvUnifierT notSimplifier =
+evalEnvUnifierT =
     flip runReaderT conditionSimplifier
         . getUnifierT
   where
     conditionSimplifier =
-        ConditionSimplifier.create (substitutionSimplifier notSimplifier)
+        ConditionSimplifier.create substitutionSimplifier

--- a/kore/test/Test/Kore/Builtin/Bool.hs
+++ b/kore/test/Test/Kore/Builtin/Bool.hs
@@ -39,7 +39,6 @@ import Kore.Rewrite.RewritingVariable (
     RewritingVariableName,
     configElementVariableFromId,
  )
-import Kore.Simplify.Not qualified as Not
 import Kore.Simplify.Simplify (
     Simplifier,
     runSimplifier,
@@ -239,7 +238,7 @@ run :: MaybeT (UnifierT Simplifier) a -> IO [Maybe a]
 run =
     runNoSMT
         . runSimplifier testEnv
-        . runUnifierT Not.notSimplifier
+        . runUnifierT
         . runMaybeT
 
 termSimplifier ::

--- a/kore/test/Test/Kore/Builtin/Builtin.hs
+++ b/kore/test/Test/Kore/Builtin/Builtin.hs
@@ -87,7 +87,6 @@ import Kore.Rewrite.Step qualified as Step
 import Kore.Simplify.AndTerms (termUnification)
 import Kore.Simplify.Condition qualified as Simplifier.Condition
 import Kore.Simplify.InjSimplifier
-import Kore.Simplify.Not qualified as Not
 import Kore.Simplify.OverloadSimplifier
 import Kore.Simplify.Pattern qualified as Pattern
 import Kore.Simplify.Simplify hiding (simplifyPattern)
@@ -343,15 +342,14 @@ unifyEq ::
 unifyEq eqKey term1 term2 =
     unify matched
         & runMaybeT
-        & evalEnvUnifierT Not.notSimplifier
+        & evalEnvUnifierT
         & runSimplifierBranch testEnv
         & runNoSMT
   where
     unify Nothing = empty
     unify (Just unifyData) =
         Builtin.unifyEq
-            (termUnification Not.notSimplifier)
-            Not.notSimplifier
+            termUnification
             unifyData
             & lift
 

--- a/kore/test/Test/Kore/Builtin/Endianness.hs
+++ b/kore/test/Test/Kore/Builtin/Endianness.hs
@@ -19,7 +19,6 @@ import Kore.Rewrite.RewritingVariable (
 import Kore.Simplify.AndTerms (
     termUnification,
  )
-import Kore.Simplify.Not qualified as Not
 import Kore.Simplify.Simplify (
     runSimplifier,
  )
@@ -118,5 +117,5 @@ unify ::
 unify term1 term2 =
     runNoSMT $
         runSimplifier testEnv $
-            runUnifierT Not.notSimplifier $
-                termUnification Not.notSimplifier term1 term2
+            runUnifierT $
+                termUnification term1 term2

--- a/kore/test/Test/Kore/Builtin/KEqual.hs
+++ b/kore/test/Test/Kore/Builtin/KEqual.hs
@@ -28,7 +28,6 @@ import Kore.Rewrite.RewritingVariable (
 import Kore.Simplify.AndTerms (
     termUnification,
  )
-import Kore.Simplify.Not qualified as Not
 import Kore.Simplify.Simplify (
     runSimplifierBranch,
  )
@@ -233,7 +232,7 @@ runKEqualSimplification ::
 runKEqualSimplification term1 term2 =
     unify matched
         & runMaybeT
-        & evalEnvUnifierT Not.notSimplifier
+        & evalEnvUnifierT
         & runSimplifierBranch testEnv
   where
     matched =
@@ -241,8 +240,7 @@ runKEqualSimplification term1 term2 =
             <|> KEqual.matchUnifyKequalsEq term2 term1
     unify (Just unifyData) =
         Builtin.unifyEq
-            (termUnification Not.notSimplifier)
-            Not.notSimplifier
+            termUnification
             unifyData
             & lift
     unify Nothing = empty

--- a/kore/test/Test/Kore/Builtin/Set.hs
+++ b/kore/test/Test/Kore/Builtin/Set.hs
@@ -100,7 +100,6 @@ import Kore.Rewrite.RulePattern as RulePattern (
 import Kore.Simplify.AndTerms (
     termUnification,
  )
-import Kore.Simplify.Not qualified as Not
 import Kore.Unification.UnifierT (
     runUnifierT,
  )
@@ -1870,8 +1869,8 @@ unifiedBy (termLike1, termLike2) (Substitution.unsafeWrap -> expect) testName =
     testCase testName $ do
         actuals <-
             testRunSimplifier testEnv $
-                runUnifierT Not.notSimplifier $
-                    termUnification Not.notSimplifier termLike1 termLike2
+                runUnifierT $
+                    termUnification termLike1 termLike2
         liftIO $ do
             actual <- expectOne actuals
             assertBool "expected \\top predicate" (isTop $ predicate actual)

--- a/kore/test/Test/Kore/Builtin/Signedness.hs
+++ b/kore/test/Test/Kore/Builtin/Signedness.hs
@@ -19,7 +19,6 @@ import Kore.Rewrite.RewritingVariable (
 import Kore.Simplify.AndTerms (
     termUnification,
  )
-import Kore.Simplify.Not qualified as Not
 import Kore.Simplify.Simplify (
     runSimplifier,
  )
@@ -118,5 +117,5 @@ unify ::
 unify term1 term2 =
     runNoSMT $
         runSimplifier testEnv $
-            runUnifierT Not.notSimplifier $
-                termUnification Not.notSimplifier term1 term2
+            runUnifierT $
+                termUnification term1 term2

--- a/kore/test/Test/Kore/Simplify/And.hs
+++ b/kore/test/Test/Kore/Simplify/And.hs
@@ -26,7 +26,6 @@ import Kore.Rewrite.RewritingVariable (
     RewritingVariableName,
  )
 import Kore.Simplify.And
-import Kore.Simplify.Not qualified as Not
 import Prelude.Kore
 import Test.Kore.Rewrite.MockSymbols (
     testSort,
@@ -466,7 +465,7 @@ evaluate ::
     IO (OrPattern RewritingVariableName)
 evaluate And{andFirst, andSecond} =
     MultiAnd.make [andFirst, andSecond]
-        & simplify Mock.testSort Not.notSimplifier SideCondition.top
+        & simplify Mock.testSort SideCondition.top
         & testRunSimplifier Mock.env
 
 evaluatePatterns ::
@@ -475,6 +474,6 @@ evaluatePatterns ::
     IO (OrPattern RewritingVariableName)
 evaluatePatterns first second =
     MultiAnd.make [first, second]
-        & makeEvaluate Mock.testSort Not.notSimplifier SideCondition.top
+        & makeEvaluate Mock.testSort SideCondition.top
         & testRunSimplifierBranch Mock.env
         & fmap OrPattern.fromPatterns

--- a/kore/test/Test/Kore/Simplify/AndTerms.hs
+++ b/kore/test/Test/Kore/Simplify/AndTerms.hs
@@ -66,7 +66,6 @@ import Kore.Simplify.AndTerms (
 import Kore.Simplify.Equals (
     termEquals,
  )
-import Kore.Simplify.Not qualified as Not
 import Kore.Simplify.Simplify
 import Kore.Syntax.Sentence (
     SentenceAlias,
@@ -1562,9 +1561,8 @@ unify first second =
   where
     mockEnv = Mock.env
     unification =
-        Monad.Unify.runUnifierT Not.notSimplifier $
+        Monad.Unify.runUnifierT $
             termUnification
-                Not.notSimplifier
                 (simplifiedTerm first)
                 (simplifiedTerm second)
 
@@ -1574,7 +1572,7 @@ simplify ::
     IO [Pattern RewritingVariableName]
 simplify first second =
     testRunSimplifierBranch mockEnv $
-        termAnd Not.notSimplifier (simplifiedTerm first) (simplifiedTerm second)
+        termAnd (simplifiedTerm first) (simplifiedTerm second)
   where
     mockEnv = Mock.env
 

--- a/kore/test/Test/Kore/Simplify/SubstitutionSimplifier.hs
+++ b/kore/test/Test/Kore/Simplify/SubstitutionSimplifier.hs
@@ -17,7 +17,6 @@ import Kore.Internal.TermLike
 import Kore.Rewrite.RewritingVariable (
     RewritingVariableName,
  )
-import Kore.Simplify.Not qualified as Not
 import Kore.Simplify.SubstitutionSimplifier (
     SubstitutionSimplifier (..),
  )
@@ -251,9 +250,9 @@ test_SubstitutionSimplifier =
                         (all Substitution.isNormalized actualSubstitutions)
                 , testCase "unification" $ do
                     let SubstitutionSimplifier{simplifySubstitution} =
-                            Unification.substitutionSimplifier Not.notSimplifier
+                            Unification.substitutionSimplifier
                     actual <-
-                        testRunSimplifier Mock.env . runUnifierT Not.notSimplifier $
+                        testRunSimplifier Mock.env . runUnifierT $
                             simplifySubstitution SideCondition.top input
                     let expect = Condition.fromNormalizationSimplified <$> results
                         actualConditions = OrCondition.toConditions <$> actual

--- a/kore/test/Test/Kore/Unification/Unifier.hs
+++ b/kore/test/Test/Kore/Unification/Unifier.hs
@@ -24,7 +24,6 @@ import Kore.Internal.SideCondition qualified as SideCondition (
 import Kore.Rewrite.RewritingVariable (
     RewritingVariableName,
  )
-import Kore.Simplify.Not qualified as Not
 import Kore.Simplify.Pattern qualified as Pattern
 import Kore.Simplify.Simplify (
     Env (..),
@@ -173,7 +172,7 @@ simplifyAnds ::
     unifier (Pattern RewritingVariableName)
 simplifyAnds =
     SubstitutionSimplifier.simplifyAnds
-        (Unification.unificationMakeAnd Not.notSimplifier)
+        Unification.unificationMakeAnd
         SideCondition.top
 
 andSimplify ::
@@ -186,7 +185,7 @@ andSimplify term1 term2 results = do
     let expect = OrPattern.fromPatterns $ map unificationResult results
     subst' <-
         simplifyAnds (unificationProblem term1 term2 :| [])
-            & Monad.Unify.runUnifierT Not.notSimplifier
+            & Monad.Unify.runUnifierT
             & runSimplifier testEnv
             & runNoSMT
             & fmap OrPattern.fromPatterns
@@ -219,7 +218,7 @@ andSimplifyException message term1 term2 exceptionMessage =
         assignment <-
             runNoSMT $
                 runSimplifier testEnv $
-                    Monad.Unify.runUnifierT Not.notSimplifier $
+                    Monad.Unify.runUnifierT $
                         simplifyAnds (unificationProblem term1 term2 :| [])
         _ <- evaluate assignment
         assertFailure "This evaluation should fail"

--- a/kore/test/Test/Kore/Unification/UnifierT.hs
+++ b/kore/test/Test/Kore/Unification/UnifierT.hs
@@ -32,7 +32,6 @@ import Kore.Rewrite.RewritingVariable (
     RewritingVariableName,
  )
 import Kore.Simplify.Condition qualified as Condition
-import Kore.Simplify.Not qualified as Not
 import Kore.Simplify.Simplify (
     Env (..),
  )
@@ -406,7 +405,7 @@ merge
     (Substitution.mkUnwrappedSubstitution -> s1)
     (Substitution.mkUnwrappedSubstitution -> s2) =
         Test.testRunSimplifier mockEnv $
-            Monad.Unify.runUnifierT Not.notSimplifier $
+            Monad.Unify.runUnifierT $
                 mergeSubstitutionsExcept $
                     Substitution.wrap
                         . fmap simplifiedAssignment
@@ -440,7 +439,7 @@ normalizeExcept ::
 normalizeExcept predicated =
     fmap MultiOr.make $
         Test.testRunSimplifier mockEnv $
-            Monad.Unify.runUnifierT Not.notSimplifier $
+            Monad.Unify.runUnifierT $
                 Logic.lowerLogicT $
                     Simplifier.simplifyCondition SideCondition.top predicated
   where


### PR DESCRIPTION
Passing around `NotSimplifier` manually is tedious and a bit confusing. Make it a class instead.

Fixes #nnnn

### Scope:

### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
