### PR TITLE
Add equational rule label in debug output (#3428)

### DIFF
--- a/kore/src/Kore/Equation/DebugEquation.hs
+++ b/kore/src/Kore/Equation/DebugEquation.hs
@@ -239,6 +239,7 @@ instance Pretty DebugAttemptEquation where
         Pretty.vsep
             [ (Pretty.hsep . catMaybes)
                 [ Just "applying equation"
+                , (\label -> Pretty.hsep ["(label: ", pretty label, ")"]) <$> ruleLabel equation
                 , (\loc -> Pretty.hsep ["at", pretty loc]) <$> srcLoc equation
                 , Just "to term:"
                 ]
@@ -257,6 +258,7 @@ instance Entry DebugAttemptEquation where
     contextDoc (DebugAttemptEquation equation _) =
         (Just . Pretty.hsep . catMaybes)
             [ Just "while applying equation"
+            , (\label -> Pretty.hsep ["(label: ", pretty label, ")"]) <$> ruleLabel equation
             , (\loc -> Pretty.hsep ["at", pretty loc]) <$> srcLoc equation
             ]
     contextDoc _ = Nothing
@@ -301,6 +303,7 @@ instance Pretty DebugApplyEquation where
         Pretty.vsep
             [ (Pretty.hsep . catMaybes)
                 [ Just "applied equation"
+                , (\label -> Pretty.hsep ["(label: ", pretty label, ")"]) <$> ruleLabel equation
                 , (\loc -> Pretty.hsep ["at", pretty loc]) <$> srcLoc equation
                 , Just "with result:"
                 ]
@@ -319,6 +322,9 @@ srcLoc equation
 isLocEmpty :: Attribute.SourceLocation -> Bool
 isLocEmpty Attribute.SourceLocation{source = Attribute.Source file} =
     isNothing file
+
+ruleLabel :: Equation RewritingVariableName -> Maybe Text
+ruleLabel = Attribute.unLabel . Attribute.label . attributes
 
 instance Entry DebugApplyEquation where
     entrySeverity _ = Debug


### PR DESCRIPTION
Problem: When debugging equational rules we want to see in debug output rule label if it exists.

Solution: Extract label information from equation and add it to debug output.

Fixes #3428 

### Scope: 
Fixes #3428 only regarding equational rules labels

### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
