### PR TITLE
Fix json logging redirection predicate

### DIFF
--- a/booster/tools/booster/Server.hs
+++ b/booster/tools/booster/Server.hs
@@ -145,13 +145,15 @@ main = do
             monadLogger <- askLoggerIO
 
             koreLogEntriesAsJsonSelector <-
-                case Map.lookup (Logger.LevelOther "SimplifyJson") logLevelToKoreLogEntryMap of
-                    Nothing -> do
-                        Logger.logWarnNS
-                            "proxy"
-                            "Could not find out which Kore log entries correspond to the SimplifyJson level"
-                        pure (const False)
-                    Just es -> pure (`elem` es)
+                if Logger.LevelOther "SimplifyJson" `elem` customLevels
+                    then case Map.lookup (Logger.LevelOther "SimplifyJson") logLevelToKoreLogEntryMap of
+                        Nothing -> do
+                            Logger.logWarnNS
+                                "proxy"
+                                "Could not find out which Kore log entries correspond to the SimplifyJson level"
+                            pure (const False)
+                        Just koreSimplificationLogEntries -> pure (`elem` koreSimplificationLogEntries)
+                    else pure (const False)
 
             liftIO $ void $ withBugReport (ExeName "kore-rpc-booster") BugReportOnError $ \_reportDirectory -> withMDLib llvmLibraryFile $ \mdl -> do
                 let coLogLevel = fromMaybe Log.Info $ toSeverity logLevel

--- a/dev-tools/kore-rpc-dev/Server.hs
+++ b/dev-tools/kore-rpc-dev/Server.hs
@@ -157,13 +157,15 @@ main = do
         monadLogger <- askLoggerIO
 
         koreLogEntriesAsJsonSelector <-
-            case Map.lookup (Logger.LevelOther "SimplifyJson") logLevelToKoreLogEntryMap of
-                Nothing -> do
-                    Logger.logWarnNS
-                        "proxy"
-                        "Could not find out which Kore log entries correspond to the SimplifyJson level"
-                    pure (const False)
-                Just es -> pure (`elem` es)
+            if Logger.LevelOther "SimplifyJson" `elem` customLevels
+                then case Map.lookup (Logger.LevelOther "SimplifyJson") logLevelToKoreLogEntryMap of
+                    Nothing -> do
+                        Logger.logWarnNS
+                            "proxy"
+                            "Could not find out which Kore log entries correspond to the SimplifyJson level"
+                        pure (const False)
+                    Just koreSimplificationLogEntries -> pure (`elem` koreSimplificationLogEntries)
+                else pure (const False)
 
         let coLogLevel = fromMaybe Log.Info $ toSeverity logLevel
             koreLogOptions =


### PR DESCRIPTION
Previously, the logging filter would always enable JSON logs, even without `-l SimplifyJson`.