### PR TITLE
Nix - read the z3 version from release.yml

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,11 +19,10 @@
         z3 = prev.z3.overrideAttrs (old: {
           src = z3-src;
           version =
-            # hacky way of keeping the version number of this derivation consistent with
-            # the z3-src input.
-            let lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-            in builtins.replaceStrings [ "z3-" ] [ "" ]
-            lock.nodes.z3-src.original.ref;
+
+            let release = builtins.readFile "${z3-src}/scripts/release.yml";
+            # read the release version from scripts/release.yml
+            in builtins.head (builtins.match ".+ReleaseVersion: '([^']+).+" release);
         });
       });
       integration-tests-overlay = (final: prev: {


### PR DESCRIPTION
Minor tweak to the nix derivation to read the z3 version from the source code of the z3 repo, specifically from `scripts/release.yml`. Because nix doesn't read YAML, we use a regex, which is slightly hacky but should be stable enough. This change is useful when overriding z3 via

```
nix build github:runtimeverification/haskell-backend#kore-exec --override-input z3-src github:Z3Prover/z3/z3-4.8.15
```
With this change, we build
```
/nix/store/m9filf9jjcwihfrfglqv01wnawg6jdq9-z3-4.8.15
```

whereas before this change, the package name would have been
```
/nix/store/...-z3-4.12.1
```
even though calling
```
/nix/store/...-z3-4.12.1/bin/z3 --version
```
would have reported 4.8.15.