### PR TITLE
3475 align rpc protocol

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -38,6 +38,7 @@
       - Prettyprinter.String
     within:
       - Pretty
+      - Kore.JsonRpc.Base
 
 
 # Add custom hints for this project

--- a/docs/2022-07-18-JSON-RPC-Server-API.md
+++ b/docs/2022-07-18-JSON-RPC-Server-API.md
@@ -91,12 +91,13 @@ If the verification of the `state` pattern fails, the following error is returne
 ### Correct Response:
 
 All correct responses have a result containing a `reason`, with one of the following values:
-* `"reason: "branching"`
-* `"reason: "stuck"`
-* `"reason: "depth-bound"`
-* `"reason: "cut-point-rule"`
-* `"reason: "terminal-rule"`
-* `"reason: "timeout"`
+* `"reason": "branching"`
+* `"reason": "stuck"`
+* `"reason": "depth-bound"`
+* `"reason": "cut-point-rule"`
+* `"reason": "terminal-rule"`
+* `"reason": "timeout"`
+* `"reason": "aborted"`
 
 A field `state` contains the state reached (including optional `predicate` and `substitution`), a field `depth` indicates the execution depth.
 
@@ -119,6 +120,7 @@ A field `state` contains the state reached (including optional `predicate` and `
 The above will be also be the same for:
   * `"reason": "depth-bound"`
   * `"reason": "timeout"`
+  * `"reason": "aborted"`
 
 If `"reason":  "terminal-rule"`, an additional `rule` field indicates which of the `terminal-rule` labels or IDs led to terminating the execution:
 

--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -367,6 +367,7 @@ library
     Kore.Internal.TermLike.TermLike
     Kore.Internal.Variable
     Kore.JsonRpc
+    Kore.JsonRpc.Base
     Kore.Log
     Kore.Log.DebugAppliedRewriteRules
     Kore.Log.DebugAttemptedRewriteRules

--- a/kore/src/Kore/JsonRpc/Base.hs
+++ b/kore/src/Kore/JsonRpc/Base.hs
@@ -1,0 +1,237 @@
+{- |
+Copyright   : (c) Runtime Verification, 2022
+License     : BSD-3-Clause
+-}
+module Kore.JsonRpc.Base (
+    module Kore.JsonRpc.Base,
+) where
+
+import Control.Exception (Exception)
+import Data.Aeson.Encode.Pretty qualified as PrettyJson
+import Data.Aeson.Types (FromJSON (..), ToJSON (..))
+import Data.Text (Text)
+import Deriving.Aeson (
+    CamelToKebab,
+    ConstructorTagModifier,
+    CustomJSON (..),
+    FieldLabelModifier,
+    OmitNothingFields,
+    StripPrefix,
+ )
+import GHC.Generics (Generic)
+import Kore.Syntax.Json (KoreJson)
+import Network.JSONRPC (
+    FromRequest (..),
+ )
+import Numeric.Natural
+import Prettyprinter qualified as Pretty
+
+import Kore.Rewrite.Timeout (StepTimeout)
+import Kore.Syntax.Sentence (ModuleName)
+import Prelude.Kore
+
+newtype Depth = Depth {getNat :: Natural}
+    deriving stock (Show, Eq)
+    deriving newtype (FromJSON, ToJSON)
+
+data ExecuteRequest = ExecuteRequest
+    { state :: !KoreJson
+    , maxDepth :: !(Maybe Depth)
+    , _module :: !(Maybe ModuleName)
+    , cutPointRules :: !(Maybe [Text])
+    , terminalRules :: !(Maybe [Text])
+    , movingAverageStepTimeout :: !(Maybe Bool)
+    , stepTimeout :: !(Maybe StepTimeout)
+    }
+    deriving stock (Generic, Show, Eq)
+    deriving
+        (FromJSON, ToJSON)
+        via CustomJSON '[OmitNothingFields, FieldLabelModifier '[CamelToKebab, StripPrefix "_"]] ExecuteRequest
+
+data ImpliesRequest = ImpliesRequest
+    { antecedent :: !KoreJson
+    , consequent :: !KoreJson
+    , _module :: !(Maybe ModuleName)
+    }
+    deriving stock (Generic, Show, Eq)
+    deriving
+        (FromJSON, ToJSON)
+        via CustomJSON '[OmitNothingFields, FieldLabelModifier '[CamelToKebab, StripPrefix "_"]] ImpliesRequest
+
+data SimplifyRequest = SimplifyRequest
+    { state :: KoreJson
+    , _module :: !(Maybe ModuleName)
+    }
+    deriving stock (Generic, Show, Eq)
+    deriving
+        (FromJSON, ToJSON)
+        via CustomJSON '[OmitNothingFields, FieldLabelModifier '[CamelToKebab, StripPrefix "_"]] SimplifyRequest
+
+data AddModuleRequest = AddModuleRequest
+    { name :: ModuleName
+    , _module :: Text
+    }
+    deriving stock (Generic, Show, Eq)
+    deriving
+        (FromJSON, ToJSON)
+        via CustomJSON '[FieldLabelModifier '[StripPrefix "_"]] AddModuleRequest
+
+data ReqException = CancelRequest deriving stock (Show)
+
+instance Exception ReqException
+
+instance FromRequest (API 'Req) where
+    parseParams "execute" = Just $ fmap (Execute <$>) parseJSON
+    parseParams "implies" = Just $ fmap (Implies <$>) parseJSON
+    parseParams "simplify" = Just $ fmap (Simplify <$>) parseJSON
+    parseParams "add-module" = Just $ fmap (AddModule <$>) parseJSON
+    parseParams "cancel" = Just $ const $ return Cancel
+    parseParams _ = Nothing
+
+data ExecuteState = ExecuteState
+    { term :: KoreJson
+    , substitution :: Maybe KoreJson
+    , predicate :: Maybe KoreJson
+    }
+    deriving stock (Generic, Show, Eq)
+    deriving
+        (FromJSON, ToJSON)
+        via CustomJSON '[OmitNothingFields, FieldLabelModifier '[CamelToKebab]] ExecuteState
+
+data HaltReason
+    = Branching
+    | Stuck
+    | DepthBound
+    | CutPointRule
+    | TerminalRule
+    | Aborted
+    | Timeout
+    deriving stock (Generic, Show, Eq)
+    deriving
+        (FromJSON, ToJSON)
+        via CustomJSON '[OmitNothingFields, ConstructorTagModifier '[CamelToKebab]] HaltReason
+
+data ExecuteResult = ExecuteResult
+    { reason :: HaltReason
+    , depth :: Depth
+    , state :: ExecuteState
+    , nextStates :: Maybe [ExecuteState]
+    , rule :: Maybe Text
+    }
+    deriving stock (Generic, Show, Eq)
+    deriving
+        (FromJSON, ToJSON)
+        via CustomJSON '[OmitNothingFields, FieldLabelModifier '[CamelToKebab]] ExecuteResult
+
+data Condition = Condition
+    { substitution :: KoreJson
+    , predicate :: KoreJson
+    }
+    deriving stock (Generic, Show, Eq)
+    deriving
+        (FromJSON, ToJSON)
+        via CustomJSON '[OmitNothingFields, FieldLabelModifier '[CamelToKebab]] Condition
+
+data ImpliesResult = ImpliesResult
+    { implication :: KoreJson
+    , satisfiable :: Bool
+    , condition :: Maybe Condition
+    }
+    deriving stock (Generic, Show, Eq)
+    deriving
+        (FromJSON, ToJSON)
+        via CustomJSON '[OmitNothingFields, FieldLabelModifier '[CamelToKebab]] ImpliesResult
+
+newtype SimplifyResult = SimplifyResult
+    { state :: KoreJson
+    }
+    deriving stock (Generic, Show, Eq)
+    deriving
+        (FromJSON, ToJSON)
+        via CustomJSON '[OmitNothingFields, FieldLabelModifier '[CamelToKebab]] SimplifyResult
+
+data ReqOrRes = Req | Res
+
+data APIMethods
+    = ExecuteM
+    | ImpliesM
+    | SimplifyM
+    | AddModuleM
+
+type family APIPayload (api :: APIMethods) (r :: ReqOrRes) where
+    APIPayload 'ExecuteM 'Req = ExecuteRequest
+    APIPayload 'ExecuteM 'Res = ExecuteResult
+    APIPayload 'ImpliesM 'Req = ImpliesRequest
+    APIPayload 'ImpliesM 'Res = ImpliesResult
+    APIPayload 'SimplifyM 'Req = SimplifyRequest
+    APIPayload 'SimplifyM 'Res = SimplifyResult
+    APIPayload 'AddModuleM 'Req = AddModuleRequest
+    APIPayload 'AddModuleM 'Res = ()
+
+data API (r :: ReqOrRes) where
+    Execute :: APIPayload 'ExecuteM r -> API r
+    Implies :: APIPayload 'ImpliesM r -> API r
+    Simplify :: APIPayload 'SimplifyM r -> API r
+    AddModule :: APIPayload 'AddModuleM r -> API r
+    Cancel :: API 'Req
+
+deriving stock instance Show (API 'Req)
+deriving stock instance Show (API 'Res)
+deriving stock instance Eq (API 'Req)
+deriving stock instance Eq (API 'Res)
+
+instance ToJSON (API 'Res) where
+    toJSON = \case
+        Execute payload -> toJSON payload
+        Implies payload -> toJSON payload
+        Simplify payload -> toJSON payload
+        AddModule payload -> toJSON payload
+
+instance Pretty.Pretty (API 'Req) where
+    pretty = \case
+        Execute _ -> "execute"
+        Implies _ -> "implies"
+        Simplify _ -> "simplify"
+        AddModule _ -> "add-module"
+        Cancel -> "cancel"
+
+rpcJsonConfig :: PrettyJson.Config
+rpcJsonConfig =
+    PrettyJson.defConfig
+        { PrettyJson.confCompare =
+            PrettyJson.keyOrder
+                [ "format"
+                , "version"
+                , "term"
+                , "tag"
+                , "assoc"
+                , "name"
+                , "symbol"
+                , "argSort"
+                , "sort"
+                , "sorts"
+                , "var"
+                , "varSort"
+                , "arg"
+                , "args"
+                , "argss"
+                , "source"
+                , "dest"
+                , "value"
+                , "jsonrpc"
+                , "id"
+                , "reason"
+                , "depth"
+                , "rule"
+                , "state"
+                , "next-states"
+                , "substitution"
+                , "predicate"
+                , "satisfiable"
+                , "implication"
+                , "condition"
+                , "module"
+                , "step-timeout"
+                , "moving-average-step-timeout"
+                ]
+        }

--- a/kore/src/Kore/JsonRpc/Base.hs
+++ b/kore/src/Kore/JsonRpc/Base.hs
@@ -1,5 +1,5 @@
 {- |
-Copyright   : (c) Runtime Verification, 2022
+Copyright   : (c) Runtime Verification, 2023
 License     : BSD-3-Clause
 -}
 module Kore.JsonRpc.Base (

--- a/kore/src/Kore/Rewrite/Timeout.hs
+++ b/kore/src/Kore/Rewrite/Timeout.hs
@@ -24,6 +24,7 @@ import Control.Concurrent (
  )
 import Data.Aeson (
     FromJSON,
+    ToJSON,
  )
 import Prelude.Kore
 import System.Clock (
@@ -44,7 +45,7 @@ newtype StepTimeout = StepTimeout
     { unStepTimeout :: Int
     }
     deriving stock (Eq, Ord, Show)
-    deriving newtype (FromJSON)
+    deriving newtype (FromJSON, ToJSON)
 
 data EnableMovingAverage
     = DisableMovingAverage

--- a/nix/kore-ghc925.nix.d/kore.nix
+++ b/nix/kore-ghc925.nix.d/kore.nix
@@ -287,6 +287,7 @@
         "Kore/Internal/TermLike/TermLike"
         "Kore/Internal/Variable"
         "Kore/JsonRpc"
+        "Kore/JsonRpc/Base"
         "Kore/Log"
         "Kore/Log/DebugAppliedRewriteRules"
         "Kore/Log/DebugAttemptedRewriteRules"


### PR DESCRIPTION
Pert of  #3475 

Most of this code was already present, but resided in `Kore.JsonRpc`. The separate module makes it easier to re-use the code elsewhere.

New: `stop-reason: aborted` (never returned by code in this repository)

Also added some additional `FromJSON` and `ToJSON` instances
