### PR TITLE
Retrigger run when pushing formatting changes via CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
           submodules: recursive
+          token: ${{ secrets.JENKINS_GITHUB_PAT }}
 
       - name: 'Install Nix'
         uses: cachix/install-nix-action@v25

--- a/booster/library/Booster/Pattern/Base.hs
+++ b/booster/library/Booster/Pattern/Base.hs
@@ -606,7 +606,7 @@ pattern KMap def keyVals rest <- Term _ (KMapF def keyVals rest)
                                 , hash . getAttributes <$> newRest
                                 )
                         }
-                    $ KMapF def newKeyVals newRest
+                    $      KMapF def newKeyVals newRest
 
 pattern KList :: KListDefinition -> [Term] -> Maybe (Term, [Term]) -> Term
 pattern KList def heads rest <- Term _ (KListF def heads rest)

--- a/booster/library/Booster/Pattern/Base.hs
+++ b/booster/library/Booster/Pattern/Base.hs
@@ -606,7 +606,7 @@ pattern KMap def keyVals rest <- Term _ (KMapF def keyVals rest)
                                 , hash . getAttributes <$> newRest
                                 )
                         }
-                    $      KMapF def newKeyVals newRest
+                    $ KMapF def newKeyVals newRest
 
 pattern KList :: KListDefinition -> [Term] -> Maybe (Term, [Term]) -> Term
 pattern KList def heads rest <- Term _ (KListF def heads rest)


### PR DESCRIPTION
We do not currently re-trigger the CI run if formatting is pushed within the CI run.