### PR TITLE
3624 omit trace collection unless required

### DIFF
--- a/kore/src/Kore/Equation/Application.hs
+++ b/kore/src/Kore/Equation/Application.hs
@@ -22,7 +22,9 @@ import Control.Error (
 import Control.Monad (
     (>=>),
  )
+import Control.Monad.Reader (asks)
 import Control.Monad.State (modify)
+import Data.Bifunctor
 import Data.Map.Strict (
     Map,
  )
@@ -257,10 +259,12 @@ applyEquation ::
     Simplifier (OrPattern RewritingVariableName)
 applyEquation _ term equation result = do
     let results = OrPattern.fromPattern result
-    let simplify = return
     debugApplyEquation equation result
-    modify $ \(cache, equations) -> (cache, equations |> SimplifierTrace term (Attribute.uniqueId (attributes equation)) result)
-    simplify results
+    doTracing <- liftSimplifier $ asks Simplifier.tracingEnabled
+    when doTracing $
+        modify $
+            second (|> SimplifierTrace term (Attribute.uniqueId $ attributes equation) result)
+    pure results
 
 {- | Use a 'MatchResult' to instantiate an 'Equation'.
 

--- a/kore/src/Kore/Simplify/API.hs
+++ b/kore/src/Kore/Simplify/API.hs
@@ -86,13 +86,14 @@ traceProfSimplify =
         . Pattern.toTermLike
 
 mkSimplifierEnv ::
+    Bool ->
     VerifiedModuleSyntax Attribute.Symbol ->
     SortGraph ->
     OverloadGraph ->
     SmtMetadataTools Attribute.Symbol ->
     Map AxiomIdentifier [Equation VariableName] ->
     SMT Env
-mkSimplifierEnv verifiedModule sortGraph overloadGraph metadataTools rawEquations =
+mkSimplifierEnv tracingEnabled verifiedModule sortGraph overloadGraph metadataTools rawEquations =
     runSimplifier earlyEnv initialize
   where
     !earlyEnv =
@@ -107,6 +108,7 @@ mkSimplifierEnv verifiedModule sortGraph overloadGraph metadataTools rawEquation
             , injSimplifier
             , overloadSimplifier
             , hookedSymbols = Map.empty
+            , tracingEnabled
             }
     injSimplifier =
         {-# SCC "evalSimplifier/injSimplifier" #-}
@@ -154,6 +156,7 @@ mkSimplifierEnv verifiedModule sortGraph overloadGraph metadataTools rawEquation
                 , overloadSimplifier
                 , hookedSymbols
                 , axiomEquations
+                , tracingEnabled
                 }
 
 {- | Evaluate a simplifier computation, returning the result of only one branch.
@@ -171,7 +174,7 @@ evalSimplifier ::
     Simplifier a ->
     SMT a
 evalSimplifier verifiedModule sortGraph overloadGraph metadataTools rawEquations simplifier = do
-    env <- mkSimplifierEnv verifiedModule sortGraph overloadGraph metadataTools rawEquations
+    env <- mkSimplifierEnv False verifiedModule sortGraph overloadGraph metadataTools rawEquations
     runSimplifier env simplifier
 
 evalSimplifierLogged ::
@@ -183,7 +186,7 @@ evalSimplifierLogged ::
     Simplifier a ->
     SMT (Seq SimplifierTrace, a)
 evalSimplifierLogged verifiedModule sortGraph overloadGraph metadataTools rawEquations simplifier = do
-    env <- mkSimplifierEnv verifiedModule sortGraph overloadGraph metadataTools rawEquations
+    env <- mkSimplifierEnv True verifiedModule sortGraph overloadGraph metadataTools rawEquations
     runSimplifierLogged env simplifier
 
 evalSimplifierProofs ::

--- a/kore/src/Kore/Simplify/Simplify.hs
+++ b/kore/src/Kore/Simplify/Simplify.hs
@@ -151,6 +151,7 @@ data Env = Env
     , injSimplifier :: !InjSimplifier
     , overloadSimplifier :: !OverloadSimplifier
     , hookedSymbols :: !(Map Id Text)
+    , tracingEnabled :: Bool
     }
 
 data SimplifierTrace = SimplifierTrace

--- a/kore/test/Test/Kore/Builtin/Builtin.hs
+++ b/kore/test/Test/Kore/Builtin/Builtin.hs
@@ -245,6 +245,7 @@ testEnv =
         , injSimplifier = testInjSimplifier
         , overloadSimplifier = testOverloadSimplifier
         , hookedSymbols = mkHookedSymbols $ indexedModuleSyntax verifiedModule
+        , tracingEnabled = False
         }
 
 simplify :: TermLike RewritingVariableName -> IO [Pattern RewritingVariableName]

--- a/kore/test/Test/Kore/Exec.hs
+++ b/kore/test/Test/Kore/Exec.hs
@@ -1217,6 +1217,7 @@ rpcExecTest cutPointLs terminalLs depthLimit verifiedModule initial =
             depthLimit
             Nothing
             DisableMovingAverage
+            False
             serializedModule
             (StopLabels cutPointLs terminalLs)
             initial

--- a/kore/test/Test/Kore/Rewrite/Function/Integration.hs
+++ b/kore/test/Test/Kore/Rewrite/Function/Integration.hs
@@ -1184,4 +1184,5 @@ testEnv =
                 [ mkHookedSymbols $ indexedModuleSyntax verifiedModule
                 , listHookedSymbols
                 ]
+        , tracingEnabled = False
         }

--- a/kore/test/Test/Kore/Rewrite/MockSymbols.hs
+++ b/kore/test/Test/Kore/Rewrite/MockSymbols.hs
@@ -2305,8 +2305,6 @@ overloadGraph = OverloadGraph.fromOverloads overloads
 overloadSimplifier :: OverloadSimplifier
 overloadSimplifier = mkOverloadSimplifier overloadGraph Test.Kore.Rewrite.MockSymbols.injSimplifier
 
--- TODO(Ana): if needed, create copy with experimental simplifier
--- enabled
 env :: Env
 env =
     Env
@@ -2319,6 +2317,7 @@ env =
         , injSimplifier = Test.Kore.Rewrite.MockSymbols.injSimplifier
         , overloadSimplifier = Test.Kore.Rewrite.MockSymbols.overloadSimplifier
         , hookedSymbols = Map.empty
+        , tracingEnabled = False
         }
 
 generatorSetup :: ConsistentKore.Setup


### PR DESCRIPTION
Part of #3624

Omits tracing simplifications and rewrites when no trace was requested by the caller.
This fixes a memory issue for execute requests with large depth - traces would otherwise take up large amounts of heap and bring the server down.