### PR TITLE
Catch IOError when a query times out and retry correctly

### DIFF
--- a/kore/src/Kore/Rewrite/SMT/Evaluator.hs
+++ b/kore/src/Kore/Rewrite/SMT/Evaluator.hs
@@ -19,7 +19,9 @@ import Control.Error (
     MaybeT (..),
     runMaybeT,
  )
+import Control.Exception (IOException)
 import Control.Lens qualified as Lens
+import Control.Monad.Catch qualified as Exception
 import Control.Monad.Counter qualified as Counter
 import Control.Monad.Morph qualified as Morph
 import Control.Monad.State.Strict qualified as State
@@ -92,8 +94,6 @@ import SMT (
  )
 import SMT qualified
 import SMT.SimpleSMT qualified as SimpleSMT
-import Control.Monad.Catch qualified as Exception
-import Control.Exception (IOException)
 
 {- | Attempt to evaluate the 'Predicate' argument with an optional side
  condition using an external SMT solver.


### PR DESCRIPTION
This (hopefully) fixes https://github.com/runtimeverification/k/issues/3729, specifially the error below, thrown [here](https://github.com/runtimeverification/haskell-backend/blob/58a101d279efb64e7042bab2968a22f27a9e2706/kore/src/SMT/SimpleSMT.hs#L444-L450)
```
kore-exec: [41516716] Error (ErrorException):
    user error (Unexpected result from the SMT solver:
      Command: (push 1 )
      Expected: success
      Result: (error "line 178 column 8: push canceled" )
    )
```

This error occurs when smt-limit is low and we send an assert query to the solver. When this happens, we want to re-try instead of letting the error bubble up, as it currently does.

I have tested this and confirmed that at a threshold level of `smt-timeout` where Z3 fails intermittently, with this change, we re-try the specified number of times before failing fully.