### PR TITLE
RPC logging tweak

### DIFF
--- a/kore-rpc-types/src/Kore/JsonRpc/Types/Log.hs
+++ b/kore-rpc-types/src/Kore/JsonRpc/Types/Log.hs
@@ -29,7 +29,7 @@ data LogRewriteResult
         }
     | Failure
         { reason :: Text
-        , ruleId :: Text
+        , ruleId :: Maybe Text
         }
     deriving stock (Generic, Show, Eq)
     deriving

--- a/kore-rpc-types/src/Kore/JsonRpc/Types/Log.hs
+++ b/kore-rpc-types/src/Kore/JsonRpc/Types/Log.hs
@@ -13,6 +13,7 @@ import Deriving.Aeson (
     CustomJSON (..),
     FieldLabelModifier,
     OmitNothingFields,
+    StripPrefix,
  )
 
 data LogOrigin = KoreRpc | Booster | Llvm
@@ -29,12 +30,12 @@ data LogRewriteResult
         }
     | Failure
         { reason :: Text
-        , ruleId :: Maybe Text
+        , _ruleId :: Maybe Text
         }
     deriving stock (Generic, Show, Eq)
     deriving
         (FromJSON, ToJSON)
-        via CustomJSON '[OmitNothingFields, FieldLabelModifier '[CamelToKebab], ConstructorTagModifier '[CamelToKebab]] LogRewriteResult
+        via CustomJSON '[OmitNothingFields, FieldLabelModifier '[CamelToKebab, StripPrefix "_"], ConstructorTagModifier '[CamelToKebab]] LogRewriteResult
 
 data LogEntry
     = Rewrite


### PR DESCRIPTION
Make the `rule-id` field in the RPC failure logs optional, as the failure may not be attached to a particular rule, e.g. a message saying no rules could be found for the particular configuration.

