### PR TITLE
Make necessary changes for new encoding of rewrites

### DIFF
--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -351,8 +351,8 @@ exec
         execStrategy :: [Strategy.Step Prim]
         execStrategy =
             Limit.takeWithin depthLimit $
-                [Begin, Simplify, Rewrite, Simplify]
-                    : repeat [Begin, Rewrite, Simplify]
+                [Begin, Simplify, Rewrite, Simplify] :
+                repeat [Begin, Rewrite, Simplify]
 
         transit ::
             GraphTraversal.TState
@@ -401,12 +401,12 @@ data StopLabels = StopLabels
 
 -- | Type for json-rpc execution state, for readability
 data RpcExecState v = RpcExecState
-    { rpcProgState :: ProgramState (Pattern v)
-    -- ^ program state
-    , rpcRule :: Maybe Text
-    -- ^ rule label/id we have stopped on
-    , rpcDepth :: ExecDepth
-    -- ^ execution depth
+    { -- | program state
+      rpcProgState :: ProgramState (Pattern v)
+    , -- | rule label/id we have stopped on
+      rpcRule :: Maybe Text
+    , -- | execution depth
+      rpcDepth :: ExecDepth
     }
     deriving stock (Eq, Show)
 
@@ -481,8 +481,8 @@ rpcExec
         execStrategy :: [Strategy.Step Prim]
         execStrategy =
             Limit.takeWithin depthLimit $
-                [Begin, Simplify, Rewrite, Simplify]
-                    : repeat [Begin, Rewrite, Simplify]
+                [Begin, Simplify, Rewrite, Simplify] :
+                repeat [Begin, Rewrite, Simplify]
 
         transit ::
             GraphTraversal.TState Prim (RpcExecState RewritingVariableName) ->
@@ -545,10 +545,10 @@ rpcExec
             labels
             (RewriteRule RulePattern{attributes = Attribute.Axiom{label, uniqueId}})
                 | Just lbl <- Attribute.unLabel label
-                , lbl `elem` labels =
+                  , lbl `elem` labels =
                     Just lbl
                 | Just uid <- Attribute.getUniqueId uniqueId
-                , uid `elem` labels =
+                  , uid `elem` labels =
                     Just uid
                 | otherwise =
                     Nothing

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -351,8 +351,8 @@ exec
         execStrategy :: [Strategy.Step Prim]
         execStrategy =
             Limit.takeWithin depthLimit $
-                [Begin, Simplify, Rewrite, Simplify] :
-                repeat [Begin, Rewrite, Simplify]
+                [Begin, Simplify, Rewrite, Simplify]
+                    : repeat [Begin, Rewrite, Simplify]
 
         transit ::
             GraphTraversal.TState
@@ -401,12 +401,12 @@ data StopLabels = StopLabels
 
 -- | Type for json-rpc execution state, for readability
 data RpcExecState v = RpcExecState
-    { -- | program state
-      rpcProgState :: ProgramState (Pattern v)
-    , -- | rule label/id we have stopped on
-      rpcRule :: Maybe Text
-    , -- | execution depth
-      rpcDepth :: ExecDepth
+    { rpcProgState :: ProgramState (Pattern v)
+    -- ^ program state
+    , rpcRule :: Maybe Text
+    -- ^ rule label/id we have stopped on
+    , rpcDepth :: ExecDepth
+    -- ^ execution depth
     }
     deriving stock (Eq, Show)
 
@@ -481,8 +481,8 @@ rpcExec
         execStrategy :: [Strategy.Step Prim]
         execStrategy =
             Limit.takeWithin depthLimit $
-                [Begin, Simplify, Rewrite, Simplify] :
-                repeat [Begin, Rewrite, Simplify]
+                [Begin, Simplify, Rewrite, Simplify]
+                    : repeat [Begin, Rewrite, Simplify]
 
         transit ::
             GraphTraversal.TState Prim (RpcExecState RewritingVariableName) ->
@@ -545,10 +545,10 @@ rpcExec
             labels
             (RewriteRule RulePattern{attributes = Attribute.Axiom{label, uniqueId}})
                 | Just lbl <- Attribute.unLabel label
-                  , lbl `elem` labels =
+                , lbl `elem` labels =
                     Just lbl
                 | Just uid <- Attribute.getUniqueId uniqueId
-                  , uid `elem` labels =
+                , uid `elem` labels =
                     Just uid
                 | otherwise =
                     Nothing
@@ -888,10 +888,12 @@ checkFunctions ::
 checkFunctions verifiedModule =
     evalSimplifierProofs verifiedModule $ do
         -- check if RHS is function pattern
-        equations >>= filter (not . isFunctionPattern . right)
+        equations
+            >>= filter (not . isFunctionPattern . right)
             & mapM_ errorEquationRightFunction
         -- check if two equations both match the same term
-        equations >>= inOrderPairs
+        equations
+            >>= inOrderPairs
             & filterM (uncurry bothMatch)
             >>= mapM_ (uncurry errorEquationsSameMatch)
   where
@@ -963,7 +965,7 @@ initialize ::
 initialize simplificationProcedure verifiedModule = do
     rewriteRules <-
         Logic.observeAllT $ do
-            rule <- Logic.scatter (extractRewriteAxioms verifiedModule)
+            rule <- Logic.scatter (either error id (extractRewriteAxioms verifiedModule))
             initializeRule (mapRuleVariables (pure mkRuleVariable) rule)
     pure Initialized{rewriteRules}
   where

--- a/kore/src/Kore/Internal/Predicate.hs
+++ b/kore/src/Kore/Internal/Predicate.hs
@@ -518,11 +518,11 @@ unparse2WithSort ::
     Pretty.Doc ann
 unparse2WithSort sort = unparse2 . fromPredicate sort
 
--- |'PredicateFalse' is a pattern for matching 'bottom' predicates.
+-- | 'PredicateFalse' is a pattern for matching 'bottom' predicates.
 pattern PredicateFalse :: Predicate variable
 pattern PredicateFalse <- (Recursive.project -> _ :< BottomF _)
 
--- |'PredicateTrue' is a pattern for matching 'top' predicates.
+-- | 'PredicateTrue' is a pattern for matching 'top' predicates.
 pattern PredicateTrue :: Predicate variable
 pattern PredicateTrue <- (Recursive.project -> _ :< TopF _)
 
@@ -1271,7 +1271,7 @@ mapVariables adj predicate =
             , Pretty.pretty termPredicate
             ]
 
--- |Is the predicate free of the given variables?
+-- | Is the predicate free of the given variables?
 isFreeOf ::
     Ord variable =>
     Predicate variable ->
@@ -1301,6 +1301,7 @@ hasFreeVariable variableName =
 -- !!  the code using wrapPredicate should be refactored    !!
 
 wrapPredicate ::
+    HasCallStack =>
     InternalVariable variable =>
     TermLike variable ->
     Predicate variable

--- a/kore/src/Kore/Rewrite/Rule.hs
+++ b/kore/src/Kore/Rewrite/Rule.hs
@@ -145,7 +145,7 @@ extractRewriteAxioms idxMod =
  a verified definition.
 -}
 extractImplicationClaims ::
-    -- |'IndexedModule' containing the definition
+    -- | 'IndexedModule' containing the definition
     VerifiedModule declAtts ->
     [ ( Attribute.Axiom Internal.Symbol.Symbol VariableName
       , ImplicationRule VariableName
@@ -207,15 +207,26 @@ simpleRewriteTermToRule attributes pat =
                         , Pretty.indent 4 $ unparse pat
                         ]
         -- normal rewrite axioms
-        TermLike.Rewrites _ (TermLike.And_ _ requires lhs) rhs ->
-            RewriteRule
-                RulePattern
-                    { left = lhs
-                    , antiLeft = Nothing
-                    , requires = Predicate.wrapPredicate requires
-                    , rhs = termToRHS rhs
-                    , attributes
-                    }
+        TermLike.Rewrites _ (TermLike.And_ _ requires' lhs) rhs
+            | Right requires <- Predicate.makePredicate requires' ->
+                RewriteRule
+                    RulePattern
+                        { left = lhs
+                        , antiLeft = Nothing
+                        , requires
+                        , rhs = termToRHS rhs
+                        , attributes
+                        }
+        TermLike.Rewrites _ (TermLike.And_ _ lhs requires') rhs
+            | Right requires <- Predicate.makePredicate requires' ->
+                RewriteRule
+                    RulePattern
+                        { left = lhs
+                        , antiLeft = Nothing
+                        , requires
+                        , rhs = termToRHS rhs
+                        , attributes
+                        }
         _ ->
             (error . show . Pretty.vsep)
                 [ "Expected simple rewrite rule form, but got"

--- a/kore/src/Kore/Rewrite/RulePattern.hs
+++ b/kore/src/Kore/Rewrite/RulePattern.hs
@@ -361,8 +361,12 @@ termToRHS (TermLike.Exists_ _ v pat) =
     rhs{existentials = v : existentials rhs}
   where
     rhs = termToRHS pat
-termToRHS (TermLike.And_ _ ensures right) =
-    RHS{existentials = [], right, ensures = Predicate.wrapPredicate ensures}
+termToRHS (TermLike.And_ _ right ensures')
+    | Right ensures <- Predicate.makePredicate ensures' =
+        RHS{existentials = [], right, ensures}
+termToRHS (TermLike.And_ _ ensures' right)
+    | Right ensures <- Predicate.makePredicate ensures' =
+        RHS{existentials = [], right, ensures}
 termToRHS term = injectTermIntoRHS term
 
 instance
@@ -382,7 +386,7 @@ instance
                 <> freeVariables requires
                 <> freeVariables rhs
 
--- |Is the rule free of the given variables?
+-- | Is the rule free of the given variables?
 isFreeOf ::
     forall variable.
     InternalVariable variable =>

--- a/kore/test/Test/Kore/Rewrite/Rule.hs
+++ b/kore/test/Test/Kore/Rewrite/Rule.hs
@@ -73,6 +73,7 @@ axiomPatternsUnitTests =
                 ( simpleRewriteTermToRule
                     def
                     (mkRewriteAxiomPattern varI1 varI2 Nothing)
+                    & fromRight (error "Expected simple rewrite rule")
                 )
             )
         , testCase
@@ -96,6 +97,7 @@ axiomPatternsUnitTests =
                 ( simpleRewriteTermToRule
                     def
                     (mkAliasAxiomPattern applyAliasLHS varI2)
+                    & fromRight (error "Expected simple rewrite rule")
                 )
             )
         , let axiom1, axiom2 :: Verified.Sentence
@@ -131,11 +133,12 @@ axiomPatternsUnitTests =
                         , definitionModules = [moduleTest]
                         }
            in testCase "definition containing I1:AInt => I2:AInt"
-              --TODO(traiansf): such checks should be made during verification
+              -- TODO(traiansf): such checks should be made during verification
               $
                 assertErrorIO
                     (assertSubstring "" "Unsupported pattern type in axiom")
-                    ( evaluate . force
+                    ( evaluate
+                        . force
                         . map fromSentenceAxiom
                         . indexedModuleAxioms
                         $ extractIndexedModule "TEST" indexedDefinition
@@ -173,6 +176,7 @@ axiomPatternsIntegrationTests =
                 ( simpleRewriteTermToRule
                     def
                     (mkRewriteAxiomPattern left right Nothing)
+                    & fromRight (error "Expected simple rewrite rule")
                 )
             )
         ]
@@ -238,7 +242,9 @@ test_rewritePatternToRewriteRuleAndBack =
         ]
   where
     perhapsFinalPattern attribute initialPattern =
-        rewriteRuleToTerm $ simpleRewriteTermToRule attribute initialPattern
+        rewriteRuleToTerm $
+            fromRight (error "Expected simple rewrite rule") $
+                simpleRewriteTermToRule attribute initialPattern
 
 test_patternToAxiomPatternAndBack :: TestTree
 test_patternToAxiomPatternAndBack =


### PR DESCRIPTION
Fixes #3567 

The Haskell backend already supported the simplified encoding of rewrite rules. We needed to add support for the following:
- reverse ordering of the arguments inside the rule
- the backend should not expect priority rules to be of the "complex" form

After the frontend removes support for the antileft-encoding, we should remove the antileft field in the `RulePattern` type.

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
