### PR TITLE
Serialize the unknown predicate as JSON on `DecidePredicateUnknown`

### DIFF
--- a/kore/src/Kore/JsonRpc.hs
+++ b/kore/src/Kore/JsonRpc.hs
@@ -646,11 +646,9 @@ runServer port serverState mainModule runSMT Log.LoggerEnv{logAction} = do
 
 handleDecidePredicateUnknown :: JsonRpcHandler
 handleDecidePredicateUnknown = JsonRpcHandler $ \(err :: DecidePredicateUnknown) ->
-    let mkPretty = Pretty.renderText . Pretty.layoutPretty Pretty.defaultLayoutOptions . Pretty.pretty
-     in logInfoN (mkPretty err)
-            >> pure
-                ( backendError SmtSolverError $
-                    PatternJson.fromPredicate
-                        (TermLike.SortActualSort $ TermLike.SortActual (TermLike.Id "SortBool" TermLike.AstLocationNone) [])
-                        (makeMultipleAndPredicate . toList $ predicates err)
-                )
+    pure
+        ( backendError SmtSolverError $
+            PatternJson.fromPredicate
+                (TermLike.SortActualSort $ TermLike.SortActual (TermLike.Id "SortBool" TermLike.AstLocationNone) [])
+                (makeMultipleAndPredicate . toList $ predicates err)
+        )

--- a/kore/src/Kore/JsonRpc.hs
+++ b/kore/src/Kore/JsonRpc.hs
@@ -10,7 +10,7 @@ module Kore.JsonRpc (
 
 import Control.Concurrent.MVar qualified as MVar
 import Control.Monad.Except (runExceptT)
-import Control.Monad.Logger (logInfoN, runLoggingT)
+import Control.Monad.Logger (runLoggingT)
 import Data.Aeson.Types (ToJSON (..))
 import Data.Coerce (coerce)
 import Data.Conduit.Network (serverSettings)
@@ -96,7 +96,6 @@ import Kore.Validate.PatternVerifier (Context (..))
 import Kore.Validate.PatternVerifier qualified as PatternVerifier
 import Log qualified
 import Prelude.Kore
-import Pretty qualified
 import SMT qualified
 import System.Clock (Clock (Monotonic), diffTimeSpec, getTime, toNanoSecs)
 


### PR DESCRIPTION
This PR changes the JSON RPC handler for `DecidePredicateUnknown`.

Before we pretty-printed (ugly-printed, let's be honest) the predicate and returned that as the "data" field of the JSON RPC error. Now we conjunct the predicates and side conditions, serialize the conjunction as JSON and return that as "data".

This will solve two sources of paper cuts when using Kontrol:
* the server won't spam `stderr` with incomprehensible Kore output when encountering difficult predicates
* `pyk`/`kontrol` can handle server errors with `"code": 5, "message":"Smt solver error` better, for example by pretty-printing the JSON predicate into surface K or tool-specific representation.