### PR TITLE
3595 clean up library dependencies

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -168,7 +168,6 @@
     within:
       - Test.Kore.Rewrite.Transition
 
-
 # Define some custom infix operators
 # - fixity: infixr 3 ~^#^~
 

--- a/cabal.project
+++ b/cabal.project
@@ -2,11 +2,6 @@ packages:
   kore
   kore-rpc-types
 
-allow-newer:
-  compact:base,
-  compact:bytestring,
-  ghc-trace-events:base
-
 package *
   ghc-options: -fhide-source-paths -haddock
   profiling-detail: none

--- a/kore/app/exec/Main.hs
+++ b/kore/app/exec/Main.hs
@@ -7,14 +7,7 @@ import Control.Monad.Catch (
  )
 import Control.Monad.Extra as Monad
 import Control.Monad.Validate
-import Data.Binary qualified as Binary
-import Data.ByteString.Lazy (hPut)
-import Data.Compact (
-    compactWithSharing,
- )
-import Data.Compact.Serialize (
-    hPutCompact,
- )
+import Data.Compact.Serialize (writeCompact)
 import Data.Default (
     def,
  )
@@ -35,7 +28,7 @@ import Data.Set.Internal qualified as Set
 import Data.Text (
     unpack,
  )
-import GHC.Fingerprint as Fingerprint
+import GHC.Compact (compactWithSharing)
 import GHC.Generics qualified as GHC
 import GlobalMain
 import Kore.Attribute.Definition (
@@ -173,9 +166,6 @@ import System.Directory (
     setOwnerSearchable,
     setOwnerWritable,
     setPermissions,
- )
-import System.Environment (
-    getExecutablePath,
  )
 import System.Exit (
     exitWith,
@@ -793,11 +783,8 @@ koreSerialize execOptions = do
     case outputFileName of
         Nothing -> return (locations, ExitFailure 1)
         Just outputFile -> liftIO $ do
-            execHash <- getExecutablePath >>= Fingerprint.getFileHash
             compact <- compactWithSharing serializedDefinition
-            withFile outputFile WriteMode $ \outputHandle -> do
-                hPut outputHandle (Binary.encode execHash)
-                hPutCompact outputHandle compact
+            writeCompact outputFile compact
             return (locations, ExitSuccess)
 
 koreProve ::

--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -104,7 +104,7 @@ common library
   build-depends: clock >=0.8
   build-depends: co-log >=0.4
   build-depends: comonad >=5.0
-  build-depends: compact >= 0.2.0.0
+  build-depends: ghc-compact
   build-depends: conduit-extra >=1.3
   build-depends: containers >=0.5.8
   build-depends: cryptonite >=0.25
@@ -180,6 +180,7 @@ library
   exposed-modules:
     Changed
     Control.Monad.Counter
+    Data.Compact.Serialize
     Data.Graph.TopologicalSort
     Data.InternedText
     Data.Limit
@@ -584,7 +585,7 @@ executable kore-exec
   build-depends: binary >=0.8.8.0
   build-depends: bytestring >=0.10
   build-depends: clock >=0.8
-  build-depends: compact >=0.2.0.0
+  build-depends: ghc-compact
   build-depends: containers >=0.5
   build-depends: data-default >=0.7
   build-depends: directory >=1.3

--- a/kore/src/Data/Compact/Serialize.hs
+++ b/kore/src/Data/Compact/Serialize.hs
@@ -1,0 +1,229 @@
+{- | Drop-in replacement for Data.Compact.Serialize of the `compact`
+  library (which appears unmaintained at the time of writing).
+
+  Original: Copyright (c) 2017, Edward Z. Yang
+
+  This adaptation: Copyright (c) 2023, Runtime Verification Inc.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Edward Z. Yang nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-}
+module Data.Compact.Serialize (
+    writeCompact,
+    unsafeReadCompact,
+    hPutCompact,
+    hUnsafeGetCompact,
+    hHasCompactMarker,
+) where
+
+import Control.Monad
+import Data.Binary qualified as B
+import Data.ByteString.Lazy qualified as BSL
+import Data.Monoid
+import Data.Word
+import Foreign.Marshal.Alloc
+import Foreign.Ptr
+import Foreign.Storable
+import GHC.Compact hiding (compact)
+import GHC.Compact.Serialized
+import GHC.Fingerprint qualified as Fingerprint
+import System.Environment (getExecutablePath)
+import System.IO
+import System.IO.Unsafe (unsafePerformIO)
+import Type.Reflection
+
+import Prelude
+
+{- | Write a compact region to a file.  The resulting file can
+be read back into memory using 'unsafeReadCompact'.
+-}
+writeCompact :: Typeable a => FilePath -> Compact a -> IO ()
+writeCompact fname compact =
+    withFile fname WriteMode $ \h -> hPutCompact h compact
+
+{- | Write a compact region to a 'Handle'.  The compact region
+can be read out of the handle by using 'hUnsafeGetCompact'.
+-}
+hPutCompact :: Typeable a => Handle -> Compact a -> IO ()
+hPutCompact hdl compact =
+    withSerializedCompact compact $ \scompact -> do
+        -- write a format marker first
+        BSL.hPut hdl compactMarker
+        let bs = B.encode $ CompactFile scompact
+        -- By writing out the length of the metadata segment, we
+        -- can read out a single word, read out the metadata segment,
+        -- and then immediately start blasting further data from
+        -- the handle into the memory region where the compact
+        -- is going to go.  Otherwise, we have to indirect through
+        -- a lazy bytestring which has a cost.
+        hPutStorable hdl (fromIntegral (BSL.length bs) :: Int)
+        BSL.hPut hdl bs
+        let putBlock (ptr, len) = hPutBuf hdl ptr (fromIntegral len)
+        mapM_ putBlock (serializedCompactBlockList scompact)
+
+{- | Read out a compact region that was serialized to a file.
+See 'hUnsafeGetCompact' for safety considerations when using this function.
+-}
+unsafeReadCompact :: Typeable a => FilePath -> IO (Either String (Compact a))
+unsafeReadCompact fname =
+    withFile fname ReadMode $ \hdl -> hUnsafeGetCompact hdl
+
+{- | Read out a compact region from a handle.
+
+Compact regions written to handles this way are subject to some
+restrictions:
+
+ * Our binary representation contains direct pointers to the info
+   tables of objects in the region.  This means that the info tables
+   of the receiving process must be laid out in exactly the same
+   way as from the original process; in practice, this means using
+   static linking, using the exact same binary and turning off ASLR.  This
+   API only does a very basic check and will probably segfault if you
+   get it wrong.  DO NOT run this on untrusted input.
+
+ * You must read out the value at the correct type.  We will
+   check this for you and raise an error if the types do not match
+   (this is what the 'Typeable' constraint is for).
+-}
+hUnsafeGetCompact ::
+    forall a.
+    Typeable a =>
+    Handle ->
+    IO (Either String (Compact a))
+hUnsafeGetCompact hdl = do
+    marker <- BSL.hGet hdl (fromIntegral $ BSL.length compactMarker)
+    if (marker /= compactMarker)
+        then
+            return . Left $
+                "Unexpected format marker: expected "
+                    <> show compactMarker
+                    <> ", found "
+                    <> show marker
+        else do
+            l <- hGetStorable hdl
+            mbs <- BSL.hGet hdl (l :: Int)
+            case B.decodeOrFail @(CompactFile a) mbs of
+                Left (_, _, err) -> return $ Left err
+                Right (rest, _, CompactFile scompact)
+                    | not (BSL.null rest) ->
+                        return . Left $
+                            "Had " ++ show (BSL.length rest) ++ " bytes of leftover metadata"
+                    | otherwise -> do
+                        res <- importCompact scompact $ \ptr len ->
+                            void $ hGetBuf hdl ptr (fromIntegral len)
+                        case res of
+                            Nothing -> return $ Left "Failed to import compact"
+                            Just compact -> return $ Right compact
+
+{- | Check if a handle points to a compact marker (start of serialized compact data)
+and rewind the handle to its previous position
+-}
+hHasCompactMarker :: Handle -> IO Bool
+hHasCompactMarker handle = do
+    marker <- BSL.hGet handle offset
+    hSeek handle RelativeSeek (negate offset)
+    pure $ compactMarker == marker
+  where
+    offset :: Integral a => a
+    offset = fromIntegral $ BSL.length compactMarker
+
+----------------------------------------
+
+newtype CompactFile a = CompactFile (SerializedCompact a)
+
+-- NB: This instance cannot be put on SerializedCompact as
+-- ghc-compact does not have a binary dependency
+instance Typeable a => B.Binary (CompactFile a) where
+    get = do
+        magic <- B.get
+        when (magic /= magicNumber) $
+            fail
+                "Data.Compact.Serialized:\
+                \ Executable mismatch, data was serialized by a different executable."
+        SomeTypeRep tyrep <- B.get
+        case tyrep `eqTypeRep` typeRep @a of
+            Just HRefl -> CompactFile <$> getSerializedCompact
+            Nothing ->
+                fail $
+                    "Data.Compact.Serialized: expected "
+                        ++ show (typeRep @a)
+                        ++ " but got "
+                        ++ show tyrep
+    put (CompactFile a) = B.put magicNumber >> B.put (typeRep @a) >> putSerializedCompact a
+
+compactMarker :: BSL.ByteString
+compactMarker = "COMPACT"
+
+-- Integrity check for stored data: ensure the memory layout is the
+-- same by requiring the _executable_binary_ to be the same.
+{-# NOINLINE magicNumber #-}
+magicNumber :: Fingerprint.Fingerprint
+magicNumber = unsafePerformIO $ getExecutablePath >>= Fingerprint.getFileHash
+
+-- magicNumber = 0x7c155e7a53f094f2
+
+putPtr :: Ptr a -> B.Put
+putPtr = B.put @Word64 . fromIntegral . ptrToWordPtr
+
+getPtr :: B.Get (Ptr a)
+getPtr = wordPtrToPtr . fromIntegral <$> B.get @Word64
+
+getList :: B.Get a -> B.Get [a]
+getList getElem = do
+    n <- B.get @Int
+    replicateM n getElem
+
+putList :: (a -> B.Put) -> [a] -> B.Put
+putList putElem xs = do
+    B.put @Int (length xs)
+    mapM_ putElem xs
+
+getSerializedCompact :: B.Get (SerializedCompact a)
+getSerializedCompact = SerializedCompact <$> getList getBlock <*> getPtr
+  where
+    getBlock :: B.Get (Ptr a, Word)
+    getBlock = (,) <$> getPtr <*> B.get
+
+putSerializedCompact :: SerializedCompact a -> B.Put
+putSerializedCompact (SerializedCompact a b) = putList putBlock a <> putPtr b
+  where
+    putBlock :: (Ptr a, Word) -> B.Put
+    putBlock (ptr, len) = putPtr ptr <> B.put len
+
+hPutStorable :: forall a. Storable a => Handle -> a -> IO ()
+hPutStorable h a =
+    alloca $ \ptr -> do
+        poke ptr a
+        hPutBuf h ptr (sizeOf (undefined :: a))
+
+hGetStorable :: forall a. Storable a => Handle -> IO a
+hGetStorable h =
+    alloca $ \ptr -> do
+        void $ hGetBuf h ptr (sizeOf (undefined :: a))
+        peek ptr

--- a/kore/test/Test/Kore/Syntax/Json.hs
+++ b/kore/test/Test/Kore/Syntax/Json.hs
@@ -119,7 +119,7 @@ genIdChar =
     Gen.frequency
         [ (10, Gen.alpha)
         , (3, Gen.digit)
-        , (1, Gen.element "-'")
+        , (1, Gen.element ['-', '\''])
         ]
 
 genStringLiteral :: Gen Text

--- a/stack.yaml
+++ b/stack.yaml
@@ -54,9 +54,6 @@ extra-deps:
   - typerep-map-0.6.0.0
   - monad-validate-1.2.0.1
 
-# TODO (treeowl): Remove this when compact is updated upstream.
-allow-newer: true
-
 ghc-options:
   "$everything": -haddock
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -50,7 +50,6 @@ packages:
 extra-deps:
   - chronos-1.1.5
   - co-log-0.5.0.0
-  - compact-0.2.0.0
   - decision-diagrams-0.2.0.0
   - typerep-map-0.6.0.0
   - monad-validate-1.2.0.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -53,7 +53,7 @@ extra-deps:
   - compact-0.2.0.0
   - decision-diagrams-0.2.0.0
   - typerep-map-0.6.0.0
-  - monad-validate-1.2.0.0@sha256:9850f408431098b28806dd464b6825a88a0b56c84f380d7fe0454c1df9d6f881,3505
+  - monad-validate-1.2.0.1
 
 # TODO (treeowl): Remove this when compact is updated upstream.
 allow-newer: true

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -19,13 +19,6 @@ packages:
   original:
     hackage: co-log-0.5.0.0
 - completed:
-    hackage: compact-0.2.0.0@sha256:75ef98cb51201b4a0d6de95cbbb62be6237c092a3d594737346c70c5d56c2380,2413
-    pantry-tree:
-      sha256: 9514e48c9141b29a5f58b27c2950f17cc1c53eea3d393a6a1ed46ca16e876754
-      size: 546
-  original:
-    hackage: compact-0.2.0.0
-- completed:
     hackage: decision-diagrams-0.2.0.0@sha256:94058731961a98c53cd233bdb911f9ec4f1781de3f0d80a0133ebb3f4789938b,3415
     pantry-tree:
       sha256: 340509eeb518acd55bb125d8eeb29aa5247b9600096472db134c739b1924b828

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -40,12 +40,12 @@ packages:
   original:
     hackage: typerep-map-0.6.0.0
 - completed:
-    hackage: monad-validate-1.2.0.0@sha256:9850f408431098b28806dd464b6825a88a0b56c84f380d7fe0454c1df9d6f881,3505
+    hackage: monad-validate-1.2.0.1@sha256:5a100da896f11ca4b7c123da85decbedeb46c37054a097f258ac911e715cb68d,2587
     pantry-tree:
-      sha256: 8e049bd12ce2bd470909578f2ee8eb80b89d5ff88860afa30e29dd4eafecfa3e
-      size: 713
+      sha256: 034ee4de9765e38b763f5d73b236cc112205728e680cefbfe12d2882accc3264
+      size: 611
   original:
-    hackage: monad-validate-1.2.0.0@sha256:9850f408431098b28806dd464b6825a88a0b56c84f380d7fe0454c1df9d6f881,3505
+    hackage: monad-validate-1.2.0.1
 snapshots:
 - completed:
     sha256: 126fa33ceb11f5e85ceb4e86d434756bd9a8439e2e5776d306a15fbc63b01e89

--- a/test/serialized-definition/Makefile
+++ b/test/serialized-definition/Makefile
@@ -1,0 +1,27 @@
+include $(CURDIR)/../include.mk
+
+KORE_FILES=$(wildcard [a-z]*definition.kore)
+
+test: $(addprefix test-,$(basename $(KORE_FILES)))
+
+MODULE=UNDEFINED-MODULE
+
+# lame solution: specify the --module $MODULE individually instead of grep|tail|sed
+test-a-to-f-definition: MODULE=TEST
+test-test-smoke-definition: MODULE=C
+test-test-totalSupply-definition: MODULE=VERIFICATION
+
+test-%: %.kore
+	@echo "Serializing definition $<"
+	time -f "%esec" $(KORE_EXEC) $< --output serialized.bin --module $(MODULE) --serialize
+	@echo "Loading serialized definition (to hit an error afterwards)"
+	time -f "%esec" sh -c "$(KORE_EXEC) serialized.bin \
+		--module $(MODULE) \
+		--pattern serialized.bin \
+		--debug-rewrite FAIL-ME-PLEASE 2>&1 | \
+		grep FAIL-ME-PLEASE"
+	@rm serialized.bin
+
+clean:
+
+golden:

--- a/test/serialized-definition/README.md
+++ b/test/serialized-definition/README.md
@@ -1,0 +1,26 @@
+## Smoke tests for definition serialisation
+
+A few large kore files (from other regression tests) are serialised using the `--serialize` option:
+
+```shell
+$ kore-exec --serialize FILENAME.kore --output serialized.bin --module MODULE
+```
+The `MODULE` variable needs to be set for each test (see `Makefile`)
+
+Then the serialised definition is loaded back into memory by a call to `kore-exec` which fails on a sanity check after loading the definition:
+
+```shell
+$ kore-exec serialized.bin --module MODULE --pattern DUMMY --debug-rewrite FAIL-ME-PLEASE
+```
+The expected failure is
+
+```
+kore-exec: [NUMBER] Error (ErrorException):
+    Rule labels for the following debug options are not defined:
+    --debug-rewrite: FAIL-ME-PLEASE
+```
+Presence of the error is checked by piping output to `grep FAIL-ME-PLEASE`.
+
+This is the best we can do because of some assumptions hard-coded into `kore-exec`[1], and because we must use the exact same executable to write and read the serialised file.
+
+[1] For instance, the binary file must have suffix `.bin` and an adjacent `definition.kore` file must exist when using a binary file.

--- a/test/serialized-definition/a-to-f-definition.kore
+++ b/test/serialized-definition/a-to-f-definition.kore
@@ -1,0 +1,1 @@
+../rpc-server/resources/a-to-f/definition.kore

--- a/test/serialized-definition/test-smoke-definition.kore
+++ b/test/serialized-definition/test-smoke-definition.kore
@@ -1,0 +1,1 @@
+../regression-c/test-smoke-definition.kore

--- a/test/serialized-definition/test-totalSupply-definition.kore
+++ b/test/serialized-definition/test-totalSupply-definition.kore
@@ -1,0 +1,1 @@
+../regression-evm/test-totalSupply-definition.kore


### PR DESCRIPTION
Part of #3595 , and general house-keeping.

* Use a released version of `monad-validate`
* Simplify the `MetadataSyntax` type
* assimilate `Data.Compact.Serialize` and remove dependency on (unmaintained) `compact`

By accident, I discovered that the `cabal` build broke with the latest `hedgehog` update and included the 1-line fix here.
* be explicit about the argument type of a `Gen.element` call in the json generator.
