### PR TITLE
Add module fix

### DIFF
--- a/kore/app/rpc/Main.hs
+++ b/kore/app/rpc/Main.hs
@@ -181,6 +181,7 @@ koreRpcServerRun GlobalMain.LocalOptions{execOptions} = do
                 ServerState
                     { serializedModules = Map.singleton mainModuleName sd
                     , loadedDefinition
+                    , receivedModules = mempty
                     }
     GlobalMain.clockSomethingIO "Executing" $
         -- wrap the call to runServer in the logger monad

--- a/kore/src/Kore/JsonRpc.hs
+++ b/kore/src/Kore/JsonRpc.hs
@@ -535,7 +535,6 @@ respond serverState moduleName runSMT =
 
             -- put the original state back if we fail at any point
             flip catchE (\e -> liftIO (MVar.putMVar serverState st) >> throwError e) $ do
-
                 -- check if we already received a module with this name
                 when nameAsId $
                     case Map.lookup (coerce name) receivedModules of

--- a/kore/src/Kore/JsonRpc.hs
+++ b/kore/src/Kore/JsonRpc.hs
@@ -549,6 +549,9 @@ respond serverState moduleName runSMT =
                                 -- we can allow this, since the contents of the named module
                                 -- are the same
                                 pure ()
+                        (Nothing, Just{}) ->
+                            -- an unlikely case where another module's name clashes with the current module's hash
+                            throwError $ backendError DuplicateModuleName name
                         _ -> pure ()
 
                 case (Map.lookup (coerce moduleHash) indexedModules, Map.lookup (coerce moduleHash) serializedModules) of

--- a/kore/src/Kore/JsonRpc.hs
+++ b/kore/src/Kore/JsonRpc.hs
@@ -545,7 +545,7 @@ respond serverState moduleName runSMT =
                 -- Check for a corner case when we send module M1 with the name "m<hash of M2>"" and name-as-id: true
                 -- followed by adding M2. Should not happen in practice...
                 case Map.lookup (coerce moduleHash) receivedModules of
-                    Just m | _module /= m -> throwError $ backendError DuplicateModuleName name
+                    Just m | _module /= m -> throwError $ backendError DuplicateModuleName moduleHash
                     _ -> pure ()
 
                 case (Map.lookup (coerce moduleHash) indexedModules, Map.lookup (coerce moduleHash) serializedModules) of


### PR DESCRIPTION
Fixes a corner case tested for in https://github.com/runtimeverification/pyk/pull/871 where

* we send module `M1` with the name `"m<hash of M2>"` and `"name-as-id": true`
* we send `M2`

In this case, the server should reject `M2`, but currently both requests succeed, with `M1` being overridden by `M2` 