### PR TITLE
Ignore fantom cbits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ booster/*.cabal
 /booster/scripts/bug-reports
 /booster/test/rpc-integration/resources/*.dylib
 /booster/test/*/definition/*kompiled/
+
+# the LLVM bindings from ./booster/cbits are symlinked to the root ./cbits to make HLS work
+/cbits


### PR DESCRIPTION
Fixes #3803 

Note that the real fix is:
```
ln -s booster/cbits cbits
```
and this change avoids committing the symlink.