### PR TITLE
[#3462] Keep original names in SMT transcript

### DIFF
--- a/kore/src/Kore/Rewrite/SMT/Evaluator.hs
+++ b/kore/src/Kore/Rewrite/SMT/Evaluator.hs
@@ -298,6 +298,7 @@ declareUninterpreted
             n <- Counter.increment
             logVariableAssignment n boundPat
             let smtName = "<" <> Text.pack (show n) <> ">"
+                origName = Text.pack . show . Pretty.pretty $ boundPat
                 (boundVars, bindings) = unzip $ Map.assocs boundVarsMap
                 cached = SMTDependentAtom{smtName, smtType = sExpr, boundVars}
             _ <-
@@ -307,6 +308,7 @@ declareUninterpreted
                         , inputSorts = smtType <$> bindings
                         , resultSort = sExpr
                         }
+                    origName
             stateSetter Lens.%= Map.insert boundPat cached
             translateSMTDependentAtom boundVarsMap cached
 
@@ -359,9 +361,11 @@ declareVariable ::
 declareVariable t variable = do
     n <- Counter.increment
     let varName = "<" <> Text.pack (show n) <> ">"
-    var <- SMT.declare varName t
+        pat = TermLike.mkElemVar variable
+        origName = Text.pack . show . Pretty.pretty $ pat
+    var <- SMT.declare varName origName t
     field @"freeVars" Lens.%= Map.insert variable var
-    logVariableAssignment n (TermLike.mkElemVar variable)
+    logVariableAssignment n pat
     return var
 
 logVariableAssignment ::

--- a/kore/test/Test/Kore/Rewrite/SMT/Helpers.hs
+++ b/kore/test/Test/Kore/Rewrite/SMT/Helpers.hs
@@ -84,7 +84,7 @@ newtype SmtPrelude = SmtPrelude {getSmtPrelude :: SMT ()}
 
 ofType :: SMT.MonadSMT m => Text -> Text -> m ()
 name `ofType` constType = do
-    _ <- SMT.declare name (atom constType)
+    _ <- SMT.declare name "" (atom constType)
     return ()
 
 atom :: Text -> SMT.SExpr


### PR DESCRIPTION
Problem: Variable names and some predicate names are translated as `<n>` where n is a natural number. We need to keep original names in comments.

Solution: Put comment like `origName -> <n>` just before declaration.

Fixes #3462 
