### PR TITLE
Reduce `DecidePredicateUnknown` pretty instance to only rule locations

### DIFF
--- a/kore/src/Kore/JsonRpc.hs
+++ b/kore/src/Kore/JsonRpc.hs
@@ -646,11 +646,9 @@ runServer port serverState mainModule runSMT Log.LoggerEnv{logAction} = do
 
 handleDecidePredicateUnknown :: JsonRpcHandler
 handleDecidePredicateUnknown = JsonRpcHandler $ \(err :: DecidePredicateUnknown) ->
-    let mkPretty = Pretty.renderText . Pretty.layoutPretty Pretty.defaultLayoutOptions . Pretty.pretty
-     in logInfoN (mkPretty err)
-            >> pure
-                ( backendError SmtSolverError $
-                    PatternJson.fromPredicate
-                        (TermLike.SortActualSort $ TermLike.SortActual (TermLike.Id "SortBool" TermLike.AstLocationNone) [])
-                        (makeMultipleAndPredicate . toList $ predicates err)
-                )
+    pure
+        ( backendError SmtSolverError $
+            PatternJson.fromPredicate
+                (TermLike.SortActualSort $ TermLike.SortActual (TermLike.Id "SortBool" TermLike.AstLocationNone) [])
+                (makeMultipleAndPredicate . toList $ predicates err)
+        )

--- a/kore/src/Kore/JsonRpc.hs
+++ b/kore/src/Kore/JsonRpc.hs
@@ -10,7 +10,7 @@ module Kore.JsonRpc (
 
 import Control.Concurrent.MVar qualified as MVar
 import Control.Monad.Except (runExceptT)
-import Control.Monad.Logger (logInfoN, runLoggingT)
+import Control.Monad.Logger (runLoggingT)
 import Data.Aeson.Types (ToJSON (..))
 import Data.Coerce (coerce)
 import Data.Conduit.Network (serverSettings)
@@ -96,7 +96,6 @@ import Kore.Validate.PatternVerifier (Context (..))
 import Kore.Validate.PatternVerifier qualified as PatternVerifier
 import Log qualified
 import Prelude.Kore
-import Pretty qualified
 import SMT qualified
 import System.Clock (Clock (Monotonic), diffTimeSpec, getTime, toNanoSecs)
 

--- a/kore/src/Kore/Log/DecidePredicateUnknown.hs
+++ b/kore/src/Kore/Log/DecidePredicateUnknown.hs
@@ -19,7 +19,6 @@ import Control.Exception (
     Exception (..),
     throw,
  )
-import Data.Limit (Limit (..))
 import Debug
 import Kore.Attribute.SourceLocation (
     SourceLocation (..),
@@ -69,27 +68,8 @@ instance Diff DecidePredicateUnknown where
     diffPrec = diffPrecEq
 
 instance Pretty DecidePredicateUnknown where
-    pretty DecidePredicateUnknown{smtLimit = SMT.RetryLimit limit, predicates} =
-        Pretty.vsep
-            ( [ "Failed to decide predicate:"
-              , Pretty.indent 4 (pretty predicate)
-              ]
-                ++ do
-                    sideCondition <- sideConditions
-                    [ "with side condition:"
-                        , Pretty.indent 4 (pretty sideCondition)
-                        ]
-                ++ [ "SMT limit set at:"
-                   , Pretty.indent
-                        4
-                        ( case limit of
-                            Limit n -> pretty n
-                            Unlimited -> "infinity"
-                        )
-                   ]
-            )
-      where
-        predicate :| sideConditions = predicates
+    pretty DecidePredicateUnknown{} =
+        Pretty.vsep ["Failed to decide predicate."]
 
 instance Entry DecidePredicateUnknown where
     entrySeverity DecidePredicateUnknown{action} =


### PR DESCRIPTION
Follow-up for #3694.

Knowing which rule caused `DecidePredicateUnknown` is useful, but seeing the Kore of the predicate in the logs is not, since we now have it in the response anyway.