### PR TITLE
add AddModuleResult type

### DIFF
--- a/kore-rpc-types/kore-rpc-types.cabal
+++ b/kore-rpc-types/kore-rpc-types.cabal
@@ -76,6 +76,7 @@ common library
   build-depends: stm-conduit >= 4.0
   build-depends: text >=1.2
   build-depends: unliftio >= 0.2
+  build-depends: vector >= 0.12.3.1
 
 library
   import: haskell

--- a/kore-rpc-types/kore-rpc-types.cabal
+++ b/kore-rpc-types/kore-rpc-types.cabal
@@ -76,7 +76,6 @@ common library
   build-depends: stm-conduit >= 4.0
   build-depends: text >=1.2
   build-depends: unliftio >= 0.2
-  build-depends: vector >= 0.12.3.1
 
 library
   import: haskell

--- a/kore-rpc-types/src/Kore/JsonRpc/Types.hs
+++ b/kore-rpc-types/src/Kore/JsonRpc/Types.hs
@@ -9,8 +9,9 @@ module Kore.JsonRpc.Types (
 
 import Control.Exception (Exception)
 import Data.Aeson.Encode.Pretty qualified as PrettyJson
-import Data.Aeson.Types (FromJSON (..), ToJSON (..))
+import Data.Aeson.Types (FromJSON (..), ToJSON (..), withArray, emptyArray)
 import Data.Text (Text)
+import Data.Vector qualified as Vector
 import Deriving.Aeson (
     CamelToKebab,
     ConstructorTagModifier,
@@ -22,7 +23,7 @@ import Deriving.Aeson (
 import GHC.Generics (Generic)
 import Kore.JsonRpc.Types.Depth (Depth (..))
 import Kore.JsonRpc.Types.Log (LogEntry)
-import Kore.Syntax.Json.Types (KoreJson)
+import Kore.Syntax.Json.Types (KoreJson, expect)
 import Network.JSONRPC (
     FromRequest (..),
  )
@@ -169,6 +170,15 @@ data SimplifyResult = SimplifyResult
         (FromJSON, ToJSON)
         via CustomJSON '[OmitNothingFields, FieldLabelModifier '[CamelToKebab]] SimplifyResult
 
+data AddModuleResult = AddModuleResult
+    deriving stock (Generic, Show, Eq)
+
+instance FromJSON AddModuleResult where
+    parseJSON = withArray "AddModuleResult" (expect Vector.empty AddModuleResult)
+
+instance ToJSON AddModuleResult where
+    toJSON AddModuleResult = emptyArray
+
 data GetModelResult = GetModelResult
     { satisfiable :: SatResult
     , substitution :: Maybe KoreJson
@@ -205,7 +215,7 @@ type family APIPayload (api :: APIMethod) (r :: ReqOrRes) where
     APIPayload 'SimplifyM 'Req = SimplifyRequest
     APIPayload 'SimplifyM 'Res = SimplifyResult
     APIPayload 'AddModuleM 'Req = AddModuleRequest
-    APIPayload 'AddModuleM 'Res = ()
+    APIPayload 'AddModuleM 'Res = AddModuleResult
     APIPayload 'GetModelM 'Req = GetModelRequest
     APIPayload 'GetModelM 'Res = GetModelResult
 

--- a/kore-rpc-types/src/Kore/JsonRpc/Types.hs
+++ b/kore-rpc-types/src/Kore/JsonRpc/Types.hs
@@ -9,7 +9,7 @@ module Kore.JsonRpc.Types (
 
 import Control.Exception (Exception)
 import Data.Aeson.Encode.Pretty qualified as PrettyJson
-import Data.Aeson.Types (FromJSON (..), ToJSON (..), withArray, emptyArray)
+import Data.Aeson.Types (FromJSON (..), ToJSON (..), emptyArray, withArray)
 import Data.Text (Text)
 import Data.Vector qualified as Vector
 import Deriving.Aeson (

--- a/kore-rpc-types/src/Kore/JsonRpc/Types.hs
+++ b/kore-rpc-types/src/Kore/JsonRpc/Types.hs
@@ -9,9 +9,8 @@ module Kore.JsonRpc.Types (
 
 import Control.Exception (Exception)
 import Data.Aeson.Encode.Pretty qualified as PrettyJson
-import Data.Aeson.Types (FromJSON (..), ToJSON (..), emptyArray, withArray)
+import Data.Aeson.Types (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
-import Data.Vector qualified as Vector
 import Deriving.Aeson (
     CamelToKebab,
     ConstructorTagModifier,
@@ -23,7 +22,7 @@ import Deriving.Aeson (
 import GHC.Generics (Generic)
 import Kore.JsonRpc.Types.Depth (Depth (..))
 import Kore.JsonRpc.Types.Log (LogEntry)
-import Kore.Syntax.Json.Types (KoreJson, expect)
+import Kore.Syntax.Json.Types (KoreJson)
 import Network.JSONRPC (
     FromRequest (..),
  )
@@ -172,12 +171,9 @@ data SimplifyResult = SimplifyResult
 
 data AddModuleResult = AddModuleResult
     deriving stock (Generic, Show, Eq)
-
-instance FromJSON AddModuleResult where
-    parseJSON = withArray "AddModuleResult" (expect Vector.empty AddModuleResult)
-
-instance ToJSON AddModuleResult where
-    toJSON AddModuleResult = emptyArray
+    deriving
+        (FromJSON, ToJSON)
+        via CustomJSON '[OmitNothingFields, FieldLabelModifier '[CamelToKebab]] AddModuleResult
 
 data GetModelResult = GetModelResult
     { satisfiable :: SatResult

--- a/kore-rpc-types/src/Kore/JsonRpc/Types.hs
+++ b/kore-rpc-types/src/Kore/JsonRpc/Types.hs
@@ -169,11 +169,11 @@ data SimplifyResult = SimplifyResult
         (FromJSON, ToJSON)
         via CustomJSON '[OmitNothingFields, FieldLabelModifier '[CamelToKebab]] SimplifyResult
 
-data AddModuleResult = AddModuleResult
+data AddModuleResult = AddModuleResult {_module :: !Text}
     deriving stock (Generic, Show, Eq)
     deriving
         (FromJSON, ToJSON)
-        via CustomJSON '[OmitNothingFields, FieldLabelModifier '[CamelToKebab]] AddModuleResult
+        via CustomJSON '[FieldLabelModifier '[StripPrefix "_"]] AddModuleResult
 
 data GetModelResult = GetModelResult
     { satisfiable :: SatResult

--- a/kore/src/Kore/JsonRpc.hs
+++ b/kore/src/Kore/JsonRpc.hs
@@ -489,7 +489,7 @@ respond serverState moduleName runSMT =
                                                     , loadedDefinition
                                                     }
 
-                                    pure . Right $ AddModule AddModuleResult
+                                    pure . Right . AddModule $ AddModuleResult (getModuleName name)
         GetModel GetModelRequest{state, _module} ->
             withMainModule (coerce _module) $ \serializedModule lemmas ->
                 case verifyIn serializedModule state of

--- a/kore/src/Kore/JsonRpc.hs
+++ b/kore/src/Kore/JsonRpc.hs
@@ -489,7 +489,7 @@ respond serverState moduleName runSMT =
                                                     , loadedDefinition
                                                     }
 
-                                    pure . Right $ AddModule ()
+                                    pure . Right $ AddModule AddModuleResult
         GetModel GetModelRequest{state, _module} ->
             withMainModule (coerce _module) $ \serializedModule lemmas ->
                 case verifyIn serializedModule state of

--- a/test/rpc-server/add-module/add/response.golden
+++ b/test/rpc-server/add-module/add/response.golden
@@ -1,1 +1,1 @@
-{"jsonrpc":"2.0","id":1,"result":[]}
+{"jsonrpc":"2.0","id":1,"result":{"module":"NEW"}}


### PR DESCRIPTION
Previously `decodeKoreRpc` in the booster would treat certain terms as an AddModule response that were not in fact such a term. By changing how we parse and unparse the json corresponding to AddModule responses, I am hoping to fix this.

### Scope:

### Estimate:

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
