### PR TITLE
Update SIncrease the defult SMT timeout/retry limits

### DIFF
--- a/kore/src/SMT.hs
+++ b/kore/src/SMT.hs
@@ -441,8 +441,8 @@ defaultConfig =
             ]
         , prelude = Prelude Nothing
         , logFile = Nothing
-        , timeOut = TimeOut (Limit 40)
-        , retryLimit = RetryLimit (Limit 1)
+        , timeOut = TimeOut (Limit 125)
+        , retryLimit = RetryLimit (Limit 3)
         , rLimit = RLimit Unlimited
         , resetInterval = ResetInterval 100
         }


### PR DESCRIPTION
Fixes #3643

Increase the default SMT timeout limit to 125 and number of re-tries to 3 