### PR TITLE
Fix some small problems

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -6,11 +6,10 @@ packages:
 
 package *
   ghc-options: -fhide-source-paths -haddock
-  profiling-detail: none
 
 package kore
   ghc-options: -Wall -Werror
-  profiling-detail: toplevel-functions
+  profiling-detail: exported-functions
 
 source-repository-package
   type: git


### PR DESCRIPTION
* `--interim-simplification` problem: When `maxDepth < forceFallback` , the proxy was considering a genuine `DepthBound` result as an artefact caused by the interim simplification, and would try to continue execution.
* The `cabal.project` file was set up to never profile any `booster` or `kore-rpc-types` code
* When given a path to a non-existing file as input, `RpcClient` reported a server connection error and retried (the criterion for recognising connection errors was to general).