### PR TITLE
Rename APIMethods to APIMethod + derive some instances

### DIFF
--- a/kore-rpc-types/src/Kore/JsonRpc/Types.hs
+++ b/kore-rpc-types/src/Kore/JsonRpc/Types.hs
@@ -159,13 +159,14 @@ data SimplifyResult = SimplifyResult
 
 data ReqOrRes = Req | Res
 
-data APIMethods
+data APIMethod
     = ExecuteM
     | ImpliesM
     | SimplifyM
     | AddModuleM
+    deriving stock (Eq, Ord, Show, Enum)
 
-type family APIPayload (api :: APIMethods) (r :: ReqOrRes) where
+type family APIPayload (api :: APIMethod) (r :: ReqOrRes) where
     APIPayload 'ExecuteM 'Req = ExecuteRequest
     APIPayload 'ExecuteM 'Res = ExecuteResult
     APIPayload 'ImpliesM 'Req = ImpliesRequest


### PR DESCRIPTION
Part of https://github.com/runtimeverification/hs-backend-booster/issues/182

* Adds instances necessary to use this type downstream. 
* Also renames `APIMethods` to `APIMethod`

