### PR TITLE
Fail when checking definition with Z3 returns Unknown

### DIFF
--- a/kore/src/Kore/Rewrite/SMT/Lemma.hs
+++ b/kore/src/Kore/Rewrite/SMT/Lemma.hs
@@ -93,10 +93,7 @@ declareSMTLemmas tools lemmas = do
         Just Sat -> pure ()
         Just Unsat -> errorInconsistentDefinitions
         Just Unknown -> do
-            SMT.localTimeOut doubleTimeOut $ do
-                SMT.reinit
-                declareSortsSymbols $ smtData tools
-                mapM_ declareRule lemmas
+            SMT.localTimeOut doubleTimeOut $
                 SMT.check >>= \case
                     Nothing -> pure ()
                     Just Sat -> pure ()

--- a/kore/src/Kore/Rewrite/SMT/Lemma.hs
+++ b/kore/src/Kore/Rewrite/SMT/Lemma.hs
@@ -86,7 +86,7 @@ declareSMTLemmas tools lemmas = do
     mapM_ declareRule lemmas
     SMT.check >>= \case
         Nothing -> pure ()
-        Just Sat -> pure()
+        Just Sat -> pure ()
         Just Unsat -> errorInconsistentDefinitions
         Just Unknown -> errorPossiblyInconsistentDefinitions
   where

--- a/kore/src/Kore/Rewrite/SMT/Lemma.hs
+++ b/kore/src/Kore/Rewrite/SMT/Lemma.hs
@@ -57,7 +57,6 @@ import SMT (
     assert,
     check,
     localTimeOut,
-    reinit,
  )
 
 getSMTLemmas ::
@@ -93,16 +92,16 @@ declareSMTLemmas tools lemmas = do
         Just Sat -> pure ()
         Just Unsat -> errorInconsistentDefinitions
         Just Unknown -> do
-            SMT.localTimeOut doubleTimeOut $
+            SMT.localTimeOut quadrupleTimeOut $
                 SMT.check >>= \case
                     Nothing -> pure ()
                     Just Sat -> pure ()
                     Just Unsat -> errorInconsistentDefinitions
                     Just Unknown -> errorPossiblyInconsistentDefinitions
   where
-    doubleTimeOut :: SMT.TimeOut -> SMT.TimeOut
-    doubleTimeOut (SMT.TimeOut Unlimited) = SMT.TimeOut Unlimited
-    doubleTimeOut (SMT.TimeOut (Limit r)) = SMT.TimeOut (Limit (2 * r))
+    quadrupleTimeOut :: SMT.TimeOut -> SMT.TimeOut
+    quadrupleTimeOut (SMT.TimeOut Unlimited) = SMT.TimeOut Unlimited
+    quadrupleTimeOut (SMT.TimeOut (Limit r)) = SMT.TimeOut (Limit (4 * r))
 
     declareRule ::
         SentenceAxiom (TermLike VariableName) ->

--- a/kore/src/Kore/Simplify/Condition.hs
+++ b/kore/src/Kore/Simplify/Condition.hs
@@ -16,8 +16,15 @@ import Control.Monad.State.Strict (
     StateT,
  )
 import Control.Monad.State.Strict qualified as State
+import Data.Functor.Foldable qualified as Recursive
 import Data.Generics.Product (
     field,
+ )
+import Data.Set (
+    Set,
+ )
+import Kore.Attribute.Pattern.FreeVariables (
+    freeVariableNames,
  )
 import Kore.Internal.Condition qualified as Condition
 import Kore.Internal.Conditional qualified as Conditional
@@ -53,6 +60,8 @@ import Kore.Simplify.SubstitutionSimplifier (
     SubstitutionSimplifier (..),
  )
 import Kore.Substitute
+import Kore.Syntax.Exists qualified as Exists
+import Kore.Syntax.Variable (SomeVariableName)
 import Kore.TopBottom qualified as TopBottom
 import Logic
 import Prelude.Kore
@@ -179,14 +188,39 @@ simplifyPredicates sideCondition original = do
     let predicates =
             SideCondition.simplifyConjunctionByAssumption original
                 & fst . extract
-    simplifiedPredicates <- 
+    simplifiedPredicates <- do
+        let eliminatedExists =
+                map
+                    ( simplifyPredicateExistElim $
+                        -- TODO (sam): this is quite conservative and we may not need to
+                        -- avoid names here, but there doesn't seem to be a negative
+                        -- impact on performance, so best leave this in for now.
+                        freeVariableNames original
+                            <> freeVariableNames sideCondition
+                    )
+                    $ toList predicates
         simplifyPredicatesWithAssumptions
             sideCondition
-            (toList predicates)
+            eliminatedExists
     let simplified = foldMap mkCondition simplifiedPredicates
     if original == simplifiedPredicates
         then return (Condition.markSimplified simplified)
         else simplifyPredicates sideCondition simplifiedPredicates
+
+{- | Simplify an existential predicate by removing the existential binder and refreshing
+all occurrences of the name within the child term
+-}
+simplifyPredicateExistElim ::
+    Set (SomeVariableName RewritingVariableName) ->
+    Predicate RewritingVariableName ->
+    Predicate RewritingVariableName
+simplifyPredicateExistElim avoid predicate = case predicateF of
+    Predicate.ExistsF existsF ->
+        let existsF'@Exists.Exists{existsChild} = Exists.refreshExists avoid existsF
+         in simplifyPredicateExistElim (avoid <> freeVariableNames existsF') existsChild
+    _ -> predicate
+  where
+    _ :< predicateF = Recursive.project predicate
 
 {- | Simplify a conjunction of predicates by simplifying each one
 under the assumption that the others are true.

--- a/kore/src/Kore/Simplify/Condition.hs
+++ b/kore/src/Kore/Simplify/Condition.hs
@@ -16,15 +16,8 @@ import Control.Monad.State.Strict (
     StateT,
  )
 import Control.Monad.State.Strict qualified as State
-import Data.Functor.Foldable qualified as Recursive
 import Data.Generics.Product (
     field,
- )
-import Data.Set (
-    Set,
- )
-import Kore.Attribute.Pattern.FreeVariables (
-    freeVariableNames,
  )
 import Kore.Internal.Condition qualified as Condition
 import Kore.Internal.Conditional qualified as Conditional
@@ -60,8 +53,6 @@ import Kore.Simplify.SubstitutionSimplifier (
     SubstitutionSimplifier (..),
  )
 import Kore.Substitute
-import Kore.Syntax.Exists qualified as Exists
-import Kore.Syntax.Variable (SomeVariableName)
 import Kore.TopBottom qualified as TopBottom
 import Logic
 import Prelude.Kore
@@ -188,39 +179,14 @@ simplifyPredicates sideCondition original = do
     let predicates =
             SideCondition.simplifyConjunctionByAssumption original
                 & fst . extract
-    simplifiedPredicates <- do
-        let eliminatedExists =
-                map
-                    ( simplifyPredicateExistElim $
-                        -- TODO (sam): this is quite conservative and we may not need to
-                        -- avoid names here, but there doesn't seem to be a negative
-                        -- impact on performance, so best leave this in for now.
-                        freeVariableNames original
-                            <> freeVariableNames sideCondition
-                    )
-                    $ toList predicates
+    simplifiedPredicates <- 
         simplifyPredicatesWithAssumptions
             sideCondition
-            eliminatedExists
+            (toList predicates)
     let simplified = foldMap mkCondition simplifiedPredicates
     if original == simplifiedPredicates
         then return (Condition.markSimplified simplified)
         else simplifyPredicates sideCondition simplifiedPredicates
-
-{- | Simplify an existential predicate by removing the existential binder and refreshing
-all occurrences of the name within the child term
--}
-simplifyPredicateExistElim ::
-    Set (SomeVariableName RewritingVariableName) ->
-    Predicate RewritingVariableName ->
-    Predicate RewritingVariableName
-simplifyPredicateExistElim avoid predicate = case predicateF of
-    Predicate.ExistsF existsF ->
-        let existsF'@Exists.Exists{existsChild} = Exists.refreshExists avoid existsF
-         in simplifyPredicateExistElim (avoid <> freeVariableNames existsF') existsChild
-    _ -> predicate
-  where
-    _ :< predicateF = Recursive.project predicate
 
 {- | Simplify a conjunction of predicates by simplifying each one
 under the assumption that the others are true.


### PR DESCRIPTION
Fixes #3619
The definition provided in the above issue now throws the following error:

```
kore-rpc: [4462799] Error (ErrorException):
    The definitions sent to the solver may not be consistent (Z3 timed out).
    CallStack (from HasCallStack):
      error, called at src/Kore/Rewrite/SMT/Lemma.hs:180:9 in kore-0.60.0.0-inplace:Kore.Rewrite.SMT.Lemma
```