### PR TITLE
Revert 'Eliminate top level existentials in side-condtions'

### DIFF
--- a/kore/src/Kore/Reachability/Claim.hs
+++ b/kore/src/Kore/Reachability/Claim.hs
@@ -773,7 +773,7 @@ checkSimpleImplication inLeft inRight existentials =
         rhsBottom <-
             fmap isBottom . liftSimplifier $
                 SMT.Evaluator.filterMultiOr $srcLoc
-                    =<< Pattern.simplify right
+                    =<< Exists.makeEvaluate SideCondition.top existentials right
 
         case (trivial, rhsBottom) of
             (True, _) -> pure (claimToCheck, Implied Nothing)

--- a/kore/src/Kore/Simplify/Condition.hs
+++ b/kore/src/Kore/Simplify/Condition.hs
@@ -16,15 +16,8 @@ import Control.Monad.State.Strict (
     StateT,
  )
 import Control.Monad.State.Strict qualified as State
-import Data.Functor.Foldable qualified as Recursive
 import Data.Generics.Product (
     field,
- )
-import Data.Set (
-    Set,
- )
-import Kore.Attribute.Pattern.FreeVariables (
-    freeVariableNames,
  )
 import Kore.Internal.Condition qualified as Condition
 import Kore.Internal.Conditional qualified as Conditional
@@ -60,8 +53,6 @@ import Kore.Simplify.SubstitutionSimplifier (
     SubstitutionSimplifier (..),
  )
 import Kore.Substitute
-import Kore.Syntax.Exists qualified as Exists
-import Kore.Syntax.Variable (SomeVariableName)
 import Kore.TopBottom qualified as TopBottom
 import Logic
 import Prelude.Kore
@@ -188,39 +179,14 @@ simplifyPredicates sideCondition original = do
     let predicates =
             SideCondition.simplifyConjunctionByAssumption original
                 & fst . extract
-    simplifiedPredicates <- do
-        let eliminatedExists =
-                map
-                    ( simplifyPredicateExistElim $
-                        -- TODO (sam): this is quite conservative and we may not need to
-                        -- avoid names here, but there doesn't seem to be a negative
-                        -- impact on performance, so best leave this in for now.
-                        freeVariableNames original
-                            <> freeVariableNames sideCondition
-                    )
-                    $ toList predicates
+    simplifiedPredicates <- 
         simplifyPredicatesWithAssumptions
             sideCondition
-            eliminatedExists
+            (toList predicates)
     let simplified = foldMap mkCondition simplifiedPredicates
     if original == simplifiedPredicates
         then return (Condition.markSimplified simplified)
         else simplifyPredicates sideCondition simplifiedPredicates
-
-{- | Simplify an existential predicate by removing the existential binder and refreshing
-all occurrences of the name within the child term
--}
-simplifyPredicateExistElim ::
-    Set (SomeVariableName RewritingVariableName) ->
-    Predicate RewritingVariableName ->
-    Predicate RewritingVariableName
-simplifyPredicateExistElim avoid predicate = case predicateF of
-    Predicate.ExistsF existsF ->
-        let existsF'@Exists.Exists{existsChild} = Exists.refreshExists avoid existsF
-         in simplifyPredicateExistElim (avoid <> freeVariableNames existsF') existsChild
-    _ -> predicate
-  where
-    _ :< predicateF = Recursive.project predicate
 
 {- | Simplify a conjunction of predicates by simplifying each one
 under the assumption that the others are true.


### PR DESCRIPTION
This PR fixes #3605 
The bug was introduced by  #3202, which eliminated top level existentials in side-conditions. However, this was incorrect because when translated to Z3, these variables would get a universal quantification, which is what was happening in #3605 