### PR TITLE
Allow kore-rpc-booster to read additional options from KORE_RPC_OPTS

### DIFF
--- a/booster/tools/booster/Server.hs
+++ b/booster/tools/booster/Server.hs
@@ -94,7 +94,7 @@ import Proxy qualified
 import SMT qualified as KoreSMT
 import Stats qualified
 
-envName:: String
+envName :: String
 envName = "KORE_RPC_OPTS" -- aligned with legacy kore-rpc
 
 main :: IO ()

--- a/booster/tools/booster/Server.hs
+++ b/booster/tools/booster/Server.hs
@@ -39,8 +39,10 @@ import System.Clock (
     Clock (..),
     getTime,
  )
+import System.Environment qualified as Env
 import System.Exit
 import System.FilePath.Glob qualified as Glob
+import System.IO (hPutStrLn, stderr)
 import System.Log.FastLogger (newTimeCache)
 
 import Booster.CLOptions
@@ -92,10 +94,19 @@ import Proxy qualified
 import SMT qualified as KoreSMT
 import Stats qualified
 
+envName:: String
+envName = "KORE_RPC_OPTS" -- aligned with legacy kore-rpc
+
 main :: IO ()
 main = do
     startTime <- getTime Monotonic
-    options <- execParser clParser
+    options <- do
+        Env.lookupEnv envName >>= \case
+            Nothing -> execParser clParser
+            Just envArgs -> do
+                hPutStrLn stderr $ "Reading additional server options from " <> envName
+                args <- Env.getArgs
+                Env.withArgs (words envArgs <> args) $ execParser clParser
     let CLProxyOptions
             { clOptions =
                 clOPts@CLOptions


### PR DESCRIPTION
* like `kore-rpc` , `kore-rpc-booster` should read additional options from an environment variable.
* This PR chooses the same variable name as for `kore-rpc` for consistency and to avoid it getting too long.

Use case: testing optional optimisation in performance tests without having to modify the pytest framework or the `KoreServer` in `pyk`  