### PR TITLE
unify ErrorWithTerm and ErrorWithContext

### DIFF
--- a/kore-rpc-types/src/Kore/JsonRpc/Error.hs
+++ b/kore-rpc-types/src/Kore/JsonRpc/Error.hs
@@ -56,11 +56,14 @@ data ErrorWithTermAndContext = ErrorWithTermAndContext
                 '[SumUntaggedValue, OmitNothingFields, FieldLabelModifier '[CamelToKebab]]
                 ErrorWithTermAndContext
 
-pattern ErrorWithTerm :: Text.Text -> Maybe KoreJson -> ErrorWithTermAndContext
-pattern ErrorWithTerm error term = ErrorWithTermAndContext error Nothing term
+pattern ErrorWithTerm :: Text.Text -> KoreJson -> ErrorWithTermAndContext
+pattern ErrorWithTerm error term = ErrorWithTermAndContext error Nothing (Just term)
 
-pattern ErrorWithContext :: Text.Text -> Maybe [Text.Text] -> ErrorWithTermAndContext
-pattern ErrorWithContext error context = ErrorWithTermAndContext error context Nothing
+pattern ErrorWithContext :: Text.Text -> [Text.Text] -> ErrorWithTermAndContext
+pattern ErrorWithContext error context = ErrorWithTermAndContext error (Just context) Nothing
+
+pattern ErrorOnly :: Text.Text -> ErrorWithTermAndContext
+pattern ErrorOnly error = ErrorWithTermAndContext error Nothing Nothing
 
 {- | Do NOT re-order the constructors in this type!
     If new error types are to be added, only append at the end.

--- a/kore-rpc-types/src/Kore/JsonRpc/Error.hs
+++ b/kore-rpc-types/src/Kore/JsonRpc/Error.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 
@@ -43,25 +44,23 @@ unsupportedOption = ErrorObj "Unsupported option" (-32003) . toJSON
 
 -- Runtime backend errors
 
-data ErrorWithContext = ErrorWithContext
+data ErrorWithTermAndContext = ErrorWithTermAndContext
     { error :: Text.Text
     , context :: Maybe [Text.Text]
+    , term :: Maybe KoreJson
     }
     deriving stock (Generic, Show, Eq)
     deriving
         (ToJSON)
         via CustomJSON
                 '[SumUntaggedValue, OmitNothingFields, FieldLabelModifier '[CamelToKebab]]
-                ErrorWithContext
+                ErrorWithTermAndContext
 
-data ErrorWithTerm = ErrorWithTerm
-    { error :: Text.Text
-    , term :: Maybe KoreJson
-    }
-    deriving stock (Generic, Show, Eq)
-    deriving
-        (ToJSON)
-        via CustomJSON '[SumUntaggedValue, OmitNothingFields, FieldLabelModifier '[CamelToKebab]] ErrorWithTerm
+pattern ErrorWithTerm :: Text.Text -> Maybe KoreJson -> ErrorWithTermAndContext
+pattern ErrorWithTerm error term = ErrorWithTermAndContext error Nothing term
+
+pattern ErrorWithContext :: Text.Text -> Maybe [Text.Text] -> ErrorWithTermAndContext
+pattern ErrorWithContext error context = ErrorWithTermAndContext error context Nothing
 
 {- | Do NOT re-order the constructors in this type!
     If new error types are to be added, only append at the end.
@@ -69,14 +68,14 @@ data ErrorWithTerm = ErrorWithTerm
     the error codes in `ErrorObj`.
 -}
 data JsonRpcBackendError
-    = CouldNotParsePattern ErrorWithContext
-    | CouldNotVerifyPattern ErrorWithContext
+    = CouldNotParsePattern ErrorWithTermAndContext
+    | CouldNotVerifyPattern ErrorWithTermAndContext
     | CouldNotFindModule Text.Text
-    | ImplicationCheckError ErrorWithContext
-    | SmtSolverError ErrorWithTerm
+    | ImplicationCheckError ErrorWithTermAndContext
+    | SmtSolverError ErrorWithTermAndContext
     | Aborted Text.Text
     | MultipleStates Text.Text
-    | InvalidModule ErrorWithContext
+    | InvalidModule ErrorWithTermAndContext
     | DuplicateModuleName Text.Text
     deriving stock (Generic, Show, Eq)
     deriving

--- a/kore/src/Kore/JsonRpc.hs
+++ b/kore/src/Kore/JsonRpc.hs
@@ -543,7 +543,7 @@ respond serverState moduleName runSMT =
         AddModule AddModuleRequest{_module, nameAsId = nameAsId'} -> runExceptT $ do
             let nameAsId = fromMaybe False nameAsId'
             parsedModule@Module{moduleName = name} <-
-                withExceptT (\err -> backendError $ InvalidModule $ ErrorOnly $ pack err) $
+                withExceptT (backendError . InvalidModule . ErrorOnly . pack) $
                     liftEither $
                         parseKoreModule "<add-module>" _module
             st@ServerState


### PR DESCRIPTION
We are currently nesting the two types of errors in the booster. it would therefore be better to emit objects which can have both the context and term