### PR TITLE
Update nix to >=2.4 in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,9 @@ jobs:
           extra_nix_config: |
             substituters = http://cache.nixos.org https://hydra.iohk.io
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
-          install_url: "https://releases.nixos.org/nix/nix-2.3.16/install"
+          # Keep nix at <=2.7 https://github.com/NixOS/nix/issues/6572
+          # but >= 2.4 due to ZSTD compression done by cachix >=1.1 https://blog.cachix.org/posts/2022-12-19-zstd-compression/
+          install_url: https://releases.nixos.org/nix/nix-2.7.0/install
 
       - name: Install Cachix
         uses: cachix/cachix-action@v10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
         uses: cachix/install-nix-action@v15
         with:
           # Keep nix at <=2.7 https://github.com/NixOS/nix/issues/6572
+          # but >= 2.4 due to ZSTD compression done by cachix >=1.1 https://blog.cachix.org/posts/2022-12-19-zstd-compression/
           install_url: https://releases.nixos.org/nix/nix-2.7.0/install
           extra_nix_config: |
             substituters = http://cache.nixos.org https://cache.iog.io
@@ -82,7 +83,9 @@ jobs:
           extra_nix_config: |
             substituters = http://cache.nixos.org https://hydra.iohk.io
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
-          install_url: "https://releases.nixos.org/nix/nix-2.3.16/install"
+          # Keep nix at <=2.7 https://github.com/NixOS/nix/issues/6572
+          # but >= 2.4 due to ZSTD compression done by cachix >=1.1 https://blog.cachix.org/posts/2022-12-19-zstd-compression/
+          install_url: https://releases.nixos.org/nix/nix-2.7.0/install
 
       - name: Install Cachix
         uses: cachix/cachix-action@v10
@@ -243,7 +246,9 @@ jobs:
           extra_nix_config: |
             substituters = http://cache.nixos.org https://hydra.iohk.io
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
-          install_url: "https://releases.nixos.org/nix/nix-2.3.16/install"
+          # Keep nix at <=2.7 https://github.com/NixOS/nix/issues/6572
+          # but >= 2.4 due to ZSTD compression done by cachix >=1.1 https://blog.cachix.org/posts/2022-12-19-zstd-compression/
+          install_url: https://releases.nixos.org/nix/nix-2.7.0/install
 
       - name: Install Cachix
         uses: cachix/cachix-action@v10

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -34,6 +34,9 @@ jobs:
           extra_nix_config: |
             substituters = http://cache.nixos.org https://cache.iog.io
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+          # Keep nix at <=2.7 https://github.com/NixOS/nix/issues/6572
+          # but >= 2.4 due to ZSTD compression done by cachix >=1.1 https://blog.cachix.org/posts/2022-12-19-zstd-compression/
+          install_url: https://releases.nixos.org/nix/nix-2.7.0/install
 
       - name: 'Install Cachix'
         uses: cachix/cachix-action@v10


### PR DESCRIPTION
CI jobs recently started failing with

```
unknown compression method 'zstd'
```

This is because cachix started rolling out ZSTD compression for all it's caches, which means we need nix >=2.4, which is the first release which supports this new compression. THe affected CI runs were on 2.3.*.

See the announcement: https://blog.cachix.org/posts/2022-12-19-zstd-compression/