### PR TITLE
Print error message on `stderr` before writing the bug report

### DIFF
--- a/kore/src/Kore/BugReport.hs
+++ b/kore/src/Kore/BugReport.hs
@@ -161,6 +161,7 @@ withBugReport exeName bugReportOption act =
                     optionalWriteBugReport tmpDir
                 | otherwise -> do
                     let message = displayException someException
+                    hPutStrLn stderr message
                     writeFile (tmpDir </> "error" <.> "log") message
                     alwaysWriteBugReport tmpDir
             ExitCaseAbort -> alwaysWriteBugReport tmpDir


### PR DESCRIPTION
When something goes wrong while internalizing `definition.kore`, we can see the reason in the created bug report archive. This approach proves to be obsolete in today's workflow, where `pyk`-level bug reports are dominant, and server-level bug reports are not used at all.

With this change, we can see  the contents of `error.log` on `stderr` directly after `kore-rpc-booster` shutdown, saving the need to unpack the bug report archive. For example: 
```
[Info#proxy] Loading definition from /home/geo2a/.cache/kdist-46a7e08/evm-semantics/haskell/definition.kore, main module "EDSL"
[Info#kore] : Info (LogMessage):
    Reading the input file TimeSpec {sec = 0, nsec = 21030748} []
[Info#kore] : Info (LogMessage):
    Parsing the file TimeSpec {sec = 0, nsec = 1467} []
[Info#kore] : Info (LogMessage):
    Verifying the definition TimeSpec {sec = 0, nsec = 2445} []
Error:
  module 'EDSL':
  hooked-symbol 'LblECDSAPubKey'LParUndsRParUnds'KRYPTO'Unds'String'Unds'String' declaration (/home/geo2a/.cache/kdist-46a7e08/evm-semantics/haskell/definition.kore 756:17):
  In argument sorts:
    Sort 'SortString' is not hooked to builtin sort 'BYTES.Bytes'
Created bug report: kore-rpc-booster.tar.gz
```