### PR TITLE
Removing forced nix env setup in workflow

### DIFF
--- a/.github/workflows/kevm-performance-test.yaml
+++ b/.github/workflows/kevm-performance-test.yaml
@@ -64,7 +64,6 @@ jobs:
           # FIXME can we use a reaction emoji instead?
           gh issue comment ${ISSUE_NUMBER} --body "Running KEVM test with ${PR_HEAD:-master} and K version ${K_TAG} as ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          . /home/github-runner/.nix-profile/etc/profile.d/nix.sh
           echo "Starting Test Execution"
           echo "RUNNING TEST"
           nix build github:runtimeverification/evm-semantics#profile \

--- a/.github/workflows/profiling.yaml
+++ b/.github/workflows/profiling.yaml
@@ -67,7 +67,6 @@ jobs:
           echo "Download Test File from ${DOWNLOAD_URL}"
           curl -LOsS ${DOWNLOAD_URL}
 
-          . /home/github-runner/.nix-profile/etc/profile.d/nix.sh
           echo "Starting Test Execution"
           mkdir -p profile/tests/$(echo ${FILE_NAME} | cut -d '.' -f 1)
           echo "RUNNING PROFILE: ${FILE_NAME}"


### PR DESCRIPTION
Fixing Nix env setup by workflow and expect env of runner to container nix before running test. 