### PR TITLE
[#3170] Detect if equational rules are unsupported

### DIFF
--- a/kore/src/Kore/Equation/Validate.hs
+++ b/kore/src/Kore/Equation/Validate.hs
@@ -78,6 +78,7 @@ validateAxiom attrs verified =
         Left TotalAxiom -> return ()
         Left ConstructorAxiom -> return ()
         Left SubsortAxiom -> return ()
+        Left err@(UnsupportedLHS _) -> failWithBadEquation err
   where
     failWithBadEquation =
         koreFailWithLocations [sentenceAxiomPattern verified]

--- a/test/issue-3170/Makefile
+++ b/test/issue-3170/Makefile
@@ -1,0 +1,9 @@
+include $(CURDIR)/../include.mk
+
+.PHONY: test
+
+test: test.k
+	@if $(KOMPILE) $(KOMPILE_OPTS) $< 2>&1 | grep 'Unsupported LHS of equation' > /dev/null;\
+	  then echo "PASSED"; exit 0;\
+	  else echo "FAILED"; exit 1;\
+	fi

--- a/test/issue-3170/test.k
+++ b/test/issue-3170/test.k
@@ -1,0 +1,3 @@
+module TEST
+  rule [nonsence]: X #Or X => X [simplification]
+endmodule


### PR DESCRIPTION
Problem: Right now we support equational rules where the LHS has a function(al) symbol, \\equals or \\ceil at the top. The backend should abort execution if it detects anything else in this spot and provide an appropriate error message containing the source location of the rule.

Solution: Match LHS to supported terms. And if it don't match, throw the `UnsupportedLHS` error.

Fixes #3170 
