### PR TITLE
add debug-rewrite repl command

### DIFF
--- a/kore/src/Kore/Repl/Data.hs
+++ b/kore/src/Kore/Repl/Data.hs
@@ -46,6 +46,9 @@ module Kore.Repl.Data (
     debugAttemptEquationTransformer,
     debugApplyEquationTransformer,
     debugEquationTransformer,
+    debugAttemptRewriteTransformer,
+    debugApplyRewriteTransformer,
+    debugRewriteTransformer,
     entriesForHelp,
     TryApplyRuleResult (..),
 ) where
@@ -279,6 +282,39 @@ debugEquationTransformer
             { Log.debugEquationOptions = debugEquationOptions
             }
 
+debugAttemptRewriteTransformer ::
+    Log.DebugAttemptRewriteOptions ->
+    Log.KoreLogOptions ->
+    Log.KoreLogOptions
+debugAttemptRewriteTransformer
+    debugAttemptRewriteOptions
+    koreLogOptions =
+        koreLogOptions
+            { Log.debugAttemptRewriteOptions = debugAttemptRewriteOptions
+            }
+
+debugApplyRewriteTransformer ::
+    Log.DebugApplyRewriteOptions ->
+    Log.KoreLogOptions ->
+    Log.KoreLogOptions
+debugApplyRewriteTransformer
+    debugApplyRewriteOptions
+    koreLogOptions =
+        koreLogOptions
+            { Log.debugApplyRewriteOptions = debugApplyRewriteOptions
+            }
+
+debugRewriteTransformer ::
+    Log.DebugRewriteOptions ->
+    Log.KoreLogOptions ->
+    Log.KoreLogOptions
+debugRewriteTransformer
+    debugRewriteOptions
+    koreLogOptions =
+        koreLogOptions
+            { Log.debugRewriteOptions = debugRewriteOptions
+            }
+
 {- | List of available commands for the Repl. Note that we are always in a proof
  state. We pick the first available Claim when we initialize the state.
 -}
@@ -364,6 +400,14 @@ data ReplCommand
     | -- | Log the attempts and the applications of specific
       -- equations.
       DebugEquation Log.DebugEquationOptions
+    | -- | Log debugging information about attempting to
+      -- apply specific rewrite rules.
+      DebugAttemptRewrite Log.DebugAttemptRewriteOptions
+    | -- | Log when specific rewrite rules apply.
+      DebugApplyRewrite Log.DebugApplyRewriteOptions
+    | -- | Log the attempts and the applications of specific
+      -- rewrite rules.
+      DebugRewrite Log.DebugRewriteOptions
     | -- | Exit the repl.
       Exit
     deriving stock (Eq, Show)

--- a/kore/src/Kore/Repl/Interpreter.hs
+++ b/kore/src/Kore/Repl/Interpreter.hs
@@ -314,6 +314,9 @@ replInterpreter0 printAux printKore replCmd = do
             DebugAttemptEquation op -> debugAttemptEquation op $> Continue
             DebugApplyEquation op -> debugApplyEquation op $> Continue
             DebugEquation op -> debugEquation op $> Continue
+            DebugAttemptRewrite op -> debugAttemptRewrite op $> Continue
+            DebugApplyRewrite op -> debugApplyRewrite op $> Continue
+            DebugRewrite op -> debugRewrite op $> Continue
             Exit -> exit
     (ReplOutput output, shouldContinue) <- lift $ evaluateCommand command
     traverse_
@@ -580,6 +583,37 @@ debugEquation ::
 debugEquation debugEquationOptions =
     field @"koreLogOptions"
         %= debugEquationTransformer debugEquationOptions
+
+{- | Log debugging information about attempting to apply
+ specific equations.
+-}
+debugAttemptRewrite ::
+    MonadState ReplState m =>
+    Log.DebugAttemptRewriteOptions ->
+    m ()
+debugAttemptRewrite debugAttemptRewriteOptions =
+    field @"koreLogOptions"
+        %= debugAttemptRewriteTransformer debugAttemptRewriteOptions
+
+-- | Log when specific equations apply.
+debugApplyRewrite ::
+    MonadState ReplState m =>
+    Log.DebugApplyRewriteOptions ->
+    m ()
+debugApplyRewrite debugApplyRewriteOptions =
+    field @"koreLogOptions"
+        %= debugApplyRewriteTransformer debugApplyRewriteOptions
+
+{- | Log the attempts and the applications of specific
+ equations.
+-}
+debugRewrite ::
+    MonadState ReplState m =>
+    Log.DebugRewriteOptions ->
+    m ()
+debugRewrite debugRewriteOptions =
+    field @"koreLogOptions"
+        %= debugRewriteTransformer debugRewriteOptions
 
 -- | Focuses the node with id equals to 'n'.
 selectNode ::

--- a/kore/src/Kore/Repl/Parser.hs
+++ b/kore/src/Kore/Repl/Parser.hs
@@ -302,6 +302,9 @@ logCommand =
         <|> try debugAttemptEquation
         <|> try debugApplyEquation
         <|> debugEquation
+        <|> try debugAttemptRewrite
+        <|> try debugApplyRewrite
+        <|> debugRewrite
 
 log :: Parser ReplCommand
 log = do
@@ -354,6 +357,33 @@ debugEquation =
         . HashSet.fromList
         . fmap Text.pack
         <$$> literal "debug-equation"
+        *> many (quotedOrWordWithout "")
+
+debugAttemptRewrite :: Parser ReplCommand
+debugAttemptRewrite =
+    DebugAttemptRewrite
+        . Log.DebugAttemptRewriteOptions
+        . HashSet.fromList
+        . fmap Text.pack
+        <$$> literal "debug-attempt-rewrite"
+        *> many (quotedOrWordWithout "")
+
+debugApplyRewrite :: Parser ReplCommand
+debugApplyRewrite =
+    DebugApplyRewrite
+        . Log.DebugApplyRewriteOptions
+        . HashSet.fromList
+        . fmap Text.pack
+        <$$> literal "debug-apply-rewrite"
+        *> many (quotedOrWordWithout "")
+
+debugRewrite :: Parser ReplCommand
+debugRewrite =
+    DebugRewrite
+        . Log.DebugRewriteOptions
+        . HashSet.fromList
+        . fmap Text.pack
+        <$$> literal "debug-rewrite"
         *> many (quotedOrWordWithout "")
 
 severity :: Parser Log.Severity

--- a/kore/test/Test/Kore/Repl/Parser.hs
+++ b/kore/test/Test/Kore/Repl/Parser.hs
@@ -72,6 +72,9 @@ test_replParser =
     , debugAttemptEquationTests `tests` "debug-attempt-equation"
     , debugApplyEquationTests `tests` "debug-apply-equation"
     , debugEquationTests `tests` "debug-equation"
+    , debugAttemptRewriteTests `tests` "debug-attempt-rewrite"
+    , debugApplyRewriteTests `tests` "debug-apply-rewrite"
+    , debugRewriteTests `tests` "debug-rewrite"
     ]
 
 tests :: [ParserTest ReplCommand] -> String -> TestTree
@@ -722,6 +725,123 @@ debugEquationTests =
     , "debug-equation MODULE.label1 MODULE.label2"
         `parsesTo_` DebugEquation
             Log.DebugEquationOptions
+                { Log.selected =
+                    fromList
+                        ["MODULE.label1", "MODULE.label2"]
+                }
+    ]
+
+debugAttemptRewriteTests :: [ParserTest ReplCommand]
+debugAttemptRewriteTests =
+    [ "debug-attempt-rewrite"
+        `parsesTo_` DebugAttemptRewrite
+            Log.DebugAttemptRewriteOptions
+                { Log.selected =
+                    fromList
+                        []
+                }
+    , Text.pack ("debug-attempt-rewrite " <> totalBalanceSymbolId)
+        `parsesTo_` DebugAttemptRewrite
+            Log.DebugAttemptRewriteOptions
+                { Log.selected =
+                    fromList
+                        [totalBalanceSymbolId]
+                }
+    , Text.pack ("debug-attempt-rewrite " <> totalBalanceSymbolId <> " " <> plusSymbolId)
+        `parsesTo_` DebugAttemptRewrite
+            Log.DebugAttemptRewriteOptions
+                { Log.selected =
+                    fromList
+                        [totalBalanceSymbolId, plusSymbolId]
+                }
+    , "debug-attempt-rewrite label1 label2"
+        `parsesTo_` DebugAttemptRewrite
+            Log.DebugAttemptRewriteOptions
+                { Log.selected =
+                    fromList
+                        ["label1", "label2"]
+                }
+    , "debug-attempt-rewrite MODULE.label1 MODULE.label2"
+        `parsesTo_` DebugAttemptRewrite
+            Log.DebugAttemptRewriteOptions
+                { Log.selected =
+                    fromList
+                        ["MODULE.label1", "MODULE.label2"]
+                }
+    ]
+
+debugApplyRewriteTests :: [ParserTest ReplCommand]
+debugApplyRewriteTests =
+    [ "debug-apply-rewrite"
+        `parsesTo_` DebugApplyRewrite
+            Log.DebugApplyRewriteOptions
+                { Log.selected =
+                    fromList
+                        []
+                }
+    , Text.pack ("debug-apply-rewrite " <> totalBalanceSymbolId)
+        `parsesTo_` DebugApplyRewrite
+            Log.DebugApplyRewriteOptions
+                { Log.selected =
+                    fromList
+                        [totalBalanceSymbolId]
+                }
+    , Text.pack ("debug-apply-rewrite " <> totalBalanceSymbolId <> " " <> plusSymbolId)
+        `parsesTo_` DebugApplyRewrite
+            Log.DebugApplyRewriteOptions
+                { Log.selected =
+                    fromList
+                        [totalBalanceSymbolId, plusSymbolId]
+                }
+    , "debug-apply-rewrite label1 label2"
+        `parsesTo_` DebugApplyRewrite
+            Log.DebugApplyRewriteOptions
+                { Log.selected =
+                    fromList
+                        ["label1", "label2"]
+                }
+    , "debug-apply-rewrite MODULE.label1 MODULE.label2"
+        `parsesTo_` DebugApplyRewrite
+            Log.DebugApplyRewriteOptions
+                { Log.selected =
+                    fromList
+                        ["MODULE.label1", "MODULE.label2"]
+                }
+    ]
+
+debugRewriteTests :: [ParserTest ReplCommand]
+debugRewriteTests =
+    [ "debug-rewrite"
+        `parsesTo_` DebugRewrite
+            Log.DebugRewriteOptions
+                { Log.selected =
+                    fromList
+                        []
+                }
+    , Text.pack ("debug-rewrite" <> totalBalanceSymbolId)
+        `parsesTo_` DebugRewrite
+            Log.DebugRewriteOptions
+                { Log.selected =
+                    fromList
+                        [totalBalanceSymbolId]
+                }
+    , Text.pack ("debug-rewrite" <> totalBalanceSymbolId <> " " <> plusSymbolId)
+        `parsesTo_` DebugRewrite
+            Log.DebugRewriteOptions
+                { Log.selected =
+                    fromList
+                        [totalBalanceSymbolId, plusSymbolId]
+                }
+    , "debug-rewrite label1 label2"
+        `parsesTo_` DebugRewrite
+            Log.DebugRewriteOptions
+                { Log.selected =
+                    fromList
+                        ["label1", "label2"]
+                }
+    , "debug-rewrite MODULE.label1 MODULE.label2"
+        `parsesTo_` DebugRewrite
+            Log.DebugRewriteOptions
                 { Log.selected =
                     fromList
                         ["MODULE.label1", "MODULE.label2"]


### PR DESCRIPTION
Fixes #2404 

Added commands `debug-rewrite`, `debug-rewrite-attempt` and `debug-rewrite-apply` which allow to switch on rewrite debugging for labeled rules in repl.

### Scope:

### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [x] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [x] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
