### PR TITLE
Add unparsed versions of commands for kore-repl

### DIFF
--- a/kore/app/repl/Main.hs
+++ b/kore/app/repl/Main.hs
@@ -58,10 +58,10 @@ import Options.Applicative (
     metavar,
     progDesc,
     short,
+    showDefault,
     str,
     strOption,
     value,
-    showDefault,
  )
 import Options.SMT (
     KoreSolverOptions (..),
@@ -178,8 +178,7 @@ parseKoreReplOptions startTime =
     parseKorePrintCommand :: Parser KorePrintCommand
     parseKorePrintCommand =
         KorePrintCommand
-            <$>
-                ( strOption
+            <$> ( strOption
                     ( metavar "EXEC_FILE"
                         <> long "kore-print-command"
                         <> help "Command to run the kore-print pretty printer."

--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -673,6 +673,7 @@ executable kore-repl
   build-depends: clock >=0.8
   build-depends: exceptions >=0.10
   build-depends: extra >= 1.7
+  build-depends: filepath >=1.4
   build-depends: optparse-applicative >=0.14
 
 executable kore-match-disjunction

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -757,6 +757,8 @@ proveWithRepl ::
     ModuleName ->
     KoreLogOptions ->
     KFileLocations ->
+    Repl.Data.KompiledDir ->
+    Repl.Data.KorePrintCommand ->
     SMT ()
 proveWithRepl
     minDepth
@@ -772,7 +774,9 @@ proveWithRepl
     outputFile
     mainModuleName
     logOptions
-    kFileLocations =
+    kFileLocations
+    kompiledDir
+    korePrintCommand =
         evalSimplifierProofs definitionModule $ do
             InitializedProver{axioms, specClaims, claims} <-
                 initializeProver
@@ -794,6 +798,8 @@ proveWithRepl
                 mainModuleName
                 logOptions
                 kFileLocations
+                kompiledDir
+                korePrintCommand
 
 -- | Bounded model check a spec given as a module containing rules to be checked
 boundedModelCheck ::

--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -124,8 +124,10 @@ runRepl ::
     ModuleName ->
     Log.KoreLogOptions ->
     KFileLocations ->
+    KompiledDir ->
+    KorePrintCommand ->
     Simplifier ()
-runRepl _ _ _ _ _ [] _ _ _ _ outputFile _ _ _ =
+runRepl _ _ _ _ _ [] _ _ _ _ outputFile _ _ _ _ _ =
     let printTerm = maybe putStrLn writeFile (unOutputFile outputFile)
      in liftIO . printTerm . unparseToString $ topTerm
   where
@@ -145,7 +147,9 @@ runRepl
     outputFile
     mainModuleName
     logOptions
-    kFileLocations =
+    kFileLocations
+    kompiledDir
+    korePrintCommand =
         do
             startTime <- liftIO $ getTime Monotonic
             (newState, _) <-
@@ -220,6 +224,8 @@ runRepl
                 , outputFile
                 , mainModuleName
                 , kFileLocations
+                , kompiledDir
+                , korePrintCommand
                 }
 
         firstClaimIndex :: ClaimIndex

--- a/kore/src/Kore/Repl/Interpreter.hs
+++ b/kore/src/Kore/Repl/Interpreter.hs
@@ -51,7 +51,7 @@ import Control.Monad.RWS.Strict (
  )
 import Control.Monad.Reader (
     MonadReader,
-    ReaderT (..),
+    ReaderT (..), asks,
  )
 import Control.Monad.Reader qualified as Reader (
     ask,
@@ -273,16 +273,20 @@ replInterpreter0 printAux printKore replCmd = do
             Help -> help $> Continue
             ShowClaim mc -> showClaim mc $> Continue
             ShowAxiom ea -> showAxiom ea $> Continue
+            ShowKAxiom ea -> showUnparsed (ShowAxiom ea) $> Continue
             Prove i -> prove i $> Continue
             ShowGraph v mfile out -> showGraph v mfile out $> Continue
             ProveSteps n -> proveSteps n $> Continue
             ProveStepsF n -> proveStepsF n $> Continue
             SelectNode i -> selectNode i $> Continue
             ShowConfig mc -> showConfig mc $> Continue
+            ShowKonfig mc -> showUnparsed (ShowConfig mc) $> Continue
             ShowDest mc -> showDest mc $> Continue
+            ShowKDest mc -> showUnparsed (ShowDest mc) $> Continue
             OmitCell c -> omitCell c $> Continue
             ShowLeafs -> showLeafs $> Continue
             ShowRule mc -> showRule mc $> Continue
+            ShowKRule mc -> showUnparsed (ShowRule mc) $> Continue
             ShowRules ns -> showRules ns $> Continue
             ShowPrecBranch mn -> showPrecBranch mn $> Continue
             ShowChildren mn -> showChildren mn $> Continue
@@ -293,7 +297,9 @@ replInterpreter0 printAux printKore replCmd = do
                 redirect inn file
                     $> Continue
             Try ref -> tryAxiomClaim ref $> Continue
+            KTry ref -> showUnparsed (Try ref) $> Continue
             TryF ac -> tryFAxiomClaim ac $> Continue
+            KTryF ac -> showUnparsed (TryF ac) $> Continue
             Clear n -> clear n $> Continue
             SaveSession file -> saveSession file $> Continue
             SavePartialProof mn f -> savePartialProof mn f $> Continue
@@ -628,6 +634,14 @@ selectNode rnode = do
     if i `elem` Graph.nodes graph
         then field @"node" .= rnode
         else putStrLn' "Invalid node!"
+
+-- | Pipe result of `ReplCommand` to kore-print.
+showUnparsed :: ReplCommand -> ReplM ()
+showUnparsed cmd = do
+  dir <- asks (unKompiledDir . kompiledDir)
+  exec <- asks (unKorePrintCommand . korePrintCommand)
+  let args = ["--definition", dir, "/dev/stdin"]
+  pipe cmd exec args
 
 -- | Shows configuration at node 'n', or current node if 'Nothing' is passed.
 showConfig ::
@@ -1215,7 +1229,7 @@ pipe ::
 pipe cmd file args = do
     exists <- liftIO $ findExecutable file
     case exists of
-        Nothing -> putStrLn' "Cannot find executable."
+        Nothing -> putStrLn' $ "Cannot find " <> file <> " executable."
         Just exec -> do
             config <- ask
             pipeOutRef <- liftIO $ newIORef (mempty :: ReplOutput)

--- a/kore/src/Kore/Repl/Interpreter.hs
+++ b/kore/src/Kore/Repl/Interpreter.hs
@@ -51,7 +51,8 @@ import Control.Monad.RWS.Strict (
  )
 import Control.Monad.Reader (
     MonadReader,
-    ReaderT (..), asks,
+    ReaderT (..),
+    asks,
  )
 import Control.Monad.Reader qualified as Reader (
     ask,
@@ -638,10 +639,10 @@ selectNode rnode = do
 -- | Pipe result of `ReplCommand` to kore-print.
 showUnparsed :: ReplCommand -> ReplM ()
 showUnparsed cmd = do
-  dir <- asks (unKompiledDir . kompiledDir)
-  exec <- asks (unKorePrintCommand . korePrintCommand)
-  let args = ["--definition", dir, "/dev/stdin"]
-  pipe cmd exec args
+    dir <- asks (unKompiledDir . kompiledDir)
+    exec <- asks (unKorePrintCommand . korePrintCommand)
+    let args = ["--definition", dir, "/dev/stdin"]
+    pipe cmd exec args
 
 -- | Shows configuration at node 'n', or current node if 'Nothing' is passed.
 showConfig ::

--- a/kore/src/Kore/Repl/Parser.hs
+++ b/kore/src/Kore/Repl/Parser.hs
@@ -107,13 +107,16 @@ nonRecursiveCommand =
         [ help
         , showClaim
         , showAxiom
+        , showKAxiom
         , prove
         , showGraph
         , try proveStepsF
         , proveSteps
         , selectNode
         , showConfig
+        , showKonfig
         , showDest
+        , showKDest
         , omitCell
         , showLeafs
         , ruleCommandsParser
@@ -123,7 +126,9 @@ nonRecursiveCommand =
         , try labelDel
         , label
         , tryForceAxiomClaim
+        , tryForceKAxiomClaim
         , tryAxiomClaim
+        , tryKAxiomClaim
         , clear
         , saveSession
         , savePartialProof
@@ -166,6 +171,14 @@ showAxiom =
                 <|> Right <$> ruleNameParser
            )
 
+showKAxiom :: Parser ReplCommand
+showKAxiom =
+    ShowKAxiom
+        <$$> literal "kaxiom"
+        *> ( Left <$> parseAxiomDecimal
+                <|> Right <$> ruleNameParser
+           )
+
 prove :: Parser ReplCommand
 prove =
     Prove
@@ -198,10 +211,20 @@ showConfig = do
     dec <- literal "config" *> maybeDecimal
     return $ ShowConfig (fmap ReplNode dec)
 
+showKonfig :: Parser ReplCommand
+showKonfig = do
+    dec <- literal "konfig" *> maybeDecimal
+    return $ ShowKonfig (fmap ReplNode dec)
+
 showDest :: Parser ReplCommand
 showDest = do
     dec <- literal "dest" *> maybeDecimal
     return $ ShowDest (fmap ReplNode dec)
+
+showKDest :: Parser ReplCommand
+showKDest = do
+    dec <- literal "kdest" *> maybeDecimal
+    return $ ShowKDest (fmap ReplNode dec)
 
 omitCell :: Parser ReplCommand
 omitCell = OmitCell <$$> literal "omit" *> maybeWord
@@ -211,12 +234,17 @@ showLeafs = const ShowLeafs <$$> literal "leafs"
 
 ruleCommandsParser :: Parser ReplCommand
 ruleCommandsParser =
-    try showRules <|> showRule
+    try showRules <|> showRule <|> showKRule
 
 showRule :: Parser ReplCommand
 showRule = do
     dec <- literal "rule" *> maybeDecimal
     return $ ShowRule (fmap ReplNode dec)
+
+showKRule :: Parser ReplCommand
+showKRule = do
+    dec <- literal "krule" *> maybeDecimal
+    return $ ShowKRule (fmap ReplNode dec)
 
 showRules :: Parser ReplCommand
 showRules = do
@@ -259,10 +287,26 @@ tryAxiomClaim =
                 <|> ByName <$> ruleNameParser
            )
 
+tryKAxiomClaim :: Parser ReplCommand
+tryKAxiomClaim =
+    KTry
+        <$$> literal "ktry"
+        *> ( try (ByIndex <$> ruleIndexParser)
+                <|> ByName <$> ruleNameParser
+           )
+
 tryForceAxiomClaim :: Parser ReplCommand
 tryForceAxiomClaim =
     TryF
         <$$> literal "tryf"
+        *> ( try (ByIndex <$> ruleIndexParser)
+                <|> ByName <$> ruleNameParser
+           )
+
+tryForceKAxiomClaim :: Parser ReplCommand
+tryForceKAxiomClaim =
+    KTryF
+        <$$> literal "ktryf"
         *> ( try (ByIndex <$> ruleIndexParser)
                 <|> ByName <$> ruleNameParser
            )

--- a/kore/test/Test/Kore/Repl/Interpreter.hs
+++ b/kore/test/Test/Kore/Repl/Interpreter.hs
@@ -842,6 +842,8 @@ mkConfig logger claims' =
         , outputFile = OutputFile Nothing
         , mainModuleName = ModuleName "TEST"
         , kFileLocations = KFileLocations []
+        , kompiledDir = KompiledDir ""
+        , korePrintCommand = KorePrintCommand "kore-print"
         }
   where
     stepper0 ::

--- a/kore/test/Test/Kore/Repl/Parser.hs
+++ b/kore/test/Test/Kore/Repl/Parser.hs
@@ -37,12 +37,15 @@ test_replParser =
     [ helpTests `tests` "help"
     , claimTests `tests` "claim"
     , axiomTests `tests` "axiom"
+    , kaxiomTests `tests` "kaxiom"
     , proveTests `tests` "prove"
     , graphTests `tests` "graph"
     , stepTests `tests` "step"
     , selectTests `tests` "select"
     , configTests `tests` "config"
+    , konfigTests `tests` "konfig"
     , destTests `tests` "dest"
+    , kdestTests `tests` "kdest"
     , leafsTests `tests` "leafs"
     , precBranchTests `tests` "prec-branch"
     , childrenTests `tests` "children"
@@ -50,9 +53,12 @@ test_replParser =
     , omitTests `tests` "omit"
     , labelTests `tests` "label"
     , tryTests `tests` "try"
+    , ktryTests `tests` "ktry"
     , tryFTests `tests` "tryF"
+    , ktryFTests `tests` "ktryF"
     , redirectTests `tests` "redirect"
     , ruleTests `tests` "rule"
+    , kruleTests `tests` "krule"
     , rulesTests `tests` "rules"
     , stepfTests `tests` "stepf"
     , clearTests `tests` "clear"
@@ -123,6 +129,16 @@ axiomTests =
     , "axiom" `fails` ()
     ]
 
+kaxiomTests :: [ParserTest ReplCommand]
+kaxiomTests =
+    [ "kaxiom 0" `parsesTo_` ShowKAxiom (Left . AxiomIndex $ 0)
+    , "kaxiom 0 " `parsesTo_` ShowKAxiom (Left . AxiomIndex $ 0)
+    , "kaxiom 5" `parsesTo_` ShowKAxiom (Left . AxiomIndex $ 5)
+    , "kaxiom lbl" `parsesTo_` ShowKAxiom (Right . RuleName $ "lbl")
+    , "kaxiom \"my lbl\" " `parsesTo_` ShowKAxiom (Right . RuleName $ "my lbl")
+    , "kaxiom" `fails` ()
+    ]
+
 proveTests :: [ParserTest ReplCommand]
 proveTests =
     [ "prove 0" `parsesTo_` Prove (Left . ClaimIndex $ 0)
@@ -187,6 +203,16 @@ configTests =
     , "config | s >> " `fails` ()
     ]
 
+konfigTests :: [ParserTest ReplCommand]
+konfigTests =
+    [ "konfig" `parsesTo_` ShowKonfig Nothing
+    , "konfig " `parsesTo_` ShowKonfig Nothing
+    , "konfig 5" `parsesTo_` ShowKonfig (Just (ReplNode 5))
+    , "konfig -5" `fails` ()
+    , "konfig | > >> file" `fails` ()
+    , "konfig | s >> " `fails` ()
+    ]
+
 destTests :: [ParserTest ReplCommand]
 destTests =
     [ "dest" `parsesTo_` ShowDest Nothing
@@ -195,6 +221,16 @@ destTests =
     , "dest -5" `fails` ()
     , "dest | > >> file" `fails` ()
     , "dest | s >> " `fails` ()
+    ]
+
+kdestTests :: [ParserTest ReplCommand]
+kdestTests =
+    [ "kdest" `parsesTo_` ShowKDest Nothing
+    , "kdest " `parsesTo_` ShowKDest Nothing
+    , "kdest 5" `parsesTo_` ShowKDest (Just (ReplNode 5))
+    , "kdest -5" `fails` ()
+    , "kdest | > >> file" `fails` ()
+    , "kdest | s >> " `fails` ()
     ]
 
 omitTests :: [ParserTest ReplCommand]
@@ -256,6 +292,17 @@ tryTests =
     , "try" `fails` ()
     ]
 
+ktryTests :: [ParserTest ReplCommand]
+ktryTests =
+    [ "ktry a5" `parsesTo_` tryKAxiomIndex 5
+    , "ktry c5" `parsesTo_` tryKClaimIndex 5
+    , "ktry lbl" `parsesTo_` tryKRuleName "lbl"
+    , "ktry \"my lbl\" " `parsesTo_` tryKRuleName "my lbl"
+    , "ktry albl" `parsesTo_` tryKRuleName "albl"
+    , "ktry clbl" `parsesTo_` tryKRuleName "clbl"
+    , "ktry" `fails` ()
+    ]
+
 tryFTests :: [ParserTest ReplCommand]
 tryFTests =
     [ "tryf a5" `parsesTo_` tryFAxiomIndex 5
@@ -267,23 +314,52 @@ tryFTests =
     , "tryf" `fails` ()
     ]
 
+ktryFTests :: [ParserTest ReplCommand]
+ktryFTests =
+    [ "ktryf a5" `parsesTo_` tryFKAxiomIndex 5
+    , "ktryf c5" `parsesTo_` tryFKClaimIndex 5
+    , "ktryf lbl" `parsesTo_` tryFKRuleName "lbl"
+    , "ktryf \"my lbl\" " `parsesTo_` tryFKRuleName "my lbl"
+    , "ktryf albl" `parsesTo_` tryFKRuleName "albl"
+    , "ktryf clbl" `parsesTo_` tryFKRuleName "clbl"
+    , "ktryf" `fails` ()
+    ]
+
 tryAxiomIndex :: Int -> ReplCommand
 tryAxiomIndex = Try . ByIndex . Left . AxiomIndex
+
+tryKAxiomIndex :: Int -> ReplCommand
+tryKAxiomIndex = KTry . ByIndex . Left . AxiomIndex
 
 tryClaimIndex :: Int -> ReplCommand
 tryClaimIndex = Try . ByIndex . Right . ClaimIndex
 
+tryKClaimIndex :: Int -> ReplCommand
+tryKClaimIndex = KTry . ByIndex . Right . ClaimIndex
+
 tryRuleName :: String -> ReplCommand
 tryRuleName = Try . ByName . RuleName
+
+tryKRuleName :: String -> ReplCommand
+tryKRuleName = KTry . ByName . RuleName
 
 tryFAxiomIndex :: Int -> ReplCommand
 tryFAxiomIndex = TryF . ByIndex . Left . AxiomIndex
 
+tryFKAxiomIndex :: Int -> ReplCommand
+tryFKAxiomIndex = KTryF . ByIndex . Left . AxiomIndex
+
 tryFClaimIndex :: Int -> ReplCommand
 tryFClaimIndex = TryF . ByIndex . Right . ClaimIndex
 
+tryFKClaimIndex :: Int -> ReplCommand
+tryFKClaimIndex = KTryF . ByIndex . Right . ClaimIndex
+
 tryFRuleName :: String -> ReplCommand
 tryFRuleName = TryF . ByName . RuleName
+
+tryFKRuleName :: String -> ReplCommand
+tryFKRuleName = KTryF . ByName . RuleName
 
 exitTests :: [ParserTest ReplCommand]
 exitTests =
@@ -390,6 +466,15 @@ ruleTests =
     , "rule 5" `parsesTo_` ShowRule (Just (ReplNode 5))
     , "rule 5 " `parsesTo_` ShowRule (Just (ReplNode 5))
     , "rule -5" `fails` ()
+    ]
+
+kruleTests :: [ParserTest ReplCommand]
+kruleTests =
+    [ "krule" `parsesTo_` ShowKRule Nothing
+    , "krule " `parsesTo_` ShowKRule Nothing
+    , "krule 5" `parsesTo_` ShowKRule (Just (ReplNode 5))
+    , "krule 5 " `parsesTo_` ShowKRule (Just (ReplNode 5))
+    , "krule -5" `fails` ()
     ]
 
 rulesTests :: [ParserTest ReplCommand]

--- a/nix/kore-ghc8107.nix.d/kore.nix
+++ b/nix/kore-ghc8107.nix.d/kore.nix
@@ -623,6 +623,7 @@
           (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
           (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
           (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+          (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
           (hsPkgs."optparse-applicative" or (errorHandler.buildDepError
             "optparse-applicative"))
         ];

--- a/nix/kore-ghc923.nix.d/kore.nix
+++ b/nix/kore-ghc923.nix.d/kore.nix
@@ -623,6 +623,7 @@
           (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
           (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
           (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+          (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
           (hsPkgs."optparse-applicative" or (errorHandler.buildDepError
             "optparse-applicative"))
         ];


### PR DESCRIPTION
Work on #2797 (partially fixes this issue)

### Scope:
Add commands to print unparsed configurations and axioms. 
At the moment, we do not unparse the claims, as there is a bug in the `kore-print` https://github.com/runtimeverification/k/issues/3105.
### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
