### PR TITLE
Monomorphization of Simplifier, leg 4

### DIFF
--- a/kore/src/Kore/Builtin/AssociativeCommutative.hs
+++ b/kore/src/Kore/Builtin/AssociativeCommutative.hs
@@ -1057,7 +1057,7 @@ unifyEqualsNormalizedAc
             TermLike RewritingVariableName ->
             unifier (Pattern RewritingVariableName)
         simplify term =
-            simplifyPatternScatter SideCondition.topTODO (Pattern.fromTermLike term)
+            mapLogicT liftSimplifier (simplifyPatternScatter SideCondition.topTODO (Pattern.fromTermLike term))
                 & lowerLogicT
 
         simplifyPair ::
@@ -1106,7 +1106,7 @@ unifyEqualsNormalizedAc
                 TermLike RewritingVariableName ->
                 unifier (Pattern RewritingVariableName)
             simplifyTermLike' term =
-                simplifyPatternScatter SideCondition.topTODO (Pattern.fromTermLike term)
+                mapLogicT liftSimplifier (simplifyPatternScatter SideCondition.topTODO (Pattern.fromTermLike term))
                     & lowerLogicT
 
 buildResultFromUnifiers ::

--- a/kore/src/Kore/Rewrite/Function/Evaluator.hs
+++ b/kore/src/Kore/Rewrite/Function/Evaluator.hs
@@ -348,10 +348,11 @@ maybeEvaluatePattern
                                             }
                                     )
                         _ -> return result
-                    liftSimplifier $ mergeWithConditionAndSubstitution
-                        sideCondition
-                        childrenCondition
-                        flattened
+                    liftSimplifier $
+                        mergeWithConditionAndSubstitution
+                            sideCondition
+                            childrenCondition
+                            flattened
                 case merged of
                     AttemptedAxiom.NotApplicable ->
                         defaultValue Nothing

--- a/kore/src/Kore/Rewrite/Function/Evaluator.hs
+++ b/kore/src/Kore/Rewrite/Function/Evaluator.hs
@@ -348,7 +348,7 @@ maybeEvaluatePattern
                                             }
                                     )
                         _ -> return result
-                    mergeWithConditionAndSubstitution
+                    liftSimplifier $ mergeWithConditionAndSubstitution
                         sideCondition
                         childrenCondition
                         flattened
@@ -433,14 +433,13 @@ sortInjectionSorts symbol =
 
 -- | Ands the given condition-substitution to the given function evaluation.
 mergeWithConditionAndSubstitution ::
-    MonadSimplify simplifier =>
     -- | Top level condition.
     SideCondition RewritingVariableName ->
     -- | Condition and substitution to add.
     Condition RewritingVariableName ->
     -- | AttemptedAxiom to which the condition should be added.
     AttemptedAxiom RewritingVariableName ->
-    simplifier (AttemptedAxiom RewritingVariableName)
+    Simplifier (AttemptedAxiom RewritingVariableName)
 mergeWithConditionAndSubstitution _ _ AttemptedAxiom.NotApplicable =
     return AttemptedAxiom.NotApplicable
 mergeWithConditionAndSubstitution

--- a/kore/src/Kore/Simplify/AndPredicates.hs
+++ b/kore/src/Kore/Simplify/AndPredicates.hs
@@ -28,20 +28,17 @@ import Kore.Rewrite.RewritingVariable (
  )
 import Kore.Rewrite.Substitution qualified as Substitution
 import Kore.Simplify.Simplify (
-    MonadSimplify,
-    liftSimplifier,
+    Simplifier,
  )
 import Logic qualified as LogicT
 import Prelude.Kore
 
 simplifyEvaluatedMultiPredicate ::
-    forall simplifier.
-    MonadSimplify simplifier =>
     SideCondition RewritingVariableName ->
     MultiAnd (OrCondition RewritingVariableName) ->
-    simplifier (OrCondition RewritingVariableName)
+    Simplifier (OrCondition RewritingVariableName)
 simplifyEvaluatedMultiPredicate sideCondition predicates =
-    liftSimplifier . MultiOr.observeAllT $ do
+    MultiOr.observeAllT $ do
         element <- MultiAnd.traverse LogicT.scatter predicates
         andConditions element
   where

--- a/kore/src/Kore/Simplify/Equals.hs
+++ b/kore/src/Kore/Simplify/Equals.hs
@@ -236,15 +236,13 @@ makeEvaluateFunctionalOr sideCondition first seconds = do
     secondNotCeils <- traverse mkNotSimplified secondCeils
     let oneNotBottom = foldl' Or.simplifyEvaluated OrPattern.bottom secondCeils
     allAreBottom <-
-        liftSimplifier $
             (And.simplify sort Not.notSimplifier sideCondition)
                 (MultiAnd.make (firstNotCeil : secondNotCeils))
     firstEqualsSeconds <-
         mapM
-            (liftSimplifier . makeEvaluateEqualsIfSecondNotBottom sort first)
+            (makeEvaluateEqualsIfSecondNotBottom sort first)
             (zip seconds secondCeils)
     oneIsNotBottomEquals <-
-        liftSimplifier $
             (And.simplify sort Not.notSimplifier sideCondition)
                 (MultiAnd.make (firstCeil : oneNotBottom : firstEqualsSeconds))
     MultiOr.merge allAreBottom oneIsNotBottomEquals
@@ -305,11 +303,9 @@ makeEvaluate
             secondCeilNegation <- mkNotSimplified secondCeil
             termEquality <- makeEvaluateTermsAssumesNoBottom firstTerm secondTerm
             negationAnd <-
-                liftSimplifier $
                     (And.simplify sort Not.notSimplifier sideCondition)
                         (MultiAnd.make [firstCeilNegation, secondCeilNegation])
             equalityAnd <-
-                liftSimplifier $
                     (And.simplify sort Not.notSimplifier sideCondition)
                         (MultiAnd.make [termEquality, firstCeil, secondCeil])
             Or.simplifyEvaluated equalityAnd negationAnd
@@ -364,15 +360,14 @@ because it returns an 'or').
 See 'simplify' for detailed documentation.
 -}
 makeEvaluateTermsToPredicate ::
-    MonadSimplify simplifier =>
     TermLike RewritingVariableName ->
     TermLike RewritingVariableName ->
     SideCondition RewritingVariableName ->
-    simplifier (OrCondition RewritingVariableName)
+    Simplifier (OrCondition RewritingVariableName)
 makeEvaluateTermsToPredicate first second sideCondition
     | first == second = return OrCondition.top
     | otherwise = do
-        result <- liftSimplifier . runMaybeT $ termEquals first second
+        result <- runMaybeT $ termEquals first second
         case result of
             Nothing ->
                 return $
@@ -380,8 +375,8 @@ makeEvaluateTermsToPredicate first second sideCondition
                         Predicate.markSimplified $
                             makeEqualsPredicate first second
             Just predicatedOr -> do
-                firstCeilOr <- liftSimplifier $ makeEvaluateTermCeil sideCondition first
-                secondCeilOr <- liftSimplifier $ makeEvaluateTermCeil sideCondition second
+                firstCeilOr <- makeEvaluateTermCeil sideCondition first
+                secondCeilOr <- makeEvaluateTermCeil sideCondition second
                 firstCeilNegation <- Not.simplifyEvaluatedPredicate firstCeilOr
                 secondCeilNegation <- Not.simplifyEvaluatedPredicate secondCeilOr
                 ceilNegationAnd <-

--- a/kore/src/Kore/Simplify/Equals.hs
+++ b/kore/src/Kore/Simplify/Equals.hs
@@ -236,15 +236,15 @@ makeEvaluateFunctionalOr sideCondition first seconds = do
     secondNotCeils <- traverse mkNotSimplified secondCeils
     let oneNotBottom = foldl' Or.simplifyEvaluated OrPattern.bottom secondCeils
     allAreBottom <-
-            (And.simplify sort Not.notSimplifier sideCondition)
-                (MultiAnd.make (firstNotCeil : secondNotCeils))
+        (And.simplify sort Not.notSimplifier sideCondition)
+            (MultiAnd.make (firstNotCeil : secondNotCeils))
     firstEqualsSeconds <-
         mapM
             (makeEvaluateEqualsIfSecondNotBottom sort first)
             (zip seconds secondCeils)
     oneIsNotBottomEquals <-
-            (And.simplify sort Not.notSimplifier sideCondition)
-                (MultiAnd.make (firstCeil : oneNotBottom : firstEqualsSeconds))
+        (And.simplify sort Not.notSimplifier sideCondition)
+            (MultiAnd.make (firstCeil : oneNotBottom : firstEqualsSeconds))
     MultiOr.merge allAreBottom oneIsNotBottomEquals
         & MultiOr.map Pattern.withoutTerm
         & return
@@ -303,11 +303,11 @@ makeEvaluate
             secondCeilNegation <- mkNotSimplified secondCeil
             termEquality <- makeEvaluateTermsAssumesNoBottom firstTerm secondTerm
             negationAnd <-
-                    (And.simplify sort Not.notSimplifier sideCondition)
-                        (MultiAnd.make [firstCeilNegation, secondCeilNegation])
+                (And.simplify sort Not.notSimplifier sideCondition)
+                    (MultiAnd.make [firstCeilNegation, secondCeilNegation])
             equalityAnd <-
-                    (And.simplify sort Not.notSimplifier sideCondition)
-                        (MultiAnd.make [termEquality, firstCeil, secondCeil])
+                (And.simplify sort Not.notSimplifier sideCondition)
+                    (MultiAnd.make [termEquality, firstCeil, secondCeil])
             Or.simplifyEvaluated equalityAnd negationAnd
                 & MultiOr.map Pattern.withoutTerm
                 & return

--- a/kore/src/Kore/Simplify/Not.hs
+++ b/kore/src/Kore/Simplify/Not.hs
@@ -88,9 +88,8 @@ simplify sideCondition not'@Not{notSort} =
         mkMultiAndPattern notSort sideCondition andPattern
 
 simplifyEvaluatedPredicate ::
-    MonadSimplify simplifier =>
     OrCondition RewritingVariableName ->
-    simplifier (OrCondition RewritingVariableName)
+    Simplifier (OrCondition RewritingVariableName)
 simplifyEvaluatedPredicate notChild =
     OrCondition.observeAllT $ do
         let not' = Not{notChild = notChild, notSort = ()}

--- a/kore/src/Kore/Simplify/Simplify.hs
+++ b/kore/src/Kore/Simplify/Simplify.hs
@@ -339,11 +339,9 @@ instance MonadSimplify m => MonadSimplify (RWST r () s m)
 -- TODO (thomas.tuegel): Factor out these types.
 
 simplifyPatternScatter ::
-    forall simplifier.
-    (MonadLogic simplifier, MonadSimplify simplifier) =>
     SideCondition RewritingVariableName ->
     Pattern RewritingVariableName ->
-    simplifier (Pattern RewritingVariableName)
+    LogicT Simplifier (Pattern RewritingVariableName)
 simplifyPatternScatter sideCondition patt =
     Logic.scatter
         =<< liftSimplifier (simplifyPattern sideCondition patt)


### PR DESCRIPTION
Work on https://github.com/runtimeverification/haskell-backend/issues/3325 (partially fixes this issue)

### Scope:
The 4th leg of the Simplifier monomorphization.
Modules affected:
`Kore.Builtin.AssociativeCommutative`
`Kore.Rewrite.Function.Evaluator`
`Kore.Simplify.AndPredicates`
`Kore.Simplify.Condition`
`Kore.Simplify.Equals`
`Kore.Simplify.Not`
`Kore.Simplify.Simplify`



### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
