### PR TITLE
Do not run `forever` in request worker threads

### DIFF
--- a/kore-rpc-types/src/Kore/JsonRpc/Server.hs
+++ b/kore-rpc-types/src/Kore/JsonRpc/Server.hs
@@ -18,7 +18,7 @@ import Control.Concurrent (forkIO, throwTo)
 import Control.Concurrent.STM qualified as GHC
 import Control.Concurrent.STM.TChan (newTChan, readTChan, writeTChan)
 import Control.Exception (Exception (fromException), catch, mask, throw)
-import Control.Monad (forM, forM_, forever)
+import Control.Monad (forM, forM_)
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Control.Monad.Logger (MonadLoggerIO)
 import Control.Monad.Logger qualified as Log
@@ -205,7 +205,7 @@ srv respond handlers = do
 
         liftIO $
             forkIO $
-                forever $
+                id $
                     bracketOnReqException
                         (atomically $ readTChan reqQueue)
                         (withLog . processReq)


### PR DESCRIPTION
I've added code that tracks the worked threads spawned in `Kore.JsonRpc.Server.srv`, and polls them on their status when spawning a new one. It turns out, that they never exit, because we will spawn a new worker for every request. 

We end up with logs like when submitting several copies of the same requests one after the other: 
```
.build/kore/bin/kore-rpc test/rpc-server/simplify/and-simplify/definition.kore --module TEST --server-port 12341 --log-level info
...
    Verifying the definition TimeSpec {sec = 0, nsec = 1467} []
mkore-rpc: [173420029] Info (LogJsonRpcServer):
    Spawned worker with thread id ThreadId 27
kore-rpc: [173421622] Info (LogJsonRpcServer):
    Status of worker threads:
kore-rpc: [173422274] Info (LogJsonRpcServer):
      ThreadId 27: ThreadBlocked BlockedOnSTM

kore-rpc: [173423187] Info (LogJsonRpcServer):
    Process request 1 simplify
kore-rpc: [178823488] Info (LogJsonRpcServer):
    Spawned worker with thread id ThreadId 35
kore-rpc: [178824515] Info (LogJsonRpcServer):
    Status of worker threads:
kore-rpc: [178824876] Info (LogJsonRpcServer):
      ThreadId 35: ThreadBlocked BlockedOnSTM
      ThreadId 27: ThreadBlocked BlockedOnSTM

kore-rpc: [178825417] Info (LogJsonRpcServer):
    Process request 1 simplify
kore-rpc: [181816914] Info (LogJsonRpcServer):
    Spawned worker with thread id ThreadId 43
kore-rpc: [181817559] Info (LogJsonRpcServer):
    Status of worker threads:
kore-rpc: [181817869] Info (LogJsonRpcServer):
      ThreadId 43: ThreadBlocked BlockedOnSTM
      ThreadId 35: ThreadBlocked BlockedOnSTM
      ThreadId 27: ThreadBlocked BlockedOnSTM

kore-rpc: [181818666] Info (LogJsonRpcServer):
    Process request 1 simplify
```

and with change we get the threads to stop:

```
.build/kore/bin/kore-rpc test/rpc-server/simplify/and-simplify/definition.kore --module TEST --server-port 12341 --log-level info
kore-rpc: [2199] Info (LogMessage):
    Reading the input file TimeSpec {sec = 0, nsec = 607689} []
kore-rpc: [26521] Info (LogMessage):
    Parsing the file TimeSpec {sec = 0, nsec = 1467} []
kore-rpc: [74874] Info (LogMessage):
    Verifying the definition TimeSpec {sec = 0, nsec = 1397} []
kore-rpc: [137888] Info (LogMessage):
    Executing TimeSpec {sec = 0, nsec = 59132870} []
kore-rpc: [143984] Info (LogMessage):
    Reading the input file TimeSpec {sec = 0, nsec = 531772} []
kore-rpc: [171454] Info (LogMessage):
    Parsing the file TimeSpec {sec = 0, nsec = 1467} []
kore-rpc: [217430] Info (LogMessage):
    Verifying the definition TimeSpec {sec = 0, nsec = 1886} []
kore-rpc: [22047663] Info (LogJsonRpcServer):
    Spawned worker with thread id ThreadId 27
kore-rpc: [22048451] Info (LogJsonRpcServer):
    Status of worker threads:
kore-rpc: [22049142] Info (LogJsonRpcServer):
      ThreadId 27: ThreadBlocked BlockedOnSTM

kore-rpc: [22049871] Info (LogJsonRpcServer):
    Process request 1 simplify
kore-rpc: [24260908] Info (LogJsonRpcServer):
    Spawned worker with thread id ThreadId 36
kore-rpc: [24261398] Info (LogJsonRpcServer):
    Status of worker threads:
kore-rpc: [24261677] Info (LogJsonRpcServer):
      ThreadId 36: ThreadBlocked BlockedOnSTM
      ThreadId 27: ThreadFinished

kore-rpc: [24262226] Info (LogJsonRpcServer):
    Process request 1 simplify
kore-rpc: [25892950] Info (LogJsonRpcServer):
    Spawned worker with thread id ThreadId 45
kore-rpc: [25893404] Info (LogJsonRpcServer):
    Status of worker threads:
kore-rpc: [25893620] Info (LogJsonRpcServer):
      ThreadId 45: ThreadBlocked BlockedOnSTM
      ThreadId 36: ThreadFinished
      ThreadId 27: ThreadFinished

kore-rpc: [25894108] Info (LogJsonRpcServer):
    Process request 1 simplify
```