### PR TITLE
pin CI to ubuntu-20.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
 
   check:
     name: 'Check'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     steps:
       - name: Check out code
         uses: actions/checkout@v2.3.4
@@ -44,7 +44,7 @@ jobs:
 
   release:
     name: 'Release'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     steps:
       - name: Check out code
         uses: actions/checkout@v2.3.4
@@ -70,7 +70,7 @@ jobs:
 
   cache-cabal:
     name: 'Cache Cabal'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     env:
       ghc_version: "8.10.7"
     steps:
@@ -105,7 +105,7 @@ jobs:
 
   cache-stack:
     name: 'Cache Stack'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     steps:
       - name: Install prerequisites
         run: |
@@ -138,7 +138,7 @@ jobs:
 
   cache-stack-haddock:
     name: 'Cache Stack Haddock'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     steps:
       - name: Install prerequisites
         run: |
@@ -171,7 +171,7 @@ jobs:
 
   update-dependents:
     name: 'Publish Release'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     environment: production
     needs: [check, release, cache-cabal, cache-stack, cache-stack-haddock]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
 
   check:
     name: 'Check'
-    runs-on: ubuntu-21.10
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2.3.4
@@ -44,7 +44,7 @@ jobs:
 
   release:
     name: 'Release'
-    runs-on: ubuntu-21.10
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2.3.4
@@ -70,7 +70,7 @@ jobs:
 
   cache-cabal:
     name: 'Cache Cabal'
-    runs-on: ubuntu-21.10
+    runs-on: ubuntu-20.04
     env:
       ghc_version: "8.10.7"
     steps:
@@ -105,7 +105,7 @@ jobs:
 
   cache-stack:
     name: 'Cache Stack'
-    runs-on: ubuntu-21.10
+    runs-on: ubuntu-20.04
     steps:
       - name: Install prerequisites
         run: |
@@ -138,7 +138,7 @@ jobs:
 
   cache-stack-haddock:
     name: 'Cache Stack Haddock'
-    runs-on: ubuntu-21.10
+    runs-on: ubuntu-20.04
     steps:
       - name: Install prerequisites
         run: |
@@ -171,7 +171,7 @@ jobs:
 
   update-dependents:
     name: 'Publish Release'
-    runs-on: ubuntu-21.10
+    runs-on: ubuntu-20.04
     environment: production
     needs: [check, release, cache-cabal, cache-stack, cache-stack-haddock]
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: ubuntu-21.10
-            os: ubuntu-21.10
+          - runner: ubuntu-20.04
+            os: ubuntu-20.04
           - runner: macos-12
             os: macos-12
           - runner: MacM1
@@ -66,7 +66,7 @@ jobs:
 
   nix-integration:
     name: 'Nix / Integration'
-    runs-on: ubuntu-21.10
+    runs-on: ubuntu-20.04
     needs: nix-build
     steps:
       - name: Check out code
@@ -95,7 +95,7 @@ jobs:
 
   cabal:
     name: 'Cabal / Unit Tests'
-    runs-on: ubuntu-21.10
+    runs-on: ubuntu-20.04
     env:
       ghc_version: "8.10.7"
     steps:
@@ -135,7 +135,7 @@ jobs:
 
   stack:
     name: 'Stack / Unit Tests'
-    runs-on: ubuntu-21.10
+    runs-on: ubuntu-20.04
     steps:
       - name: Install prerequisites
         run: |
@@ -176,7 +176,7 @@ jobs:
 
   stack-haddock:
     name: 'Stack / Haddock check'
-    runs-on: ubuntu-21.10
+    runs-on: ubuntu-20.04
     steps:
       - name: Install prerequisites
         run: |
@@ -209,7 +209,7 @@ jobs:
           stack haddock --fast
   hlint:
     name: 'HLint'
-    runs-on: ubuntu-21.10
+    runs-on: ubuntu-20.04
     env:
       hlint_version: "3.4.1"
     steps:
@@ -228,7 +228,7 @@ jobs:
   performance:
     needs: [nix-build]
     name: 'Performance'
-    runs-on: ubuntu-21.10
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: ubuntu-latest
-            os: ubuntu-latest
+          - runner: ubuntu-21.10
+            os: ubuntu-21.10
           - runner: macos-12
             os: macos-12
           - runner: MacM1
@@ -66,7 +66,7 @@ jobs:
 
   nix-integration:
     name: 'Nix / Integration'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     needs: nix-build
     steps:
       - name: Check out code
@@ -95,7 +95,7 @@ jobs:
 
   cabal:
     name: 'Cabal / Unit Tests'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     env:
       ghc_version: "8.10.7"
     steps:
@@ -135,7 +135,7 @@ jobs:
 
   stack:
     name: 'Stack / Unit Tests'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     steps:
       - name: Install prerequisites
         run: |
@@ -176,7 +176,7 @@ jobs:
 
   stack-haddock:
     name: 'Stack / Haddock check'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     steps:
       - name: Install prerequisites
         run: |
@@ -209,7 +209,7 @@ jobs:
           stack haddock --fast
   hlint:
     name: 'HLint'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     env:
       hlint_version: "3.4.1"
     steps:
@@ -228,7 +228,7 @@ jobs:
   performance:
     needs: [nix-build]
     name: 'Performance'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     steps:
       - name: Check out code
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   nix:
     name: 'Nix'
-    runs-on: ubuntu-21.10
+    runs-on: ubuntu-20.04
     steps:
       - id: config
         run: |
@@ -76,7 +76,7 @@ jobs:
 
   fourmolu:
     name: 'Style'
-    runs-on: ubuntu-21.10
+    runs-on: ubuntu-20.04
     steps:
       - id: config
         run: |

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   nix:
     name: 'Nix'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     steps:
       - id: config
         run: |
@@ -76,7 +76,7 @@ jobs:
 
   fourmolu:
     name: 'Style'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     steps:
       - id: config
         run: |


### PR DESCRIPTION
Fixes #3397

Seems ubuntu-latest (i.e. 22.04) breaks the cachix action: https://github.com/cachix/cachix-action/issues/130