### PR TITLE
Updates to `scripts/performance-test-kontrol.sh`

### DIFF
--- a/scripts/performance-tests-kontrol.sh
+++ b/scripts/performance-tests-kontrol.sh
@@ -125,7 +125,7 @@ PYTEST_TEMP_DIR=$TEMPD/pytest-temp-dir
 mkdir -p $PYTEST_TEMP_DIR
 FOUNDRY_DIR=$TEMPD/foundry
 mkdir -p $FOUNDRY_DIR
-feature_shell "make test-integration TEST_ARGS='--basetemp=$PYTEST_TEMP_DIR -n0 --dist=no -k test_foundry_kompile'"
+feature_shell "make test-integration TEST_ARGS='--basetemp=$PYTEST_TEMP_DIR --foundry-root $FOUNDRY_DIR -n0 --dist=no -k test_foundry_kompile'"
 cp -r $PYTEST_TEMP_DIR/foundry/* $FOUNDRY_DIR
 
 mkdir -p $SCRIPT_DIR/logs
@@ -138,14 +138,14 @@ fi
 # set test arguments and select which tests to run
 TEST_ARGS='--foundry-root $FOUNDRY_DIR --maxfail=0 --numprocesses=$PYTEST_PARALLEL -vv $BUG_REPORT -k "not (test_kontrol_cse or test_foundry_minimize_proof or test_kontrol_end_to_end)"'
 
-feature_shell "make test-integration TEST_ARGS=$TEST_ARGS | tee $SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-$FEATURE_BRANCH_NAME.log"
+feature_shell "make test-integration TEST_ARGS=\"$TEST_ARGS\" | tee $SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-$FEATURE_BRANCH_NAME.log"
 killall kore-rpc-booster || echo "no zombie processes found"
 
 if [ -z "$BUG_REPORT" ]; then
 if [ ! -e "$SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT_SHORT.log" ]; then
   # remove proofs so that they are not reused by the master shell call
   rm -rf $FOUNDRY_DIR/out/proofs
-  master_shell "make test-integration TEST_ARGS=$TEST_ARGS | tee $SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT_SHORT.log"
+  master_shell "make test-integration TEST_ARGS=\"$TEST_ARGS\" | tee $SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT_SHORT.log"
   killall kore-rpc-booster || echo "no zombie processes found"
 fi
 

--- a/scripts/performance-tests-kontrol.sh
+++ b/scripts/performance-tests-kontrol.sh
@@ -136,16 +136,17 @@ if [[ $FRESH_TEMPD -eq 0 ]]; then
 fi
 
 # set test arguments and select which tests to run
-TEST_ARGS='--foundry-root $FOUNDRY_DIR --maxfail=0 --numprocesses=$PYTEST_PARALLEL -vv $BUG_REPORT -k "not (test_kontrol_cse or test_foundry_minimize_proof or test_kontrol_end_to_end)"'
+QUOTE='"'
+TEST_ARGS="--foundry-root $FOUNDRY_DIR --maxfail=0 --numprocesses=$PYTEST_PARALLEL -vv $BUG_REPORT -k 'not (test_kontrol_cse or test_foundry_minimize_proof or test_kontrol_end_to_end)'"
 
-feature_shell "make test-integration TEST_ARGS=\"$TEST_ARGS\" | tee $SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-$FEATURE_BRANCH_NAME.log"
+feature_shell "make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE | tee $SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-$FEATURE_BRANCH_NAME.log"
 killall kore-rpc-booster || echo "no zombie processes found"
 
 if [ -z "$BUG_REPORT" ]; then
 if [ ! -e "$SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT_SHORT.log" ]; then
   # remove proofs so that they are not reused by the master shell call
   rm -rf $FOUNDRY_DIR/out/proofs
-  master_shell "make test-integration TEST_ARGS=\"$TEST_ARGS\" | tee $SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT_SHORT.log"
+  master_shell "make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE | tee $SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT_SHORT.log"
   killall kore-rpc-booster || echo "no zombie processes found"
 fi
 

--- a/scripts/performance-tests-kontrol.sh
+++ b/scripts/performance-tests-kontrol.sh
@@ -134,14 +134,18 @@ if [[ $FRESH_TEMPD -eq 0 ]]; then
     # remove leftover proofs from previous runs
     rm -rf $FOUNDRY_DIR/out/proofs
 fi
-feature_shell "make test-integration TEST_ARGS='--foundry-root $FOUNDRY_DIR --maxfail=0 --numprocesses=$PYTEST_PARALLEL -vv $BUG_REPORT' | tee $SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-$FEATURE_BRANCH_NAME.log"
+
+# set test arguments and select which tests to run
+TEST_ARGS='--foundry-root $FOUNDRY_DIR --maxfail=0 --numprocesses=$PYTEST_PARALLEL -vv $BUG_REPORT -k "not (test_kontrol_cse or test_foundry_minimize_proof or test_kontrol_end_to_end)"'
+
+feature_shell "make test-integration TEST_ARGS=$TEST_ARGS | tee $SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-$FEATURE_BRANCH_NAME.log"
 killall kore-rpc-booster || echo "no zombie processes found"
 
 if [ -z "$BUG_REPORT" ]; then
 if [ ! -e "$SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT_SHORT.log" ]; then
   # remove proofs so that they are not reused by the master shell call
   rm -rf $FOUNDRY_DIR/out/proofs
-  master_shell "make test-integration TEST_ARGS='--foundry-root $FOUNDRY_DIR --maxfail=0 --numprocesses=$PYTEST_PARALLEL -vv' | tee $SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT_SHORT.log"
+  master_shell "make test-integration TEST_ARGS=$TEST_ARGS | tee $SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT_SHORT.log"
   killall kore-rpc-booster || echo "no zombie processes found"
 fi
 


### PR DESCRIPTION
- allow using and existing artifact directory for faster re-runs
- select test that are run in the integration tests [job](https://github.com/runtimeverification/kontrol/blob/921dfe8ddd0774265d59122d0ace19ac5889007a/.github/workflows/test-pr.yml#L119) on Kontrol CI