### PR TITLE
Split MultiApp into LeftAssoc and RightAssoc

### DIFF
--- a/kore-rpc-types/src/Kore/Syntax/Json/Types.hs
+++ b/kore-rpc-types/src/Kore/Syntax/Json/Types.hs
@@ -205,8 +205,7 @@ data KorePattern
         , sorts :: [Sort]
         , argss :: NE.NonEmpty KorePattern
         }
-    |
-      -- | right associative app pattern
+    | -- | right associative app pattern
       KJRightAssoc
         { symbol :: Id -- may start by a '\\'
         , sorts :: [Sort]

--- a/kore-rpc-types/src/Kore/Syntax/Json/Types.hs
+++ b/kore-rpc-types/src/Kore/Syntax/Json/Types.hs
@@ -199,10 +199,16 @@ data KorePattern
         }
     | -- TODO textual parser also understands And/Implies/Iff
 
-      -- | left/right associative app pattern
-      KJMultiApp
-        { assoc :: LeftRight
-        , symbol :: Id -- may start by a '\\'
+      -- | left associative app pattern
+      KJLeftAssoc
+        { symbol :: Id -- may start by a '\\'
+        , sorts :: [Sort]
+        , argss :: NE.NonEmpty KorePattern
+        }
+    |
+      -- | right associative app pattern
+      KJRightAssoc
+        { symbol :: Id -- may start by a '\\'
         , sorts :: [Sort]
         , argss :: NE.NonEmpty KorePattern
         }
@@ -265,8 +271,10 @@ lexicalCheck p =
             reportErrors txt "string literal" checkLatin1Range
         -- Input supports std Unicode (as per json spec). toJSON could
         -- check that only allowed escape sequences will be generated.
-        KJMultiApp{symbol = Id n} ->
-            reportErrors n "multi-app symbol" checkSymbolName
+        KJLeftAssoc{symbol = Id n} ->
+            reportErrors n "left-assoc symbol" checkSymbolName
+        KJRightAssoc{symbol = Id n} ->
+            reportErrors n "left-assoc symbol" checkSymbolName
         _ -> pure p
   where
     reportErrors :: Text -> String -> (Text -> [String]) -> Json.Parser KorePattern

--- a/kore/src/Kore/Syntax/Json/Internal.hs
+++ b/kore/src/Kore/Syntax/Json/Internal.hs
@@ -117,8 +117,10 @@ toParsedPattern = \case
             Kore.DomainValue (mkSort sort) (toParsedPattern (KJString value))
     KJMultiOr{assoc, sort, argss} ->
         withAssoc assoc (mkOr sort) $ NE.map toParsedPattern argss
-    KJMultiApp{assoc, symbol, sorts, argss} ->
-        withAssoc assoc (mkF symbol sorts) $ NE.map toParsedPattern argss
+    KJLeftAssoc{symbol, sorts, argss} ->
+        foldl1 (mkF symbol sorts) $ NE.map toParsedPattern argss
+    KJRightAssoc{symbol, sorts, argss} ->
+        foldr1 (mkF symbol sorts) $ NE.map toParsedPattern argss
   where
     embedVar ::
         (VariableName -> SomeVariableName VariableName) ->

--- a/kore/test/Test/Kore/Syntax/Json.hs
+++ b/kore/test/Test/Kore/Syntax/Json.hs
@@ -82,9 +82,12 @@ genMultiKorePattern =
             <$> Gen.element [Left, Right]
             <*> genSort
             <*> (NE.fromList <$> between 3 12 (Gen.small genAllKorePatterns))
-        , KJMultiApp
-            <$> Gen.element [Left, Right]
-            <*> (Gen.element [('\\' -:), id] <*> genId)
+        , KJLeftAssoc
+            <$> (Gen.element [('\\' -:), id] <*> genId)
+            <*> exactly 2 genSort
+            <*> (NE.fromList <$> between 3 12 (Gen.small genAllKorePatterns))
+        , KJRightAssoc
+            <$> (Gen.element [('\\' -:), id] <*> genId)
             <*> exactly 2 genSort
             <*> (NE.fromList <$> between 3 12 (Gen.small genAllKorePatterns))
         ]


### PR DESCRIPTION
Fixes  #3502

Implements `Left/RightAssoc` as suggested in the issue:

```json
{ 
    "tag": "LeftAssoc",
    "symbol": ...,
    "sorts" : ...,
    "argss": ...
}
```