### PR TITLE
Lock down optparse-applicative to <0.17.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
 
       - name: Build
-        run: nix-build -A project.x86_64_linux.kore -A project.x86_64_linux.kore.checks
+        run: nix-build -A project.x86_64-linux.kore -A project.x86_64-linux.kore.checks
 
   cache-cabal:
     name: 'Cache Cabal'

--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -97,8 +97,6 @@ common library
   build-depends: adjunctions >=4.4
   build-depends: aeson >=1.4 && <2.1
   build-depends: aeson-pretty == 0.8.9
-  -- pinned this to avoid optparse-applicative problems
-  build-depends: ansi-wl-pprint < 1.0
   build-depends: array
   build-depends: async >=2.2
   build-depends: binary >=0.8.8.0
@@ -148,7 +146,7 @@ common library
   build-depends: mono-traversable >=1.0
   build-depends: mtl >=2.2
   build-depends: multiset >=0.3.4.3
-  build-depends: optparse-applicative >=0.14 && <0.18
+  build-depends: optparse-applicative >=0.14 && <0.17.1
   build-depends: parser-combinators >=1.1
   build-depends: pqueue >=1.4.1.3
   build-depends: prettyprinter >=1.2

--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -97,6 +97,8 @@ common library
   build-depends: adjunctions >=4.4
   build-depends: aeson >=1.4 && <2.1
   build-depends: aeson-pretty == 0.8.9
+  -- pinned this to avoid optparse-applicative problems
+  build-depends: ansi-wl-pprint < 1.0
   build-depends: array
   build-depends: async >=2.2
   build-depends: binary >=0.8.8.0

--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -146,7 +146,7 @@ common library
   build-depends: mono-traversable >=1.0
   build-depends: mtl >=2.2
   build-depends: multiset >=0.3.4.3
-  build-depends: optparse-applicative >=0.14 && <0.18
+  build-depends: optparse-applicative >=0.14 && <0.17
   build-depends: parser-combinators >=1.1
   build-depends: pqueue >=1.4.1.3
   build-depends: prettyprinter >=1.2

--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -146,7 +146,7 @@ common library
   build-depends: mono-traversable >=1.0
   build-depends: mtl >=2.2
   build-depends: multiset >=0.3.4.3
-  build-depends: optparse-applicative >=0.14
+  build-depends: optparse-applicative >=0.14 && <0.18
   build-depends: parser-combinators >=1.1
   build-depends: pqueue >=1.4.1.3
   build-depends: prettyprinter >=1.2

--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -146,7 +146,7 @@ common library
   build-depends: mono-traversable >=1.0
   build-depends: mtl >=2.2
   build-depends: multiset >=0.3.4.3
-  build-depends: optparse-applicative >=0.14 && <0.17
+  build-depends: optparse-applicative >=0.14 && <0.18
   build-depends: parser-combinators >=1.1
   build-depends: pqueue >=1.4.1.3
   build-depends: prettyprinter >=1.2


### PR DESCRIPTION
There seems to be a breaking change in the API for optparse-applicative v0.17 and above, which causes the master cabal cache run to fail