### PR TITLE
Fully export module `Kore.JsonRpc`

### DIFF
--- a/kore/src/Kore/JsonRpc.hs
+++ b/kore/src/Kore/JsonRpc.hs
@@ -5,7 +5,7 @@ Copyright   : (c) Runtime Verification, 2022
 License     : BSD-3-Clause
 -}
 module Kore.JsonRpc (
-    module Kore.JsonRpc
+    module Kore.JsonRpc,
 ) where
 
 import Control.Concurrent (forkIO, throwTo)

--- a/kore/src/Kore/JsonRpc.hs
+++ b/kore/src/Kore/JsonRpc.hs
@@ -5,8 +5,7 @@ Copyright   : (c) Runtime Verification, 2022
 License     : BSD-3-Clause
 -}
 module Kore.JsonRpc (
-    runServer,
-    ServerState (..),
+    module Kore.JsonRpc
 ) where
 
 import Control.Concurrent (forkIO, throwTo)

--- a/kore/src/Kore/JsonRpc.hs
+++ b/kore/src/Kore/JsonRpc.hs
@@ -5,7 +5,7 @@ Copyright   : (c) Runtime Verification, 2022
 License     : BSD-3-Clause
 -}
 module Kore.JsonRpc (
-    module Kore.JsonRpc,
+    module Kore.JsonRpc
 ) where
 
 import Control.Concurrent (forkIO, throwTo)


### PR DESCRIPTION
This is needed when using the old server as a library
