### PR TITLE
Immediately prune remainders of axiom applications

### DIFF
--- a/kore/src/Kore/Reachability/OnePathClaim.hs
+++ b/kore/src/Kore/Reachability/OnePathClaim.hs
@@ -9,6 +9,7 @@ module Kore.Reachability.OnePathClaim (
     Rule (..),
 ) where
 
+import Control.Monad ((>=>))
 import Data.Generics.Wrapped (
     _Unwrapped,
  )
@@ -228,5 +229,10 @@ deriveSeqAxiomOnePath ::
         (ApplyResult OnePathClaim)
 deriveSeqAxiomOnePath rules =
     deriveSeq' _Unwrapped OnePathRewriteRule rewrites
+        >=> simplifyRemainder
   where
     rewrites = unRuleOnePath <$> rules
+    simplifyRemainder applied =
+        case applied of
+            ApplyRemainder claim -> ApplyRemainder <$> simplify claim
+            _ -> return applied

--- a/kore/src/Kore/Reachability/Prove.hs
+++ b/kore/src/Kore/Reachability/Prove.hs
@@ -421,7 +421,7 @@ proveClaim
 
         -- result interpretation for GraphTraversal.simpleTransition
         toTransitionResultWithDepth ::
-            Show c =>
+            Unparse c =>
             (ProofDepth, ClaimState c) ->
             [(ProofDepth, ClaimState c)] ->
             GraphTraversal.TransitionResult (ProofDepth, ClaimState c)
@@ -438,10 +438,14 @@ proveClaim
             cs@(c : cs')
                 | noneStuck (map snd cs) -> GraphTraversal.Branch prior (c :| cs')
                 | otherwise ->
-                    -- NB we cannot get stuck and unstuck states from
-                    -- the same step: CheckImplication yields `Stuck`
-                    -- before branching can happen (ApplyAxioms)
-                    error $ "toTransitionResult: " <> show (prior, cs)
+                    error . show $
+                        Pretty.vsep $
+                            [ "The backend cannot return both stuck and unstuck states from the same step."
+                            , "Prior state of toTransitionResult:"
+                            , Pretty.indent 4 $ Pretty.pretty prior
+                            , "Next states of toTransitionResult:"
+                            ]
+                                <> map Pretty.pretty cs
               where
                 noneStuck :: [ClaimState c] -> Bool
                 noneStuck = null . mapMaybe ClaimState.extractStuck


### PR DESCRIPTION
Fixes issue in https://github.com/runtimeverification/k/pull/3101

Branching on rule applications would result in an extra `\\bottom` state during one-path reachability proving. That state shouldn't be recorded inside the execution graph, but pruned immediately.

Before (with https://github.com/runtimeverification/haskell-backend/pull/3443):
---
![broken-spec](https://user-images.githubusercontent.com/45069775/213818416-75a477c2-ad7d-412f-ae56-f7d3ae6e5d57.svg)


After correction (with https://github.com/runtimeverification/haskell-backend/pull/3443):
---
![checkfix](https://user-images.githubusercontent.com/45069775/213818350-d290b6ab-3b95-4aaf-bdeb-577d2ad5fdd7.svg)


###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
