### PR TITLE
(Booster 310) request timing log - data definition + basic support

### DIFF
--- a/kore-rpc-types/src/Kore/JsonRpc/Types.hs
+++ b/kore-rpc-types/src/Kore/JsonRpc/Types.hs
@@ -43,6 +43,7 @@ data ExecuteRequest = ExecuteRequest
     , logFailedRewrites :: !(Maybe Bool)
     , logSuccessfulSimplifications :: !(Maybe Bool)
     , logFailedSimplifications :: !(Maybe Bool)
+    , logTiming :: !(Maybe Bool)
     }
     deriving stock (Generic, Show, Eq)
     deriving
@@ -55,6 +56,7 @@ data ImpliesRequest = ImpliesRequest
     , _module :: !(Maybe Text)
     , logSuccessfulSimplifications :: !(Maybe Bool)
     , logFailedSimplifications :: !(Maybe Bool)
+    , logTiming :: !(Maybe Bool)
     }
     deriving stock (Generic, Show, Eq)
     deriving
@@ -66,6 +68,7 @@ data SimplifyRequest = SimplifyRequest
     , _module :: !(Maybe Text)
     , logSuccessfulSimplifications :: !(Maybe Bool)
     , logFailedSimplifications :: !(Maybe Bool)
+    , logTiming :: !(Maybe Bool)
     }
     deriving stock (Generic, Show, Eq)
     deriving

--- a/kore-rpc-types/src/Kore/JsonRpc/Types/Log.hs
+++ b/kore-rpc-types/src/Kore/JsonRpc/Types/Log.hs
@@ -56,7 +56,8 @@ data LogEntry
         , origin :: LogOrigin
         }
     | ProcessingTime
-        { timing :: [(LogOrigin, Double)] -- summatory timing, by origin
+        { timing :: [(Maybe LogOrigin, Double)]
+        -- ^ summatory timing, by origin or overall
         }
     deriving stock (Generic, Show, Eq)
     deriving

--- a/kore-rpc-types/src/Kore/JsonRpc/Types/Log.hs
+++ b/kore-rpc-types/src/Kore/JsonRpc/Types/Log.hs
@@ -16,7 +16,7 @@ import Deriving.Aeson (
     StripPrefix,
  )
 
-data LogOrigin = KoreRpc | Booster | Llvm
+data LogOrigin = KoreRpc | Booster | Llvm | Proxy
     deriving stock (Generic, Show, Eq)
     deriving
         (FromJSON, ToJSON)
@@ -54,6 +54,9 @@ data LogEntry
         , originalTermIndex :: Maybe [Int]
         , result :: LogRewriteResult
         , origin :: LogOrigin
+        }
+    | ProcessingTime
+        { timing :: [(LogOrigin, Double)] -- summatory timing, by origin
         }
     deriving stock (Generic, Show, Eq)
     deriving


### PR DESCRIPTION
Part of [Booster #310](https://github.com/runtimeverification/hs-backend-booster/issues/310)

Extends data types for RPC `LogEntry` and `LogOrigin` to accommodate logging processing time.

* New `ProcessingTime{} :: LogEntry`m with a deliberately loose format. Timings are logged as a list of tagged double values (representing seconds), where the tag is optional (tag `null` is associated with the overall processing time if present). 
   Example 
```
ProcessingTime 
    {timing =
        [ (Nothing, 13.579)
        , (Just KoreRpc,0.123)
        , (Just Proxy,4.567)
        , (Just Booster,8.9012)
        ]
    }
```
rendered as JSON: 
```
{ "tag": "processing-time",
   "timing": [
      [ null, 13.579].
      [ "kore-rpc", 0.123],
      [ "proxy", 4.567],
      [ "booster", 8.9012]
    ]
}
```
* `Proxy :: LogOrigin` is added to enable logging processing overhead in the proxy (time difference between wall-clock time and what is currently measured as `booster` or `kore-rpc` time).
* The overall time of each request is logged in `kore-rpc`.