### PR TITLE
optional text argument for symbol attribute (empty text = no argument)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v22
+        uses: cachix/install-nix-action@v25
         with:
           install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           extra_nix_config: |
@@ -28,7 +28,7 @@ jobs:
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
 
       - name: Install Cachix
-        uses: cachix/cachix-action@v12
+        uses: cachix/cachix-action@v14
         with:
           name: k-framework
           authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
@@ -54,14 +54,14 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       # Do the Following only on Public Runners; Mac Runner is pre-installed with build tools
       - name: 'Install Nix'
         if: ${{ !startsWith(matrix.os, 'self') }}
-        uses: cachix/install-nix-action@v22
+        uses: cachix/install-nix-action@v25
         with:
           install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           extra_nix_config: |
@@ -71,13 +71,13 @@ jobs:
 
       - name: 'Install Cachix'
         if: ${{ !startsWith(matrix.os, 'self') }}
-        uses: cachix/cachix-action@v12
+        uses: cachix/cachix-action@v14
         with:
           name: k-framework
           authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
 
       - name: Cache Cabal package database and store
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cabal/packages
@@ -101,12 +101,12 @@ jobs:
           sudo apt install --yes z3 libsecp256k1-dev
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Cache Stack root
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.stack
           key: stack-2-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
@@ -135,12 +135,12 @@ jobs:
           sudo apt install --yes z3 libsecp256k1-dev
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Cache Stack root
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.stack
           key: stack-haddock-2-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: 'Check out code'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
@@ -23,7 +23,7 @@ jobs:
           token: ${{ secrets.JENKINS_GITHUB_PAT }}
 
       - name: 'Install Nix'
-        uses: cachix/install-nix-action@v22
+        uses: cachix/install-nix-action@v25
         with:
           install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           extra_nix_config: |
@@ -32,7 +32,7 @@ jobs:
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
 
       - name: 'Install Cachix'
-        uses: cachix/cachix-action@v12
+        uses: cachix/cachix-action@v14
         with:
           name: k-framework
           authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
@@ -80,7 +80,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Check out pull request HEAD instead of merge commit.
           ref: ${{ github.event.pull_request.head.sha }}
@@ -93,7 +93,7 @@ jobs:
       # Do the Following only on Public Runners; Mac Runner is pre-installed with build tools
       - name: 'Install Nix'
         if: ${{ !startsWith(matrix.os, 'self') }}
-        uses: cachix/install-nix-action@v22
+        uses: cachix/install-nix-action@v25
         with:
           install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           extra_nix_config: |
@@ -103,7 +103,7 @@ jobs:
 
       - name: 'Install Cachix'
         if: ${{ !startsWith(matrix.os, 'self') }}
-        uses: cachix/cachix-action@v12
+        uses: cachix/cachix-action@v14
         with:
           name: k-framework
           authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
@@ -112,7 +112,7 @@ jobs:
         run: GC_DONT_GC=1 nix build .#kore-exec
 
       - name: Cache Cabal package database and store
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cabal/packages
@@ -132,14 +132,14 @@ jobs:
     runs-on: [self-hosted, linux, normal]
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Check out pull request HEAD instead of merge commit.
           ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v22
+        uses: cachix/install-nix-action@v25
         with:
           install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           extra_nix_config: |
@@ -148,7 +148,7 @@ jobs:
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
 
       - name: Install Cachix
-        uses: cachix/cachix-action@v12
+        uses: cachix/cachix-action@v14
         with:
           name: k-framework
           skipPush: true
@@ -168,14 +168,14 @@ jobs:
         run: |
           sudo apt install --yes z3 libsecp256k1-dev
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # Check out pull request HEAD instead of merge commit.
           ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive
 
       - name: Cache Stack root
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.stack
           key: stack-2-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
@@ -209,7 +209,7 @@ jobs:
     env:
       hlint_version: "3.5"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # Check out pull request HEAD instead of merge commit.
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/update-regression-tests.yml
+++ b/.github/workflows/update-regression-tests.yml
@@ -33,14 +33,14 @@ jobs:
       EVM_SEMANTICS: ./evm-semantics
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Switch to update branch (or create it off master)
         run: |
           git checkout -B _update origin/_update || git checkout -B _update
       - name: Check out evm-semantics
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: runtimeverification/evm-semantics
           submodules: recursive

--- a/kore/src/Kore/Attribute/Symbol/SymbolKywd.hs
+++ b/kore/src/Kore/Attribute/Symbol/SymbolKywd.hs
@@ -17,7 +17,8 @@ import Kore.Debug
 import Prelude.Kore
 
 {- | @SymbolKywd@ represents the @symbolKywd@ attribute for symbols.
-FIXME change this to hold an optional Text (see kLabel), use sites can check emptiness
+  Hold an optional Text, which is an empty string if the attribute had
+  no argument. Use sites can check emptiness to achieve old behaviour.
 -}
 newtype SymbolKywd = SymbolKywd {getSymbol :: Maybe Text}
     deriving stock (Eq, Ord, Show)

--- a/kore/src/Kore/Attribute/Symbol/SymbolKywd.hs
+++ b/kore/src/Kore/Attribute/Symbol/SymbolKywd.hs
@@ -16,8 +16,9 @@ import Kore.Attribute.Parser as Parser
 import Kore.Debug
 import Prelude.Kore
 
--- | @SymbolKywd@ represents the @symbolKywd@ attribute for symbols.
--- FIXME change this to hold an optional Text (see kLabel), use sites can check emptiness
+{- | @SymbolKywd@ represents the @symbolKywd@ attribute for symbols.
+FIXME change this to hold an optional Text (see kLabel), use sites can check emptiness
+-}
 newtype SymbolKywd = SymbolKywd {getSymbol :: Maybe Text}
     deriving stock (Eq, Ord, Show)
     deriving stock (GHC.Generic)
@@ -42,10 +43,10 @@ symbolKywdSymbol =
 
 -- | Kore pattern representing the @symbolKywd@ attribute.
 symbolKywdAttribute :: Text -> AttributePattern
-symbolKywdAttribute = attributePattern symbolKywdSymbol . (:[]) . attributeString
+symbolKywdAttribute = attributePattern symbolKywdSymbol . (: []) . attributeString
 
 instance ParseAttributes SymbolKywd where
-    -- if an argument is present, use it for the contents, otherwise 
+    -- if an argument is present, use it for the contents, otherwise
     -- leave it empty (but present) to signal presence of the attribute.
     parseAttribute =
         withApplication symbolKywdId $ \params args SymbolKywd{getSymbol} -> do

--- a/kore/src/Kore/Builtin/Endianness.hs
+++ b/kore/src/Kore/Builtin/Endianness.hs
@@ -62,9 +62,9 @@ endiannessVerifier ctor =
     worker application = do
         -- TODO (thomas.tuegel): Move the checks into the symbol verifiers.
         unless (null arguments) (koreFail "expected zero arguments")
-        let Attribute.Symbol.SymbolKywd{isSymbolKywd} =
+        let Attribute.Symbol.SymbolKywd{getSymbol} =
                 Attribute.Symbol.symbolKywd $ symbolAttributes symbol
-        unless isSymbolKywd (koreFail "expected symbol'Kywd'{}() attribute")
+        unless (isJust getSymbol) (koreFail "expected symbol'Kywd'{}() attribute")
         return (EndiannessF . Const $ ctor symbol)
       where
         arguments = applicationChildren application

--- a/kore/src/Kore/Builtin/Signedness.hs
+++ b/kore/src/Kore/Builtin/Signedness.hs
@@ -62,9 +62,9 @@ signednessVerifier ctor =
     worker application = do
         -- TODO (thomas.tuegel): Move the checks into the symbol verifiers.
         unless (null arguments) (koreFail "expected zero arguments")
-        let Attribute.Symbol.SymbolKywd{isSymbolKywd} =
+        let Attribute.Symbol.SymbolKywd{getSymbol} =
                 Attribute.Symbol.symbolKywd $ symbolAttributes symbol
-        unless isSymbolKywd (koreFail "expected symbol'Kywd'{}() attribute")
+        unless (isJust getSymbol) (koreFail "expected symbol'Kywd'{}() attribute")
         return (SignednessF . Const $ ctor symbol)
       where
         arguments = applicationChildren application

--- a/kore/src/Kore/Internal/Symbol.hs
+++ b/kore/src/Kore/Internal/Symbol.hs
@@ -233,7 +233,7 @@ symbolKywd :: Symbol -> Symbol
 symbolKywd =
     Lens.set
         (typed @Attribute.Symbol . typed @Attribute.SymbolKywd)
-        Attribute.SymbolKywd{isSymbolKywd = True}
+        Attribute.SymbolKywd{getSymbol = Just ""}
 
 {- | Coerce a sort injection symbol's source and target sorts.
 

--- a/kore/test/Test/Kore/Attribute/Symbol.hs
+++ b/kore/test/Test/Kore/Attribute/Symbol.hs
@@ -187,8 +187,8 @@ test_SymbolKywd =
     [ testCase "parseAttribute" $
         assertEqual
             "[symbolKywd{}()]"
-            (Right SymbolKywd{isSymbolKywd = True})
-            (symbolKywd <$> parse [symbolKywdAttribute])
+            (Right SymbolKywd{getSymbol = Just ""})
+            (symbolKywd <$> parse [symbolKywdAttribute ""])
     , testCase "defaultSymbolAttributes" $
         assertEqual
             "[]"

--- a/kore/test/Test/Kore/Attribute/Symbol/SymbolKywd.hs
+++ b/kore/test/Test/Kore/Attribute/Symbol/SymbolKywd.hs
@@ -2,7 +2,8 @@ module Test.Kore.Attribute.Symbol.SymbolKywd (
     test_symbolKywd,
     test_Attributes,
     test_duplicate,
-    test_arguments,
+    test_argument,
+    test_2arguments,
     test_parameters,
 ) where
 
@@ -38,8 +39,8 @@ test_duplicate =
             parseSymbolKywd $
                 Attributes [symbolKywdAttribute "", symbolKywdAttribute ""]
 
-test_arguments :: TestTree
-test_arguments =
+test_argument :: TestTree
+test_argument =
     testCase "[symbolKywd{}(\"legal\")]" $
         expectSuccess legalAttribute $
             parseSymbolKywd $
@@ -47,6 +48,16 @@ test_arguments =
   where
     legalAttribute =
         attributePattern symbolKywdSymbol [attributeString "legal"]
+
+test_2arguments :: TestTree
+test_2arguments =
+    testCase "[symbolKywd{}(\"not\", \"allowed\")]" $
+        expectFailure $
+            parseSymbolKywd $
+                Attributes [legalAttribute]
+  where
+    legalAttribute =
+        attributePattern symbolKywdSymbol [attributeString "not", attributeString "allowed"]
 
 test_parameters :: TestTree
 test_parameters =

--- a/kore/test/Test/Kore/Attribute/Symbol/SymbolKywd.hs
+++ b/kore/test/Test/Kore/Attribute/Symbol/SymbolKywd.hs
@@ -42,7 +42,7 @@ test_duplicate =
 test_argument :: TestTree
 test_argument =
     testCase "[symbolKywd{}(\"legal\")]" $
-        expectSuccess legalAttribute $
+        expectSuccess SymbolKywd{getSymbol = Just "legal"} $
             parseSymbolKywd $
                 Attributes [legalAttribute]
   where
@@ -54,9 +54,9 @@ test_2arguments =
     testCase "[symbolKywd{}(\"not\", \"allowed\")]" $
         expectFailure $
             parseSymbolKywd $
-                Attributes [legalAttribute]
+                Attributes [illegalAttribute]
   where
-    legalAttribute =
+    illegalAttribute =
         attributePattern symbolKywdSymbol [attributeString "not", attributeString "allowed"]
 
 test_parameters :: TestTree

--- a/kore/test/Test/Kore/Attribute/Symbol/SymbolKywd.hs
+++ b/kore/test/Test/Kore/Attribute/Symbol/SymbolKywd.hs
@@ -41,7 +41,7 @@ test_duplicate =
 test_arguments :: TestTree
 test_arguments =
     testCase "[symbolKywd{}(\"legal\")]" $
-        expectFailure $
+        expectSuccess legalAttribute $
             parseSymbolKywd $
                 Attributes [legalAttribute]
   where

--- a/kore/test/Test/Kore/Attribute/Symbol/SymbolKywd.hs
+++ b/kore/test/Test/Kore/Attribute/Symbol/SymbolKywd.hs
@@ -17,18 +17,18 @@ parseSymbolKywd :: Attributes -> Parser SymbolKywd
 parseSymbolKywd = parseAttributes
 
 test_symbolKywd :: TestTree
-test_symbolKywd = 
-  testGroup "symbolKyWd tests" 
-    [
-      testCase "[symbolKywd{}()] :: SymbolKywd" $
-        expectSuccess SymbolKywd{getSymbol = Just ""} $
-            parseSymbolKywd $
-                Attributes [symbolKywdAttribute ""]
-    , _test_Attributes
-    , _test_duplicate
---    , _test_arguments
-    , _test_parameters
-    ]
+test_symbolKywd =
+    testGroup
+        "symbolKyWd tests"
+        [ testCase "[symbolKywd{}()] :: SymbolKywd" $
+            expectSuccess SymbolKywd{getSymbol = Just ""} $
+                parseSymbolKywd $
+                    Attributes [symbolKywdAttribute ""]
+        , _test_Attributes
+        , _test_duplicate
+        , --    , _test_arguments
+          _test_parameters
+        ]
 
 _test_Attributes :: TestTree
 _test_Attributes =

--- a/kore/test/Test/Kore/Attribute/Symbol/SymbolKywd.hs
+++ b/kore/test/Test/Kore/Attribute/Symbol/SymbolKywd.hs
@@ -1,9 +1,9 @@
 module Test.Kore.Attribute.Symbol.SymbolKywd (
     test_symbolKywd,
-    test_Attributes,
-    test_duplicate,
-    test_arguments,
-    test_parameters,
+    -- test_Attributes,
+    -- test_duplicate,
+    -- test_arguments,
+    -- test_parameters,
 ) where
 
 import Kore.Attribute.Symbol.SymbolKywd
@@ -17,39 +17,46 @@ parseSymbolKywd :: Attributes -> Parser SymbolKywd
 parseSymbolKywd = parseAttributes
 
 test_symbolKywd :: TestTree
-test_symbolKywd =
-    testCase "[symbolKywd{}()] :: SymbolKywd" $
-        expectSuccess SymbolKywd{isSymbolKywd = True} $
+test_symbolKywd = 
+  testGroup "symbolKyWd tests" 
+    [
+      testCase "[symbolKywd{}()] :: SymbolKywd" $
+        expectSuccess SymbolKywd{getSymbol = Just ""} $
             parseSymbolKywd $
-                Attributes [symbolKywdAttribute]
+                Attributes [symbolKywdAttribute ""]
+    , _test_Attributes
+    , _test_duplicate
+--    , _test_arguments
+    , _test_parameters
+    ]
 
-test_Attributes :: TestTree
-test_Attributes =
+_test_Attributes :: TestTree
+_test_Attributes =
     testCase "[symbolKywd{}()] :: Attributes" $
         expectSuccess attrs $
             parseAttributes attrs
   where
-    attrs = Attributes [symbolKywdAttribute]
+    attrs = Attributes [symbolKywdAttribute ""]
 
-test_duplicate :: TestTree
-test_duplicate =
+_test_duplicate :: TestTree
+_test_duplicate =
     testCase "[symbolKywd{}(), symbolKywd{}()]" $
         expectFailure $
             parseSymbolKywd $
-                Attributes [symbolKywdAttribute, symbolKywdAttribute]
+                Attributes [symbolKywdAttribute "", symbolKywdAttribute ""]
 
-test_arguments :: TestTree
-test_arguments =
-    testCase "[symbolKywd{}(\"illegal\")]" $
+_test_arguments :: TestTree
+_test_arguments =
+    testCase "[symbolKywd{}(\"legal\")]" $
         expectFailure $
             parseSymbolKywd $
-                Attributes [illegalAttribute]
+                Attributes [legalAttribute]
   where
-    illegalAttribute =
-        attributePattern symbolKywdSymbol [attributeString "illegal"]
+    legalAttribute =
+        attributePattern symbolKywdSymbol [attributeString "legal"]
 
-test_parameters :: TestTree
-test_parameters =
+_test_parameters :: TestTree
+_test_parameters =
     testCase "[symbolKywd{illegal}()]" $
         expectFailure $
             parseSymbolKywd $

--- a/kore/test/Test/Kore/Attribute/Symbol/SymbolKywd.hs
+++ b/kore/test/Test/Kore/Attribute/Symbol/SymbolKywd.hs
@@ -1,9 +1,9 @@
 module Test.Kore.Attribute.Symbol.SymbolKywd (
     test_symbolKywd,
-    -- test_Attributes,
-    -- test_duplicate,
-    -- test_arguments,
-    -- test_parameters,
+    test_Attributes,
+    test_duplicate,
+    test_arguments,
+    test_parameters,
 ) where
 
 import Kore.Attribute.Symbol.SymbolKywd
@@ -18,35 +18,28 @@ parseSymbolKywd = parseAttributes
 
 test_symbolKywd :: TestTree
 test_symbolKywd =
-    testGroup
-        "symbolKyWd tests"
-        [ testCase "[symbolKywd{}()] :: SymbolKywd" $
-            expectSuccess SymbolKywd{getSymbol = Just ""} $
-                parseSymbolKywd $
-                    Attributes [symbolKywdAttribute ""]
-        , _test_Attributes
-        , _test_duplicate
-        , --    , _test_arguments
-          _test_parameters
-        ]
+    testCase "[symbolKywd{}()] :: SymbolKywd" $
+        expectSuccess SymbolKywd{getSymbol = Just ""} $
+            parseSymbolKywd $
+                Attributes [symbolKywdAttribute ""]
 
-_test_Attributes :: TestTree
-_test_Attributes =
+test_Attributes :: TestTree
+test_Attributes =
     testCase "[symbolKywd{}()] :: Attributes" $
         expectSuccess attrs $
             parseAttributes attrs
   where
     attrs = Attributes [symbolKywdAttribute ""]
 
-_test_duplicate :: TestTree
-_test_duplicate =
+test_duplicate :: TestTree
+test_duplicate =
     testCase "[symbolKywd{}(), symbolKywd{}()]" $
         expectFailure $
             parseSymbolKywd $
                 Attributes [symbolKywdAttribute "", symbolKywdAttribute ""]
 
-_test_arguments :: TestTree
-_test_arguments =
+test_arguments :: TestTree
+test_arguments =
     testCase "[symbolKywd{}(\"legal\")]" $
         expectFailure $
             parseSymbolKywd $
@@ -55,8 +48,8 @@ _test_arguments =
     legalAttribute =
         attributePattern symbolKywdSymbol [attributeString "legal"]
 
-_test_parameters :: TestTree
-_test_parameters =
+test_parameters :: TestTree
+test_parameters =
     testCase "[symbolKywd{illegal}()]" $
         expectFailure $
             parseSymbolKywd $

--- a/kore/test/Test/Kore/Internal/Symbol.hs
+++ b/kore/test/Test/Kore/Internal/Symbol.hs
@@ -85,7 +85,7 @@ klabelAttributeGen :: Gen Attribute.Klabel
 klabelAttributeGen = pure Default.def
 
 symbolKywdAttributeGen :: Gen Attribute.SymbolKywd
-symbolKywdAttributeGen = Attribute.SymbolKywd <$> Gen.choice [pure Nothing, pure $ Just "", pure $ Just "aSymbol" ]
+symbolKywdAttributeGen = Attribute.SymbolKywd <$> Gen.choice [pure Nothing, pure $ Just "", pure $ Just "aSymbol"]
 
 noEvaluatorsAttributeGen :: Gen Attribute.NoEvaluators
 noEvaluatorsAttributeGen = Attribute.NoEvaluators <$> Gen.bool

--- a/kore/test/Test/Kore/Internal/Symbol.hs
+++ b/kore/test/Test/Kore/Internal/Symbol.hs
@@ -85,7 +85,7 @@ klabelAttributeGen :: Gen Attribute.Klabel
 klabelAttributeGen = pure Default.def
 
 symbolKywdAttributeGen :: Gen Attribute.SymbolKywd
-symbolKywdAttributeGen = Attribute.SymbolKywd <$> Gen.bool
+symbolKywdAttributeGen = Attribute.SymbolKywd <$> Gen.choice [pure Nothing, pure $ Just "", pure $ Just "aSymbol" ]
 
 noEvaluatorsAttributeGen :: Gen Attribute.NoEvaluators
 noEvaluatorsAttributeGen = Attribute.NoEvaluators <$> Gen.bool


### PR DESCRIPTION
The definition is now allowed to include attributes `symbol(<arg>)` . No functionality is currently using this attribute shape.

Also includes updates to the github actions to avoid warnings about nodejs-16.

Fixes https://github.com/runtimeverification/k/issues/3990