### PR TITLE
Use plain `(check-sat)` when checking consistency of SMT lemmas

### DIFF
--- a/kore/src/Kore/Rewrite/SMT/Lemma.hs
+++ b/kore/src/Kore/Rewrite/SMT/Lemma.hs
@@ -88,18 +88,21 @@ declareSMTLemmas ::
 declareSMTLemmas tools lemmas = do
     declareSortsSymbols $ smtData tools
     mapM_ declareRule lemmas
-    SMT.check >>= \case
+    SMT.checkUsing checkSatTactic >>= \case
         Nothing -> pure ()
         Just Sat -> pure ()
         Just Unsat -> errorInconsistentDefinitions
         Just Unknown -> do
             SMT.localTimeOut quadrupleTimeOut $
-                SMT.checkUsing (List [Atom "check-sat"]) >>= \case
+                SMT.checkUsing checkSatTactic >>= \case
                     Nothing -> pure ()
                     Just Sat -> pure ()
                     Just Unsat -> errorInconsistentDefinitions
                     Just Unknown -> errorPossiblyInconsistentDefinitions
   where
+    checkSatTactic :: SExpr
+    checkSatTactic = List [Atom "check-sat"]
+
     quadrupleTimeOut :: SMT.TimeOut -> SMT.TimeOut
     quadrupleTimeOut (SMT.TimeOut Unlimited) = SMT.TimeOut Unlimited
     quadrupleTimeOut (SMT.TimeOut (Limit r)) = SMT.TimeOut (Limit (4 * r))

--- a/kore/src/Kore/Rewrite/SMT/Lemma.hs
+++ b/kore/src/Kore/Rewrite/SMT/Lemma.hs
@@ -55,7 +55,6 @@ import SMT (
     SExpr (..),
     TimeOut (..),
     assert,
-    check,
     checkUsing,
     localTimeOut,
  )

--- a/kore/src/Kore/Rewrite/SMT/Lemma.hs
+++ b/kore/src/Kore/Rewrite/SMT/Lemma.hs
@@ -56,6 +56,7 @@ import SMT (
     TimeOut (..),
     assert,
     check,
+    checkUsing,
     localTimeOut,
  )
 
@@ -93,7 +94,7 @@ declareSMTLemmas tools lemmas = do
         Just Unsat -> errorInconsistentDefinitions
         Just Unknown -> do
             SMT.localTimeOut quadrupleTimeOut $
-                SMT.check >>= \case
+                SMT.checkUsing (List [Atom "check-sat"]) >>= \case
                     Nothing -> pure ()
                     Just Sat -> pure ()
                     Just Unsat -> errorInconsistentDefinitions


### PR DESCRIPTION
When calling Z3 to check consistency of the prelude/smt-lemmas, if `--smt-tactic TACTIC` was given, we were calling `(check-sat-using TACTIC)`. That causes problems if we give an experimental tactic. We should always use the plain `(check-sat)` at the initialization step.