### PR TITLE
Revert "Add --allow-vacuous  (#3425)"

### DIFF
--- a/kore/app/exec/Main.hs
+++ b/kore/app/exec/Main.hs
@@ -437,7 +437,6 @@ unparseKoreProveOptions
             saveProofs
             stuckCheck
             minDepth
-            allowVacuous
         ) =
         [ "--prove spec.kore"
         , unwords ["--spec-module", unpack moduleName]
@@ -451,9 +450,6 @@ unparseKoreProveOptions
             Claim.DisabledStuckCheck -> "--disable-stuck-check"
             _ -> ""
         , maybe "" unparseMinDepth minDepth
-        , case allowVacuous of
-            Claim.AllowedVacuous -> "--allow-vacuous"
-            _ -> ""
         ]
       where
         unparseMinDepth md =
@@ -778,11 +774,10 @@ koreProve LocalOptions{execOptions} proveOptions = do
     let KoreExecOptions{koreSolverOptions} = execOptions
     proveResult <- execute koreSolverOptions (MetadataTools.build mainModule) (getSMTLemmas mainModule) $ do
         let KoreExecOptions{breadthLimit, depthLimit, finalNodeType} = execOptions
-            KoreProveOptions{graphSearch, stuckCheck, minDepth, allowVacuous} = proveOptions
+            KoreProveOptions{graphSearch, stuckCheck, minDepth} = proveOptions
         prove
             minDepth
             stuckCheck
-            allowVacuous
             graphSearch
             breadthLimit
             depthLimit

--- a/kore/app/repl/Main.hs
+++ b/kore/app/repl/Main.hs
@@ -266,7 +266,6 @@ mainWithOptions LocalOptions{execOptions} = do
                             $ proveWithRepl
                                 replMinDepth
                                 replStuckCheck
-                                replAllowVacuous
                                 validatedDefinition
                                 specDefIndexedModule
                                 Nothing
@@ -356,6 +355,3 @@ mainWithOptions LocalOptions{execOptions} = do
 
     replMinDepth :: Maybe Claim.MinDepth
     replMinDepth = minDepth proveOptions
-
-    replAllowVacuous :: Claim.AllowVacuous
-    replAllowVacuous = allowVacuous proveOptions

--- a/kore/app/share/GlobalMain.hs
+++ b/kore/app/share/GlobalMain.hs
@@ -131,7 +131,7 @@ import Kore.Parser (
 import Kore.Parser.ParserUtils (
     readPositiveIntegral,
  )
-import Kore.Reachability.Claim (AllowVacuous (..), MinDepth (..), StuckCheck (..))
+import Kore.Reachability.Claim (MinDepth (..), StuckCheck (..))
 import Kore.Rewrite.SMT.Lemma
 import Kore.Rewrite.Strategy (
     GraphSearchOrder (..),
@@ -219,8 +219,6 @@ data KoreProveOptions = KoreProveOptions
       stuckCheck :: !StuckCheck
     , -- | Forces the prover to run at least n steps
       minDepth :: !(Maybe MinDepth)
-    , -- | Enables discharging #Bottom paths as #Top at implication checking time.
-      allowVacuous :: AllowVacuous
     }
 
 parseModuleName :: String -> String -> String -> Parser ModuleName
@@ -277,14 +275,6 @@ parseKoreProveOptions =
                     <> long "min-depth"
                     <> help "Force the prover to execute at least n steps."
                 )
-            )
-        <*> Options.flag
-            DisallowedVacuous
-            AllowedVacuous
-            ( long "allow-vacuous"
-                <> help
-                    "Enables discharging #Bottom paths as #Top at \
-                    \implication checking time."
             )
   where
     parseMinDepth =

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -133,7 +133,6 @@ import Kore.Log.WarnDepthLimitExceeded (
 import Kore.Log.WarnTrivialClaim
 import Kore.ModelChecker.Bounded qualified as Bounded
 import Kore.Reachability (
-    AllowVacuous,
     AlreadyProven (AlreadyProven),
     Axioms (Axioms),
     MinDepth,
@@ -680,7 +679,6 @@ search
 prove ::
     Maybe MinDepth ->
     StuckCheck ->
-    AllowVacuous ->
     Strategy.GraphSearchOrder ->
     Limit Natural ->
     Limit Natural ->
@@ -696,7 +694,6 @@ prove ::
 prove
     maybeMinDepth
     stuckCheck
-    allowVacuous
     searchOrder
     breadthLimit
     depthLimit
@@ -714,7 +711,6 @@ prove
             proveClaims
                 maybeMinDepth
                 stuckCheck
-                allowVacuous
                 breadthLimit
                 searchOrder
                 maxCounterexamples
@@ -738,7 +734,6 @@ prove
 proveWithRepl ::
     Maybe MinDepth ->
     StuckCheck ->
-    AllowVacuous ->
     -- | The main module
     VerifiedModule StepperAttributes ->
     -- | The spec module
@@ -763,7 +758,6 @@ proveWithRepl ::
 proveWithRepl
     minDepth
     stuckCheck
-    allowVacuous
     definitionModule
     specModule
     trustedModule
@@ -786,7 +780,6 @@ proveWithRepl
             Repl.runRepl
                 minDepth
                 stuckCheck
-                allowVacuous
                 axioms
                 specClaims
                 claims

--- a/kore/src/Kore/Log/WarnStuckClaimState.hs
+++ b/kore/src/Kore/Log/WarnStuckClaimState.hs
@@ -9,7 +9,6 @@ module Kore.Log.WarnStuckClaimState (
     WarnStuckClaimState (..),
     warnStuckClaimStateTermsUnifiable,
     warnStuckClaimStateTermsNotUnifiable,
-    warnStuckClaimStateBottomLHS,
 ) where
 
 import Kore.Attribute.SourceLocation
@@ -32,8 +31,6 @@ data WarnStuckClaimState
     | -- | The left- and right-hand side terms are unifiable, but the left-hand side
       -- condition does not imply the right-hand side condition.
       TermsNotUnifiableStuck SomeClaim
-    | -- | The left-hand side of the claim has been simplified to bottom.
-      BottomLHS SomeClaim
     deriving stock (Show)
 
 instance Pretty WarnStuckClaimState where
@@ -47,11 +44,6 @@ instance Pretty WarnStuckClaimState where
         Pretty.hsep
             [ "The configuration's term doesn't unify with the destination's term\
               \ and the configuration cannot be rewritten further. Location:"
-            , Pretty.pretty (from claim :: SourceLocation)
-            ]
-    pretty (BottomLHS claim) =
-        Pretty.hsep
-            [ "The left-hand side of the claim has been simplified to bottom. Location:"
             , Pretty.pretty (from claim :: SourceLocation)
             ]
 
@@ -69,12 +61,6 @@ instance Entry WarnStuckClaimState where
             , Pretty.colon
             , Pretty.pretty @SourceLocation $ from claim
             ]
-    oneLineDoc (BottomLHS claim) =
-        Pretty.hsep
-            [ "BottomLHS:"
-            , Pretty.colon
-            , Pretty.pretty @SourceLocation $ from claim
-            ]
 
     helpDoc _ = "distinguish the ways a proof can become stuck"
 
@@ -83,6 +69,3 @@ warnStuckClaimStateTermsUnifiable = logEntry . TermsUnifiableStuck
 
 warnStuckClaimStateTermsNotUnifiable :: MonadLog log => SomeClaim -> log ()
 warnStuckClaimStateTermsNotUnifiable = logEntry . TermsNotUnifiableStuck
-
-warnStuckClaimStateBottomLHS :: MonadLog log => SomeClaim -> log ()
-warnStuckClaimStateBottomLHS = logEntry . BottomLHS

--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -106,7 +106,6 @@ import Text.Megaparsec (
 runRepl ::
     Maybe MinDepth ->
     StuckCheck ->
-    AllowVacuous ->
     -- | list of axioms to used in the proof
     [Axiom] ->
     [SomeClaim] ->
@@ -127,7 +126,7 @@ runRepl ::
     KompiledDir ->
     KorePrintCommand ->
     Simplifier ()
-runRepl _ _ _ _ _ [] _ _ _ _ outputFile _ _ _ _ _ =
+runRepl _ _ _ _ [] _ _ _ _ outputFile _ _ _ _ _ =
     let printTerm = maybe putStrLn writeFile (unOutputFile outputFile)
      in liftIO . printTerm . unparseToString $ topTerm
   where
@@ -136,7 +135,6 @@ runRepl _ _ _ _ _ [] _ _ _ _ outputFile _ _ _ _ _ =
 runRepl
     minDepth
     stuckCheck
-    allowVacuous
     axioms'
     origClaims
     claims'
@@ -274,7 +272,7 @@ runRepl
             let node = unReplNode rnode
             if Graph.outdeg (Strategy.graph graph) node == 0
                 then
-                    proveClaimStep minDepth stuckCheck allowVacuous origClaims axioms graph node
+                    proveClaimStep minDepth stuckCheck origClaims axioms graph node
                         & Exception.handle (withConfigurationHandler graph)
                         & Exception.handle (someExceptionHandler graph)
                 else pure graph

--- a/kore/test/Test/Kore/Reachability/MockAllPath.hs
+++ b/kore/test/Test/Kore/Reachability/MockAllPath.hs
@@ -228,7 +228,7 @@ test_runStrategy =
         testRunSimplifier Mock.env $
             Strategy.runStrategy
                 Unlimited
-                (Claim.transitionRule Claim.EnabledStuckCheck Claim.AllowedVacuous [MockClaim (unRule goal)] [axioms])
+                (Claim.transitionRule Claim.EnabledStuckCheck [MockClaim (unRule goal)] [axioms])
                 (toList Claim.strategy)
                 (ClaimState.Claimed . MockClaim . unRule $ goal)
     disproves ::
@@ -373,7 +373,7 @@ runTransitionRule ::
     IO [(MockClaimState, Seq MockAppliedRule)]
 runTransitionRule claims axiomGroups prim state =
     (testRunSimplifier Mock.env . runTransitionT)
-        (Claim.transitionRule Claim.EnabledStuckCheck Claim.DisallowedVacuous claims axiomGroups prim state)
+        (Claim.transitionRule Claim.EnabledStuckCheck claims axiomGroups prim state)
 
 differentLengthPaths :: [MockRule]
 differentLengthPaths =

--- a/kore/test/Test/Kore/Reachability/OnePathStrategy.hs
+++ b/kore/test/Test/Kore/Reachability/OnePathStrategy.hs
@@ -913,7 +913,7 @@ runSteps
                 fromMaybe (error "Unexpected missing tree") . graphFilter
                     <$> runStrategy
                         breadthLimit
-                        (transitionRule EnabledStuckCheck AllowedVacuous claims axiomGroups)
+                        (transitionRule EnabledStuckCheck claims axiomGroups)
                         strategy'
                         (Claimed configuration)
       where

--- a/kore/test/Test/Kore/Reachability/Prove.hs
+++ b/kore/test/Test/Kore/Reachability/Prove.hs
@@ -858,7 +858,7 @@ test_transitionRule =
     claim = AllPathClaim $ simpleClaim (mkBottom Mock.testSort) Mock.a
     runTransitionRule claims axiomGroups prim cState =
         runSimplifierSMT Mock.env . runTransitionT $
-            transitionRule EnabledStuckCheck AllowedVacuous claims axiomGroups prim cState
+            transitionRule EnabledStuckCheck claims axiomGroups prim cState
 
 simpleAxiom ::
     TermLike VariableName ->
@@ -947,7 +947,6 @@ proveClaims
         Kore.Reachability.proveClaims
             Nothing
             EnabledStuckCheck
-            AllowedVacuous
             breadthLimit
             BreadthFirst
             maxCounterexamples

--- a/kore/test/Test/Kore/Repl/Interpreter.hs
+++ b/kore/test/Test/Kore/Repl/Interpreter.hs
@@ -852,7 +852,7 @@ mkConfig logger claims' =
         ReplNode ->
         Simplifier ExecutionGraph
     stepper0 axioms' graph (ReplNode node) =
-        proveClaimStep Nothing EnabledStuckCheck DisallowedVacuous claims' axioms' graph node
+        proveClaimStep Nothing EnabledStuckCheck claims' axioms' graph node
 
 formatUnifiers ::
     NonEmpty (Condition RewritingVariableName) ->

--- a/test/assume/Makefile
+++ b/test/assume/Makefile
@@ -1,4 +1,1 @@
 include $(CURDIR)/../include.mk
-
-test-spec.k.out: \
-	KORE_EXEC_OPTS += --allow-vacuous

--- a/test/bottom-lhs/Makefile
+++ b/test/bottom-lhs/Makefile
@@ -1,5 +1,2 @@
 DEF = test
 include $(CURDIR)/../include.mk
-
-test-spec.k.out: \
-	KORE_EXEC_OPTS += --allow-vacuous


### PR DESCRIPTION
This reverts commit eea7841322a69b9032a200880b8783381e961769.

The bug report inside https://github.com/runtimeverification/haskell-backend/issues/3432 reveals an issue regarding stuck configurations. The output on the second, stuck, branch becomes:
```
Kore (2)> step
kore-repl: [22375637] Warning (WarnStuckClaimState):
    The configuration's term unifies with the destination's term, but the implication check between the conditions has failed. Location: /Users/petarmax/Projects/RV/_audits_Ethereum-optimism_optimism/optimism_foundry/out/specs/calldataspec-test-deposittransaction-emit-creationtrue-sender-equals-origin-spec.k:349:7-409:89
Context:
    (InfoReachability) while checking the implication
kore-repl: [22380037] Warning (WarnStuckClaimState):
    The left-hand side of the claim has been simplified to bottom. Location: /Users/petarmax/Projects/RV/_audits_Ethereum-optimism_optimism/optimism_foundry/out/specs/calldataspec-test-deposittransaction-emit-creationtrue-sender-equals-origin-spec.k:349:7-409:89
Context:
    (InfoReachability) while simplifying the claim
Stopped after 0 step(s) due to reaching end of proof on current branch.
```

That doesn't make sense, there should only be one reason why the branch is stuck and execution should halt immediately.

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
