### PR TITLE
Remove `UnifierT` from `NotSimplifier`

### DIFF
--- a/kore/src/Kore/Builtin/Map.hs
+++ b/kore/src/Kore/Builtin/Map.hs
@@ -768,11 +768,12 @@ unifyNotInKeys resultSort unifyChildren (NotSimplifier notSimplifier) unifyData 
             -- the terms are all wrapped in \ceil below.
             unificationSolutions <-
                 fmap eraseTerm <$> Unify.gather (unifyChildren t1 t2)
-            lift $ (notSimplifier SideCondition.top)
-                Not
-                    { notSort = resultSort
-                    , notChild = OrPattern.fromPatterns unificationSolutions
-                    }
+            lift $
+                (notSimplifier SideCondition.top)
+                    Not
+                        { notSort = resultSort
+                        , notChild = OrPattern.fromPatterns unificationSolutions
+                        }
             >>= Unify.scatter
 
     collectConditions terms = fold terms & Pattern.fromCondition resultSort

--- a/kore/src/Kore/Builtin/Map.hs
+++ b/kore/src/Kore/Builtin/Map.hs
@@ -711,11 +711,14 @@ matchUnifyNotInKeys first second
 {-# INLINE matchUnifyNotInKeys #-}
 
 unifyNotInKeys ::
-    forall unifier.
+    forall unifier simplifier t.
+    MonadSimplify simplifier =>
     MonadUnify unifier =>
+    MonadTrans t =>
+    t simplifier ~ unifier =>
     Sort ->
     TermSimplifier RewritingVariableName unifier ->
-    NotSimplifier unifier ->
+    NotSimplifier simplifier ->
     UnifyNotInKeysResult ->
     unifier (Pattern RewritingVariableName)
 unifyNotInKeys resultSort unifyChildren (NotSimplifier notSimplifier) unifyData =
@@ -765,7 +768,7 @@ unifyNotInKeys resultSort unifyChildren (NotSimplifier notSimplifier) unifyData 
             -- the terms are all wrapped in \ceil below.
             unificationSolutions <-
                 fmap eraseTerm <$> Unify.gather (unifyChildren t1 t2)
-            (notSimplifier SideCondition.top)
+            lift $ (notSimplifier SideCondition.top)
                 Not
                     { notSort = resultSort
                     , notChild = OrPattern.fromPatterns unificationSolutions

--- a/kore/src/Kore/Simplify/And.hs
+++ b/kore/src/Kore/Simplify/And.hs
@@ -100,7 +100,7 @@ Also, we have
 -}
 simplify ::
     Sort ->
-    NotSimplifier (UnifierT Simplifier) ->
+    NotSimplifier Simplifier ->
     SideCondition RewritingVariableName ->
     MultiAnd (OrPattern RewritingVariableName) ->
     Simplifier (OrPattern RewritingVariableName)
@@ -117,7 +117,7 @@ makeEvaluate ::
     HasCallStack =>
     MonadSimplify simplifier =>
     Sort ->
-    NotSimplifier (UnifierT simplifier) ->
+    NotSimplifier simplifier ->
     SideCondition RewritingVariableName ->
     MultiAnd (Pattern RewritingVariableName) ->
     LogicT simplifier (Pattern RewritingVariableName)
@@ -131,7 +131,7 @@ makeEvaluateNonBool ::
     HasCallStack =>
     MonadSimplify simplifier =>
     Sort ->
-    NotSimplifier (UnifierT simplifier) ->
+    NotSimplifier simplifier ->
     SideCondition RewritingVariableName ->
     MultiAnd (Pattern RewritingVariableName) ->
     LogicT simplifier (Pattern RewritingVariableName)
@@ -221,7 +221,7 @@ termAnd ::
     forall simplifier.
     MonadSimplify simplifier =>
     HasCallStack =>
-    NotSimplifier (UnifierT simplifier) ->
+    NotSimplifier simplifier ->
     TermLike RewritingVariableName ->
     TermLike RewritingVariableName ->
     LogicT simplifier (Pattern RewritingVariableName)

--- a/kore/src/Kore/Simplify/AndTerms.hs
+++ b/kore/src/Kore/Simplify/AndTerms.hs
@@ -101,10 +101,13 @@ The comment for 'Kore.Simplify.And.simplify' describes all
 the special cases handled by this.
 -}
 termUnification ::
-    forall unifier.
+    forall unifier simplifier t.
+    MonadSimplify simplifier =>
     MonadUnify unifier =>
+    MonadTrans t =>
+    t simplifier ~ unifier =>
     HasCallStack =>
-    NotSimplifier unifier ->
+    NotSimplifier simplifier ->
     TermLike RewritingVariableName ->
     TermLike RewritingVariableName ->
     unifier (Pattern RewritingVariableName)
@@ -135,9 +138,12 @@ termUnification notSimplifier = \term1 term2 ->
             & return
 
 maybeTermEquals ::
+    MonadSimplify simplifier =>
     MonadUnify unifier =>
+    MonadTrans t =>
+    t simplifier ~ unifier =>
     HasCallStack =>
-    NotSimplifier unifier ->
+    NotSimplifier simplifier ->
     -- | Used to simplify subterm "and".
     TermSimplifier RewritingVariableName unifier ->
     TermLike RewritingVariableName ->
@@ -220,9 +226,12 @@ maybeTermEquals notSimplifier childTransformers first second = do
         | otherwise = empty
 
 maybeTermAnd ::
+    MonadSimplify simplifier =>
     MonadUnify unifier =>
+    MonadTrans t =>
+    t simplifier ~ unifier =>
     HasCallStack =>
-    NotSimplifier unifier ->
+    NotSimplifier simplifier ->
     -- | Used to simplify subterm "and".
     TermSimplifier RewritingVariableName unifier ->
     TermLike RewritingVariableName ->

--- a/kore/src/Kore/Simplify/Equals.hs
+++ b/kore/src/Kore/Simplify/Equals.hs
@@ -70,10 +70,8 @@ import Kore.Simplify.Or qualified as Or (
 import Kore.Simplify.Simplify
 import Kore.Sort (sameSort)
 import Kore.Unification.UnifierT (
+    UnifierT,
     runUnifierT,
- )
-import Kore.Unification.Unify (
-    MonadUnify,
  )
 import Logic (
     LogicT,
@@ -424,24 +422,20 @@ termEqualsAnd p1 p2 =
     MaybeT $ run $ maybeTermEqualsWorker p1 p2
   where
     run it =
-        (runUnifierT Not.notSimplifier . runMaybeT) it
+        (lift . runUnifierT Not.notSimplifier . runMaybeT) it
             >>= Logic.scatter
 
     maybeTermEqualsWorker ::
-        forall unifier.
-        MonadUnify unifier =>
         TermLike RewritingVariableName ->
         TermLike RewritingVariableName ->
-        MaybeT unifier (Pattern RewritingVariableName)
+        MaybeT (UnifierT Simplifier) (Pattern RewritingVariableName)
     maybeTermEqualsWorker =
         maybeTermEquals Not.notSimplifier termEqualsAndWorker
 
     termEqualsAndWorker ::
-        forall unifier.
-        MonadUnify unifier =>
         TermLike RewritingVariableName ->
         TermLike RewritingVariableName ->
-        unifier (Pattern RewritingVariableName)
+        UnifierT Simplifier (Pattern RewritingVariableName)
     termEqualsAndWorker first second =
         scatterResults
             =<< runMaybeT (maybeTermEqualsWorker first second)

--- a/kore/src/Kore/Unification/SubstitutionSimplifier.hs
+++ b/kore/src/Kore/Unification/SubstitutionSimplifier.hs
@@ -57,6 +57,7 @@ import Kore.TopBottom qualified as TopBottom
 import Kore.Unification.Unify
 import Logic qualified
 import Prelude.Kore
+import Kore.Simplify.Simplify (MonadSimplify)
 
 {- | A 'SubstitutionSimplifier' to use during unification.
 
@@ -64,9 +65,12 @@ If multiple assignments to a single variable cannot be unified, this simplifier
 uses 'Unifier.throwUnificationError'.
 -}
 substitutionSimplifier ::
-    forall unifier.
+    forall unifier simplifier t.
+    MonadSimplify simplifier =>
     MonadUnify unifier =>
-    NotSimplifier unifier ->
+    MonadTrans t =>
+    t simplifier ~ unifier =>
+    NotSimplifier simplifier ->
     SubstitutionSimplifier unifier
 substitutionSimplifier notSimplifier =
     SubstitutionSimplifier wrapper
@@ -100,9 +104,12 @@ substitutionSimplifier notSimplifier =
                 (unificationMakeAnd notSimplifier)
 
 unificationMakeAnd ::
-    forall unifier.
+    forall unifier simplifier t.
+    MonadSimplify simplifier =>
     MonadUnify unifier =>
-    NotSimplifier unifier ->
+    MonadTrans t =>
+    t simplifier ~ unifier =>
+    NotSimplifier simplifier ->
     MakeAnd unifier
 unificationMakeAnd notSimplifier =
     MakeAnd{makeAnd}

--- a/kore/src/Kore/Unification/SubstitutionSimplifier.hs
+++ b/kore/src/Kore/Unification/SubstitutionSimplifier.hs
@@ -46,6 +46,7 @@ import Kore.Simplify.AndTerms (
     termUnification,
  )
 import Kore.Simplify.NotSimplifier
+import Kore.Simplify.Simplify (MonadSimplify)
 import Kore.Simplify.Simplify qualified as Simplifier
 import Kore.Simplify.SubstitutionSimplifier (
     MakeAnd (..),
@@ -57,7 +58,6 @@ import Kore.TopBottom qualified as TopBottom
 import Kore.Unification.Unify
 import Logic qualified
 import Prelude.Kore
-import Kore.Simplify.Simplify (MonadSimplify)
 
 {- | A 'SubstitutionSimplifier' to use during unification.
 

--- a/kore/src/Kore/Unification/UnifierT.hs
+++ b/kore/src/Kore/Unification/UnifierT.hs
@@ -82,7 +82,7 @@ instance MonadSimplify m => MonadUnify (UnifierT m)
 
 runUnifierT ::
     MonadSimplify m =>
-    NotSimplifier (UnifierT m) ->
+    NotSimplifier m ->
     UnifierT m a ->
     m [a]
 runUnifierT notSimplifier =
@@ -91,7 +91,7 @@ runUnifierT notSimplifier =
 
 evalEnvUnifierT ::
     MonadSimplify m =>
-    NotSimplifier (UnifierT m) ->
+    NotSimplifier m ->
     UnifierT m a ->
     LogicT m a
 evalEnvUnifierT notSimplifier =

--- a/kore/test/Test/Kore/Unification/Unifier.hs
+++ b/kore/test/Test/Kore/Unification/Unifier.hs
@@ -28,6 +28,7 @@ import Kore.Simplify.Not qualified as Not
 import Kore.Simplify.Pattern qualified as Pattern
 import Kore.Simplify.Simplify (
     Env (..),
+    MonadSimplify,
     runSimplifier,
  )
 import Kore.Simplify.SubstitutionSimplifier qualified as SubstitutionSimplifier
@@ -169,6 +170,9 @@ data UnificationResult = UnificationResult
 
 simplifyAnds ::
     Monad.Unify.MonadUnify unifier =>
+    MonadSimplify simplifier =>
+    MonadTrans t =>
+    t simplifier ~ unifier =>
     NonEmpty (TermLike RewritingVariableName) ->
     unifier (Pattern RewritingVariableName)
 simplifyAnds =


### PR DESCRIPTION
Fixes #3362

### Scope:
Remove the redundant `UnifierT` from `NotSimplifier` as it creates nested `UnifierT`s.
### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
