### PR TITLE
internalize lists when pattern matching

### DIFF
--- a/kore/src/Kore/Rewrite/Axiom/Matcher.hs
+++ b/kore/src/Kore/Rewrite/Axiom/Matcher.hs
@@ -412,7 +412,7 @@ patternMatch' sideCondition ((MatchItem pat subject boundVars boundSet) : rest) 
                 decomposeOverload unifyData
         (_, _)
             | Just True <- List.isListSort tools sort ->
-                case (List.normalize pat, List.normalize subject) of
+                case (List.internalize tools pat, List.internalize tools subject) of
                     (Var_ var1, Var_ var2)
                         | var1 == var2 ->
                             discharge


### PR DESCRIPTION
Fixes #3518

List.normalize apparently didn't convert a list with a single element into an InternalList, which caused the pattern matcher to fail when matching a single element list against a single element list. Thus, we call List.internalize instead.

### Scope:

### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
