### PR TITLE
Use (||) directly when enabling tracing

### DIFF
--- a/kore/src/Kore/JsonRpc.hs
+++ b/kore/src/Kore/JsonRpc.hs
@@ -124,6 +124,8 @@ respond serverState moduleName runSMT =
                 case verifyIn serializedModule state of
                     Left err -> pure $ Left $ backendError CouldNotVerifyPattern err
                     Right verifiedPattern -> do
+                        let tracingEnabled =
+                                fromMaybe False logSuccessfulRewrites || fromMaybe False logSuccessfulSimplifications
                         traversalResult <-
                             liftIO
                                 ( runSMT (Exec.metadataTools serializedModule) lemmas $
@@ -134,7 +136,7 @@ respond serverState moduleName runSMT =
                                             then EnableMovingAverage
                                             else DisableMovingAverage
                                         )
-                                        (fromMaybe False $ liftA2 (||) logSuccessfulRewrites logSuccessfulSimplifications)
+                                        tracingEnabled
                                         serializedModule
                                         (toStopLabels cutPointRules terminalRules)
                                         verifiedPattern


### PR DESCRIPTION
This PR fixes the case of an `ExecuteRequest` with logging parameters `{logSuccessfulRewrites = Just True, logSuccessfulSimplifications = Nothing}` not retuning any logs (except of terminal/cut-point case).
