### PR TITLE
3874 use several cells to index

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,6 @@ jobs:
             cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}
             cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('cabal.project') }}
             cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}
-            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}
 
       - name: Test
         run: GC_DONT_GC=1 nix develop .#cabal --command bash -c "hpack ./booster && hpack dev-tools && cabal update && cabal build all && cabal test --enable-tests --test-show-details=direct kore-test unit-tests"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,12 +83,13 @@ jobs:
           path: |
             ~/.cabal/packages
             ~/.cabal/store
-          key: cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('kore/kore.cabal') }}-${{ hashFiles('kore-rpc-types/kore-rpc-types.cabal') }}-${{ hashFiles('booster/hs-backend-booster.cabal') }}
+          key: cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('kore/kore.cabal') }}-${{ hashFiles('kore-rpc-types/kore-rpc-types.cabal') }}-${{ hashFiles('booster/hs-backend-booster.cabal') }}
           restore-keys: |
-            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('kore/kore.cabal') }}-${{ hashFiles('kore-rpc-types/kore-rpc-types.cabal') }}
-            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('kore/kore.cabal') }}
-            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}
-            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('cabal.project') }}
+            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('kore/kore.cabal') }}-${{ hashFiles('kore-rpc-types/kore-rpc-types.cabal') }}
+            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('kore/kore.cabal') }}
+            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}
+            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('cabal.project') }}
+            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}
             cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}
 
       - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,6 @@ jobs:
             cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}
             cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('cabal.project') }}
             cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}
-            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}
 
       - name: Test
         run: GC_DONT_GC=1 nix develop .#cabal --command bash -c "hpack ./booster && hpack dev-tools && cabal update && cabal build all && cabal test --enable-tests --test-show-details=direct kore-test unit-tests"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,12 +124,13 @@ jobs:
           path: |
             ~/.cabal/packages
             ~/.cabal/store
-          key: cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('kore/kore.cabal') }}-${{ hashFiles('kore-rpc-types/kore-rpc-types.cabal') }}-${{ hashFiles('booster/hs-backend-booster.cabal') }}
+          key: cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('kore/kore.cabal') }}-${{ hashFiles('kore-rpc-types/kore-rpc-types.cabal') }}-${{ hashFiles('booster/hs-backend-booster.cabal') }}
           restore-keys: |
-            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('kore/kore.cabal') }}-${{ hashFiles('kore-rpc-types/kore-rpc-types.cabal') }}
-            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('kore/kore.cabal') }}
-            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}
-            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('cabal.project') }}
+            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('kore/kore.cabal') }}-${{ hashFiles('kore-rpc-types/kore-rpc-types.cabal') }}
+            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('kore/kore.cabal') }}
+            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}
+            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('cabal.project') }}
+            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}
             cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}
 
       - name: Test
@@ -194,12 +195,13 @@ jobs:
           path: |
             ~/.cabal/packages
             ~/.cabal/store
-          key: cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('kore/kore.cabal') }}-${{ hashFiles('kore-rpc-types/kore-rpc-types.cabal') }}-${{ hashFiles('booster/hs-backend-booster.cabal') }}
+          key: cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('kore/kore.cabal') }}-${{ hashFiles('kore-rpc-types/kore-rpc-types.cabal') }}-${{ hashFiles('booster/hs-backend-booster.cabal') }}
           restore-keys: |
-            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('kore/kore.cabal') }}-${{ hashFiles('kore-rpc-types/kore-rpc-types.cabal') }}
-            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('kore/kore.cabal') }}
-            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}
-            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('cabal.project') }}
+            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('kore/kore.cabal') }}-${{ hashFiles('kore-rpc-types/kore-rpc-types.cabal') }}
+            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('kore/kore.cabal') }}
+            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('cabal.project') }}-${{ hashFiles('cabal.project.freeze') }}
+            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('cabal.project') }}
+            cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('flake.lock') }}
             cabal-nix-${{ runner.os }}-ghc-${{ env.ghc_version }}
 
       - name: Run booster integration tests

--- a/booster/library/Booster/CLOptions.hs
+++ b/booster/library/Booster/CLOptions.hs
@@ -11,14 +11,16 @@ module Booster.CLOptions (
     versionInfoParser,
 ) where
 
-import Booster.Trace (CustomUserEventType)
-import Booster.Util (Bound (..))
-import Booster.VersionInfo (VersionInfo (..), versionInfo)
 import Control.Monad.Logger (LogLevel (..))
 import Data.ByteString.Char8 qualified as BS (pack)
+import Data.Char (isAscii, isPrint)
 import Data.List (intercalate, partition)
+import Data.List.Extra (splitOn, trim)
+import Data.Map (Map)
+import Data.Map qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text, pack)
+import Data.Text.Encoding (decodeASCII)
 import Options.Applicative
 import Text.Casing (fromHumps, fromKebab, toKebab, toPascal)
 import Text.Read (readMaybe)
@@ -27,8 +29,9 @@ import Booster.GlobalState (EquationOptions (..))
 import Booster.Log.Context (ContextFilter, ctxt, readContextFilter)
 import Booster.SMT.Interface (SMTOptions (..), defaultSMTOptions)
 import Booster.SMT.LowLevelCodec qualified as SMT (parseSExpr)
-import Data.Map (Map)
-import Data.Map qualified as Map
+import Booster.Trace (CustomUserEventType)
+import Booster.Util (Bound (..), encodeLabel)
+import Booster.VersionInfo (VersionInfo (..), versionInfo)
 
 data CLOptions = CLOptions
     { definitionFile :: FilePath
@@ -42,6 +45,7 @@ data CLOptions = CLOptions
     , logFile :: Maybe FilePath
     , smtOptions :: Maybe SMTOptions
     , equationOptions :: EquationOptions
+    , indexCells :: [Text]
     , -- developer options below
       eventlogEnabledUserEvents :: [CustomUserEventType]
     }
@@ -128,6 +132,13 @@ clOptionsParser =
             )
         <*> parseSMTOptions
         <*> parseEquationOptions
+        <*> option
+            (eitherReader $ mapM (readCellName . trim) . splitOn ",")
+            ( metavar "CELL-NAME[,CELL-NAME]"
+                <> long "index-cells"
+                <> help "Names of configuration cells to index rewrite rules with (default: 'k')"
+                <> value []
+            )
         -- developer options below
         <*> many
             ( option
@@ -166,6 +177,18 @@ clOptionsParser =
         "standard" -> Right Standard
         "json" -> Right Json
         other -> Left $ other <> ": Unsupported log format"
+
+    readCellName :: String -> Either String Text
+    readCellName input
+        | null input =
+            Left "Empty cell name"
+        | all isAscii input
+        , all isPrint input =
+            Right $ "Lbl'-LT-'" <> enquote input <> "'-GT-'"
+        | otherwise =
+            Left $ "Illegal non-ascii characters in `" <> input <> "'"
+
+    enquote = decodeASCII . encodeLabel . BS.pack
 
 -- custom log levels that can be selected
 allowedLogLevels :: [(String, String)]

--- a/booster/library/Booster/Definition/Attributes/Base.hs
+++ b/booster/library/Booster/Definition/Attributes/Base.hs
@@ -66,13 +66,14 @@ import Booster.Util (Flag (..))
 import Booster.Util qualified as Util
 
 newtype DefinitionAttributes = DefinitionAttributes
-    { indexCells :: Maybe [ByteString] -- which cells to index for rewriting
+    { indexCells :: [ByteString]
+    -- ^which cells to index for rewriting. Empty => default
     }
     deriving stock (Eq, Show, Generic)
     deriving anyclass (NFData)
 
 defaultDefAttributes :: DefinitionAttributes
-defaultDefAttributes = DefinitionAttributes Nothing
+defaultDefAttributes = DefinitionAttributes []
 
 data ModuleAttributes = ModuleAttributes
     {

--- a/booster/library/Booster/Definition/Attributes/Base.hs
+++ b/booster/library/Booster/Definition/Attributes/Base.hs
@@ -12,6 +12,7 @@ Attributes stored together with different entities in a
 -}
 module Booster.Definition.Attributes.Base (
     DefinitionAttributes (..),
+    defaultDefAttributes,
     ModuleAttributes (..),
     AxiomAttributes (..),
     Concreteness (..),
@@ -64,13 +65,14 @@ import Booster.SMT.Base (SExpr)
 import Booster.Util (Flag (..))
 import Booster.Util qualified as Util
 
-data DefinitionAttributes = DefinitionAttributes
-    {
+newtype DefinitionAttributes = DefinitionAttributes
+    { indexCells :: Maybe [ByteString] -- which cells to index for rewriting
     }
-    -- none needed
-
     deriving stock (Eq, Show, Generic)
     deriving anyclass (NFData)
+
+defaultDefAttributes :: DefinitionAttributes
+defaultDefAttributes = DefinitionAttributes Nothing
 
 data ModuleAttributes = ModuleAttributes
     {

--- a/booster/library/Booster/Definition/Attributes/Base.hs
+++ b/booster/library/Booster/Definition/Attributes/Base.hs
@@ -67,7 +67,7 @@ import Booster.Util qualified as Util
 
 newtype DefinitionAttributes = DefinitionAttributes
     { indexCells :: [ByteString]
-    -- ^which cells to index for rewriting. Empty => default
+    -- ^ which cells to index for rewriting. Empty => default
     }
     deriving stock (Eq, Show, Generic)
     deriving anyclass (NFData)

--- a/booster/library/Booster/Definition/Attributes/Reader.hs
+++ b/booster/library/Booster/Definition/Attributes/Reader.hs
@@ -47,14 +47,9 @@ class HasAttributes ty where
 instance HasAttributes ParsedDefinition where
     type Attributes ParsedDefinition = DefinitionAttributes
 
-    mkAttributes ParsedDefinition{attributes} = do
-        mbCells :: Maybe [Text] <- attributes .:? "indexCells"
-        let indexCells =
-                case mbCells of
-                    Nothing -> Nothing
-                    Just [] -> Nothing
-                    Just cs -> Just $ map Text.encodeUtf8 cs
-        pure DefinitionAttributes{indexCells}
+    mkAttributes ParsedDefinition{attributes} =
+        DefinitionAttributes
+            <$> (map encodeUtf8 . fromMaybe [] <$> attributes .:? "indexCells")
 
 instance HasAttributes ParsedModule where
     type Attributes ParsedModule = ModuleAttributes

--- a/booster/library/Booster/Definition/Attributes/Reader.hs
+++ b/booster/library/Booster/Definition/Attributes/Reader.hs
@@ -49,7 +49,7 @@ instance HasAttributes ParsedDefinition where
 
     mkAttributes ParsedDefinition{attributes} =
         DefinitionAttributes
-            <$> (map encodeUtf8 . fromMaybe [] <$> attributes .:? "indexCells")
+            <$> (maybe [] (map encodeUtf8) <$> attributes .:? "indexCells")
 
 instance HasAttributes ParsedModule where
     type Attributes ParsedModule = ModuleAttributes

--- a/booster/library/Booster/Definition/Attributes/Reader.hs
+++ b/booster/library/Booster/Definition/Attributes/Reader.hs
@@ -322,7 +322,7 @@ instance ReadT Text where
 
 -- read lists by reading each part as a singleton list
 instance ReadT a => ReadT [a] where
-    readT = mapM readT . (: [])
+    readT = mapM (readT . (: []))
 
 instance ReadT Position where
     readT [] = Left "empty position"

--- a/booster/library/Booster/Definition/Base.hs
+++ b/booster/library/Booster/Definition/Base.hs
@@ -55,9 +55,7 @@ data KoreDefinition = KoreDefinition
 -- | Axiom store, optimized for lookup by term-index and priority
 type Theory axiomType = Map TermIndex (Map Priority [axiomType])
 
-{- | The starting point for building up the definition. Could be
- 'Monoid' instance if the attributes had a Default.
--}
+-- | The starting point for building up the definition.
 emptyKoreDefinition :: DefinitionAttributes -> KoreDefinition
 emptyKoreDefinition attributes =
     KoreDefinition

--- a/booster/library/Booster/Definition/Util.hs
+++ b/booster/library/Booster/Definition/Util.hs
@@ -30,7 +30,7 @@ import Booster.Definition.Attributes.Base
 import Booster.Definition.Base
 import Booster.Definition.Ceil (ComputeCeilSummary (..))
 import Booster.Pattern.Base
-import Booster.Pattern.Index (TermIndex (..), CellIndex (..))
+import Booster.Pattern.Index (CellIndex (..), TermIndex (..))
 import Booster.Prettyprinter
 import Booster.Util
 

--- a/booster/library/Booster/Definition/Util.hs
+++ b/booster/library/Booster/Definition/Util.hs
@@ -30,7 +30,7 @@ import Booster.Definition.Attributes.Base
 import Booster.Definition.Base
 import Booster.Definition.Ceil (ComputeCeilSummary (..))
 import Booster.Pattern.Base
-import Booster.Pattern.Index (TermIndex (..))
+import Booster.Pattern.Index (TermIndex (..), CellIndex (..))
 import Booster.Prettyprinter
 import Booster.Util
 
@@ -138,9 +138,12 @@ instance Pretty Summary where
 
         prettyLabel = either error (pretty . BS.unpack) . decodeLabel
 
-        prettyTermIndex Anything = "Anything"
-        prettyTermIndex (TopSymbol sym) = prettyLabel sym
-        prettyTermIndex None = "None"
+        prettyTermIndex :: TermIndex -> Doc a
+        prettyTermIndex (TermIndex ixs) = Pretty.sep $ map prettyCellIndex ixs
+
+        prettyCellIndex Anything = "Anything"
+        prettyCellIndex (TopSymbol sym) = prettyLabel sym
+        prettyCellIndex None = "None"
 
         prettyCeilRule :: RewriteRule r -> Doc a
         prettyCeilRule RewriteRule{lhs, rhs} = "#Ceil(" <+> pretty lhs <+> ") =>" <+> pretty rhs

--- a/booster/library/Booster/Pattern/Index.hs
+++ b/booster/library/Booster/Pattern/Index.hs
@@ -42,7 +42,6 @@ NB for technical reasons we derive 'Ord' instances but it does not
 reflect the fact that different symbols (and likewise different
 constructors) are incompatible (partial ordering).
 -}
-
 newtype TermIndex = TermIndex [CellIndex]
     deriving stock (Eq, Ord, Show, Generic)
     deriving anyclass (NFData)
@@ -85,18 +84,19 @@ coveringIndexes (TermIndex ixs) =
   where
     orAnything :: [CellIndex] -> [[CellIndex]]
     orAnything [] = [[]]
-    orAnything (i:is) =
+    orAnything (i : is) =
         let rest = orAnything is
          in map (i :) rest <> map (Anything :) rest
 
--- | Check whether a @TermIndex@ has @None@ in any position (this
--- means no match will be possible).
+{- | Check whether a @TermIndex@ has @None@ in any position (this
+means no match will be possible).
+-}
 hasNone :: TermIndex -> Bool
 hasNone (TermIndex ixs) = any (== None) ixs
 
 -- | Indexes a term by the heads of K sequences in given cells.
 compositeTermIndex :: [SymbolName] -> Term -> TermIndex
-compositeTermIndex cells t = TermIndex [kCellIndexFor c t | c <- cells ]
+compositeTermIndex cells t = TermIndex [kCellIndexFor c t | c <- cells]
 
 -- | Indexes a term by the head of its <k>-cell.
 kCellTermIndex :: Term -> TermIndex
@@ -160,7 +160,7 @@ stripSortInjections = \case
 
 -- | indexes terms by their top symbol (combining '\and' branches)
 termTopIndex :: Term -> TermIndex
-termTopIndex = TermIndex . (:[]) . cellTopIndex
+termTopIndex = TermIndex . (: []) . cellTopIndex
 
 cellTopIndex :: Term -> CellIndex
 cellTopIndex = \case

--- a/booster/library/Booster/Pattern/Index.hs
+++ b/booster/library/Booster/Pattern/Index.hs
@@ -68,20 +68,18 @@ instance Semigroup TermIndex where
   Only constructors are used, function symbols get index 'Anything'.
 -}
 kCellTermIndex :: Term -> TermIndex
-kCellTermIndex config = termIndexForCell "k" config
+kCellTermIndex config = termIndexForCell "Lbl'-LT-'k'-GT-'" config
 
 {- | Indexes a term by the head of a K sequence inside a given cell
-   (supplied name with prefix "Lbl'-LT-'" and suffix "'-GT-'").
+   (supplied name should have prefix "Lbl'-LT-'" and suffix "'-GT-'").
 -}
 termIndexForCell :: SymbolName -> Term -> TermIndex
 termIndexForCell name config = fromMaybe Anything $ do
-    inCell <- getCell cellSymbol config
+    inCell <- getCell name config
     cellArg1 <- firstArgument inCell
     seqHead <- getKSeqHead cellArg1
     pure $ termTopIndex seqHead
   where
-    cellSymbol = "Lbl'-LT-'" <> name <> "'-GT-'"
-
     firstArgument :: Term -> Maybe Term
     firstArgument = \case
         SymbolApplication _ _ (x : _) -> Just x

--- a/booster/library/Booster/Pattern/Index.hs
+++ b/booster/library/Booster/Pattern/Index.hs
@@ -92,7 +92,7 @@ coveringIndexes (TermIndex ixs) =
 means no match will be possible).
 -}
 hasNone :: TermIndex -> Bool
-hasNone (TermIndex ixs) = any (== None) ixs
+hasNone (TermIndex ixs) = None `elem` ixs
 
 -- | Indexes a term by the heads of K sequences in given cells.
 compositeTermIndex :: [SymbolName] -> Term -> TermIndex

--- a/booster/library/Booster/Pattern/Index.hs
+++ b/booster/library/Booster/Pattern/Index.hs
@@ -84,7 +84,7 @@ coveringIndexes (TermIndex ixs) =
     Set.fromList . map TermIndex $ orAnything ixs
   where
     orAnything :: [CellIndex] -> [[CellIndex]]
-    orAnything [] = []
+    orAnything [] = [[]]
     orAnything (i:is) =
         let rest = orAnything is
          in map (i :) rest <> map (Anything :) rest

--- a/booster/library/Booster/Pattern/Rewrite.hs
+++ b/booster/library/Booster/Pattern/Rewrite.hs
@@ -63,7 +63,7 @@ import Booster.Pattern.ApplyEquations (
  )
 import Booster.Pattern.Base
 import Booster.Pattern.Bool
-import Booster.Pattern.Index (TermIndex (..), kCellTermIndex)
+import Booster.Pattern.Index (TermIndex (..), kCellTermIndex, termIndexForCell)
 import Booster.Pattern.Match (
     FailReason (ArgLengthsDiffer, SubsortingError),
     MatchResult (MatchFailed, MatchIndeterminate, MatchSuccess),
@@ -139,9 +139,13 @@ rewriteStep ::
     Pattern ->
     RewriteT io (RewriteResult Pattern)
 rewriteStep cutLabels terminalLabels pat = do
-    let termIdx = kCellTermIndex pat.term
-    when (termIdx == None) $ throw (TermIndexIsNone pat.term)
     def <- getDefinition
+    let getIndex =
+            case def.attributes.indexCells of
+                Just (c : _) -> termIndexForCell c -- FIXME supports only one cell at the moment
+                _otherwise -> kCellTermIndex
+        termIdx = getIndex pat.term
+    when (termIdx == None) $ throw (TermIndexIsNone pat.term)
     let idxRules = fromMaybe Map.empty $ Map.lookup termIdx def.rewriteTheory
         anyRules = fromMaybe Map.empty $ Map.lookup Anything def.rewriteTheory
         rules =

--- a/booster/library/Booster/Pattern/Rewrite.hs
+++ b/booster/library/Booster/Pattern/Rewrite.hs
@@ -140,7 +140,10 @@ rewriteStep ::
     RewriteT io (RewriteResult Pattern)
 rewriteStep cutLabels terminalLabels pat = do
     def <- getDefinition
-    let getIndex = maybe Idx.kCellTermIndex Idx.compositeTermIndex def.attributes.indexCells
+    let getIndex =
+            if null def.attributes.indexCells
+                then Idx.kCellTermIndex
+                else Idx.compositeTermIndex def.attributes.indexCells
         termIdx = getIndex pat.term
     when (Idx.hasNone termIdx) $ throw (TermIndexIsNone pat.term)
     let

--- a/booster/library/Booster/Syntax/Json/Internalise.hs
+++ b/booster/library/Booster/Syntax/Json/Internalise.hs
@@ -780,7 +780,7 @@ trm =
                         DisallowAlias
                         IgnoreSubsorts
                         Nothing
-                        (emptyKoreDefinition DefinitionAttributes{})
+                        (emptyKoreDefinition $ DefinitionAttributes Nothing)
                     . either error id
                     . parsePattern "INLINE"
                     . pack

--- a/booster/library/Booster/Syntax/Json/Internalise.hs
+++ b/booster/library/Booster/Syntax/Json/Internalise.hs
@@ -780,7 +780,7 @@ trm =
                         DisallowAlias
                         IgnoreSubsorts
                         Nothing
-                        (emptyKoreDefinition $ DefinitionAttributes Nothing)
+                        (emptyKoreDefinition defaultDefAttributes)
                     . either error id
                     . parsePattern "INLINE"
                     . pack

--- a/booster/library/Booster/Syntax/ParsedKore.hs
+++ b/booster/library/Booster/Syntax/ParsedKore.hs
@@ -106,9 +106,17 @@ internalisation). The map of module names to definitions is returned
 so the main module can be changed.
 -}
 loadDefinition ::
-    FilePath -> IO (Either DefinitionError (Map Text KoreDefinition))
-loadDefinition file = runExceptT $ do
+    [Text] -> FilePath -> IO (Either DefinitionError (Map Text KoreDefinition))
+loadDefinition indexCells file = runExceptT $ do
     parsedDef <-
         liftIO (Text.readFile file)
             >>= except . first (ParseError . Text.pack) . parseKoreDefinition file
-    except $ runExcept $ Internalise.buildDefinitions parsedDef
+    let parsedDef'
+            | null indexCells =
+                parsedDef
+            | otherwise =
+                ParsedDefinition
+                    { modules = parsedDef.modules
+                    , attributes = [(Id "indexCells", indexCells)]
+                    }
+    except $ runExcept $ Internalise.buildDefinitions parsedDef'

--- a/booster/library/Booster/Syntax/ParsedKore/Internalise.hs
+++ b/booster/library/Booster/Syntax/ParsedKore/Internalise.hs
@@ -107,7 +107,7 @@ addToDefinitions m prior = do
     priorDefAttributes :: DefinitionAttributes
     priorDefAttributes
         | (d : _) <- Map.elems prior = d.attributes
-        | otherwise = DefinitionAttributes Nothing -- should not happen
+        | otherwise = defaultDefAttributes -- should not happen
 
 lookupModule :: Text -> Map Text a -> Except DefinitionError a
 lookupModule k =
@@ -351,7 +351,9 @@ addModule
                 newSimplifications = mapMaybe retractSimplificationRule newAxioms
                 newCeils = mapMaybe retractCeilRule newAxioms
             let rewriteIndex =
-                    maybe Idx.kCellTermIndex Idx.compositeTermIndex defAttributes.indexCells
+                    if null defAttributes.indexCells
+                        then Idx.kCellTermIndex
+                        else Idx.compositeTermIndex defAttributes.indexCells
                 rewriteTheory =
                     addToTheoryWith (rewriteIndex . (.lhs)) newRewriteRules currentRewriteTheory
                 functionEquations =

--- a/booster/library/Booster/Syntax/ParsedKore/Internalise.hs
+++ b/booster/library/Booster/Syntax/ParsedKore/Internalise.hs
@@ -351,9 +351,7 @@ addModule
                 newSimplifications = mapMaybe retractSimplificationRule newAxioms
                 newCeils = mapMaybe retractCeilRule newAxioms
             let rewriteIndex =
-                    case defAttributes.indexCells of
-                        Just (c : _) -> Idx.termIndexForCell c -- FIXME supports only a single cell at the moment
-                        _otherwise -> Idx.kCellTermIndex
+                    maybe Idx.kCellTermIndex Idx.compositeTermIndex defAttributes.indexCells
                 rewriteTheory =
                     addToTheoryWith (rewriteIndex . (.lhs)) newRewriteRules currentRewriteTheory
                 functionEquations =

--- a/booster/library/Booster/Util.hs
+++ b/booster/library/Booster/Util.hs
@@ -5,6 +5,7 @@
 module Booster.Util (
     decodeLabel,
     decodeLabel',
+    encodeLabel,
     Flag (..),
     Bound (..),
     constructorName,
@@ -21,6 +22,7 @@ import Data.Data
 import Data.Either (fromRight)
 import Data.Hashable (Hashable)
 import Data.Map qualified as Map
+import Data.Maybe (fromMaybe)
 import GHC.Generics (Generic)
 import Language.Haskell.TH.Syntax (Lift)
 import System.Directory (removeFile)
@@ -113,6 +115,12 @@ decodeMap =
 decodeLabel' :: ByteString -> ByteString
 decodeLabel' orig =
     fromRight orig (decodeLabel orig)
+
+encodeLabel :: ByteString -> ByteString
+encodeLabel = BS.concatMap encodeChar
+  where
+    encodeMap = Map.fromList [(BS.head c, code) | (code, c) <- Map.assocs decodeMap]
+    encodeChar c = fromMaybe (BS.singleton c) $ Map.lookup c encodeMap
 
 -------------------------------------------------------------------
 -- logging helpers, some are adapted from monad-logger-aeson

--- a/booster/test/internalisation/mx-hs-kasmer-definition0.kore.report
+++ b/booster/test/internalisation/mx-hs-kasmer-definition0.kore.report
@@ -1,0 +1,5987 @@
+Modules: 5
+  - BASIC-K
+  - INJ
+  - K
+  - KASMER
+  - KSEQ
+Sorts: 480
+  - Sort#Layout
+  - SortAccountCell
+  - SortAccountCellFragment
+  - SortAccountCellMap
+  - SortAccounts
+  - SortAccountsCell
+  - SortAccountsCellFragment
+  - SortAccountsCellOpt
+  - SortAddress
+  - SortAddressCell
+  - SortAddressCellOpt
+  - SortAddressNonce
+  - SortAlignArg
+  - SortAlloc
+  - SortAllocatedKind
+  - SortAsyncCall
+  - SortAsyncCallStatus
+  - SortAsyncCallsCell
+  - SortAsyncCallsCellOpt
+  - SortBYTES
+  - SortBalanceCell
+  - SortBalanceCellOpt
+  - SortBigIntHeapCell
+  - SortBigIntHeapCellOpt
+  - SortBlockInfo
+  - SortBlockInstr
+  - SortBlockMetaData
+  - SortBool
+  - SortBufferHeapCell
+  - SortBufferHeapCellOpt
+  - SortBuiltinFunction
+  - SortBytes
+  - SortBytesOp
+  - SortBytesResult
+  - SortBytesStack
+  - SortBytesStackCell
+  - SortBytesStackCellOpt
+  - SortCallArgsCell
+  - SortCallArgsCellOpt
+  - SortCallStackCell
+  - SortCallStackCellOpt
+  - SortCallStateCell
+  - SortCallStateCellFragment
+  - SortCallStateCellOpt
+  - SortCallType
+  - SortCallTypeCell
+  - SortCallTypeCellOpt
+  - SortCallValueCell
+  - SortCallValueCellOpt
+  - SortCalleeCell
+  - SortCalleeCellOpt
+  - SortCallerCell
+  - SortCallerCellOpt
+  - SortCheckedAccountsCell
+  - SortCheckedAccountsCellOpt
+  - SortCode
+  - SortCodeCell
+  - SortCodeCellOpt
+  - SortCommandsCell
+  - SortCommandsCellOpt
+  - SortContext
+  - SortContractModIdxCell
+  - SortContractModIdxCellOpt
+  - SortCurBlockEpochCell
+  - SortCurBlockEpochCellOpt
+  - SortCurBlockNonceCell
+  - SortCurBlockNonceCellOpt
+  - SortCurBlockRandomSeedCell
+  - SortCurBlockRandomSeedCellOpt
+  - SortCurBlockRoundCell
+  - SortCurBlockRoundCellOpt
+  - SortCurBlockTimestampCell
+  - SortCurBlockTimestampCellOpt
+  - SortCurFrameCell
+  - SortCurFrameCellFragment
+  - SortCurFrameCellOpt
+  - SortCurModIdxCell
+  - SortCurModIdxCellOpt
+  - SortCurrentBlockInfoCell
+  - SortCurrentBlockInfoCellFragment
+  - SortCurrentBlockInfoCellOpt
+  - SortCvtOp
+  - SortCvtf32Op
+  - SortCvtf64Op
+  - SortCvti32Op
+  - SortCvti64Op
+  - SortDataDefn
+  - SortDataString
+  - SortDefn
+  - SortDefns
+  - SortDeterministicMemoryGrowthCell
+  - SortDeterministicMemoryGrowthCellOpt
+  - SortEAddrCell
+  - SortEAddrCellOpt
+  - SortESDTLocalRole
+  - SortESDTMetadata
+  - SortESDTTransfer
+  - SortETypeCell
+  - SortETypeCellOpt
+  - SortEValueCell
+  - SortEValueCellOpt
+  - SortElemAddrsCell
+  - SortElemAddrsCellOpt
+  - SortElemDefn
+  - SortElemExpr
+  - SortElemExprs
+  - SortElemIdsCell
+  - SortElemIdsCellOpt
+  - SortElemInstCell
+  - SortElemInstCellFragment
+  - SortElemInstCellMap
+  - SortElemList
+  - SortElemMode
+  - SortElemSegment
+  - SortElemsCell
+  - SortElemsCellFragment
+  - SortElemsCellOpt
+  - SortElrondCell
+  - SortElrondCellFragment
+  - SortElrondCellOpt
+  - SortEmptyStmt
+  - SortEmptyStmts
+  - SortEndianness
+  - SortError
+  - SortEsdtBalanceCell
+  - SortEsdtBalanceCellOpt
+  - SortEsdtDataCell
+  - SortEsdtDataCellFragment
+  - SortEsdtDataCellMap
+  - SortEsdtDatasCell
+  - SortEsdtDatasCellFragment
+  - SortEsdtDatasCellOpt
+  - SortEsdtIdCell
+  - SortEsdtIdCellOpt
+  - SortEsdtLastNonceCell
+  - SortEsdtLastNonceCellOpt
+  - SortEsdtMetadataCell
+  - SortEsdtMetadataCellOpt
+  - SortEsdtPropertiesCell
+  - SortEsdtPropertiesCellOpt
+  - SortEsdtRolesCell
+  - SortEsdtRolesCellOpt
+  - SortEsdtTransfersCell
+  - SortEsdtTransfersCellOpt
+  - SortExceptionCode
+  - SortExitCodeCell
+  - SortExitCodeCellOpt
+  - SortExportDefn
+  - SortExportsCell
+  - SortExportsCellOpt
+  - SortExtendS
+  - SortExternval
+  - SortFAddrCell
+  - SortFAddrCellOpt
+  - SortFBinOp
+  - SortFCodeCell
+  - SortFCodeCellOpt
+  - SortFLocalCell
+  - SortFLocalCellOpt
+  - SortFModInstCell
+  - SortFModInstCellOpt
+  - SortFRelOp
+  - SortFTypeCell
+  - SortFTypeCellOpt
+  - SortFUnOp
+  - SortFVal
+  - SortFValType
+  - SortFloat
+  - SortFoldedInstr
+  - SortFoundryCell
+  - SortFoundryCellFragment
+  - SortFoundryCellOpt
+  - SortFrame
+  - SortFuncAddrsCell
+  - SortFuncAddrsCellOpt
+  - SortFuncDefCell
+  - SortFuncDefCellFragment
+  - SortFuncDefCellMap
+  - SortFuncDefn
+  - SortFuncIdCell
+  - SortFuncIdCellOpt
+  - SortFuncIdsCell
+  - SortFuncIdsCellOpt
+  - SortFuncMetadata
+  - SortFuncMetadataCell
+  - SortFuncMetadataCellFragment
+  - SortFuncMetadataCellOpt
+  - SortFuncSpec
+  - SortFuncType
+  - SortFuncsCell
+  - SortFuncsCellFragment
+  - SortFuncsCellOpt
+  - SortFunctionCell
+  - SortFunctionCellOpt
+  - SortG1Point
+  - SortG2Point
+  - SortGAddrCell
+  - SortGAddrCellOpt
+  - SortGMutCell
+  - SortGMutCellOpt
+  - SortGValueCell
+  - SortGValueCellOpt
+  - SortGasPriceCell
+  - SortGasPriceCellOpt
+  - SortGasProvidedCell
+  - SortGasProvidedCellOpt
+  - SortGeneratedCounterCell
+  - SortGeneratedCounterCellOpt
+  - SortGeneratedTopCell
+  - SortGeneratedTopCellFragment
+  - SortGlobIdsCell
+  - SortGlobIdsCellOpt
+  - SortGlobalAddrsCell
+  - SortGlobalAddrsCellOpt
+  - SortGlobalDefn
+  - SortGlobalInstCell
+  - SortGlobalInstCellFragment
+  - SortGlobalInstCellMap
+  - SortGlobalSpec
+  - SortGlobalType
+  - SortGlobalsCell
+  - SortGlobalsCellFragment
+  - SortGlobalsCellOpt
+  - SortHashBytesStackInstr
+  - SortHeapType
+  - SortIBinOp
+  - SortIOError
+  - SortIOFile
+  - SortIOInt
+  - SortIOString
+  - SortIRelOp
+  - SortIUnOp
+  - SortIVal
+  - SortIValType
+  - SortId
+  - SortIdentifier
+  - SortIdentifierToken
+  - SortImportDefn
+  - SortImportDesc
+  - SortIndex
+  - SortInlineExport
+  - SortInlineImport
+  - SortInstr
+  - SortInstrs
+  - SortInstrsCell
+  - SortInstrsCellOpt
+  - SortInt
+  - SortIntResult
+  - SortInterimStatesCell
+  - SortInterimStatesCellOpt
+  - SortInternalCmd
+  - SortInternalInstr
+  - SortInts
+  - SortIternalInstr
+  - SortK
+  - SortKCell
+  - SortKCellOpt
+  - SortKConfigVar
+  - SortKItem
+  - SortLabel
+  - SortLimits
+  - SortList
+  - SortListAsyncCall
+  - SortListBytes
+  - SortListBytesResult
+  - SortListInt
+  - SortListRef
+  - SortListResult
+  - SortLoadOp
+  - SortLoadOpM
+  - SortLocalDecl
+  - SortLocalDecls
+  - SortLocalIdsCell
+  - SortLocalIdsCellOpt
+  - SortLocalsCell
+  - SortLocalsCellOpt
+  - SortLogEntry
+  - SortLoggingCell
+  - SortLoggingCellOpt
+  - SortLogsCell
+  - SortLogsCellOpt
+  - SortMAddrCell
+  - SortMAddrCellOpt
+  - SortMainStoreCell
+  - SortMainStoreCellFragment
+  - SortMainStoreCellOpt
+  - SortMandosCell
+  - SortMandosCellFragment
+  - SortMandosCellOpt
+  - SortMap
+  - SortMapBytesToBytes
+  - SortMapIntToBytes
+  - SortMapIntToInt
+  - SortMdataCell
+  - SortMdataCellOpt
+  - SortMemAddrsCell
+  - SortMemAddrsCellOpt
+  - SortMemArg
+  - SortMemIdsCell
+  - SortMemIdsCellOpt
+  - SortMemInstCell
+  - SortMemInstCellFragment
+  - SortMemInstCellMap
+  - SortMemType
+  - SortMemoryDefn
+  - SortMemorySpec
+  - SortMemsCell
+  - SortMemsCellFragment
+  - SortMemsCellOpt
+  - SortMmaxCell
+  - SortMmaxCellOpt
+  - SortModIdxCell
+  - SortModIdxCellOpt
+  - SortModuleDecl
+  - SortModuleFileNameCell
+  - SortModuleFileNameCellOpt
+  - SortModuleIdCell
+  - SortModuleIdCellOpt
+  - SortModuleIdsCell
+  - SortModuleIdsCellOpt
+  - SortModuleInstCell
+  - SortModuleInstCellFragment
+  - SortModuleInstCellMap
+  - SortModuleInstancesCell
+  - SortModuleInstancesCellFragment
+  - SortModuleInstancesCellOpt
+  - SortModuleMetadata
+  - SortModuleMetadataCell
+  - SortModuleMetadataCellFragment
+  - SortModuleMetadataCellOpt
+  - SortModuleRegistryCell
+  - SortModuleRegistryCellOpt
+  - SortMsizeCell
+  - SortMsizeCellOpt
+  - SortMut
+  - SortNewAddressesCell
+  - SortNewAddressesCellOpt
+  - SortNextElemAddrCell
+  - SortNextElemAddrCellOpt
+  - SortNextElemIdxCell
+  - SortNextElemIdxCellOpt
+  - SortNextFuncAddrCell
+  - SortNextFuncAddrCellOpt
+  - SortNextFuncIdxCell
+  - SortNextFuncIdxCellOpt
+  - SortNextGlobAddrCell
+  - SortNextGlobAddrCellOpt
+  - SortNextGlobIdxCell
+  - SortNextGlobIdxCellOpt
+  - SortNextMemAddrCell
+  - SortNextMemAddrCellOpt
+  - SortNextModuleIdxCell
+  - SortNextModuleIdxCellOpt
+  - SortNextTabAddrCell
+  - SortNextTabAddrCellOpt
+  - SortNextTabIdxCell
+  - SortNextTabIdxCellOpt
+  - SortNextTypeIdxCell
+  - SortNextTypeIdxCellOpt
+  - SortNodeCell
+  - SortNodeCellFragment
+  - SortNodeCellOpt
+  - SortNonceCell
+  - SortNonceCellOpt
+  - SortNumber
+  - SortOffset
+  - SortOffsetArg
+  - SortOptionalId
+  - SortOptionalInt
+  - SortOptionalString
+  - SortOutCell
+  - SortOutCellOpt
+  - SortOutputAccount
+  - SortOutputAccountsCell
+  - SortOutputAccountsCellOpt
+  - SortOutputTransfer
+  - SortOwnerAddressCell
+  - SortOwnerAddressCellOpt
+  - SortPlainInstr
+  - SortPrankCell
+  - SortPrankCellOpt
+  - SortPrevBlockEpochCell
+  - SortPrevBlockEpochCellOpt
+  - SortPrevBlockNonceCell
+  - SortPrevBlockNonceCellOpt
+  - SortPrevBlockRandomSeedCell
+  - SortPrevBlockRandomSeedCellOpt
+  - SortPrevBlockRoundCell
+  - SortPrevBlockRoundCellOpt
+  - SortPrevBlockTimestampCell
+  - SortPrevBlockTimestampCellOpt
+  - SortPreviousBlockInfoCell
+  - SortPreviousBlockInfoCellFragment
+  - SortPreviousBlockInfoCellOpt
+  - SortRefVal
+  - SortRefValType
+  - SortReturnCode
+  - SortSBItem
+  - SortSBItemChunk
+  - SortSet
+  - SortSignedness
+  - SortSparseBytes
+  - SortStartDefn
+  - SortStep
+  - SortSteps
+  - SortStmt
+  - SortStmts
+  - SortStorageCell
+  - SortStorageCellOpt
+  - SortStoreOp
+  - SortStoreOpM
+  - SortStream
+  - SortString
+  - SortTAddrCell
+  - SortTAddrCellOpt
+  - SortTabAddrsCell
+  - SortTabAddrsCellOpt
+  - SortTabIdsCell
+  - SortTabIdsCellOpt
+  - SortTabInstCell
+  - SortTabInstCellFragment
+  - SortTabInstCellMap
+  - SortTableDefn
+  - SortTableElemType
+  - SortTableSpec
+  - SortTableType
+  - SortTableUse
+  - SortTabsCell
+  - SortTabsCellFragment
+  - SortTabsCellOpt
+  - SortTdataCell
+  - SortTdataCellOpt
+  - SortTestOp
+  - SortTextFormatGlobalType
+  - SortTextLimits
+  - SortThrowException
+  - SortTmaxCell
+  - SortTmaxCellOpt
+  - SortTransferTx
+  - SortTransferValue
+  - SortTxCountCell
+  - SortTxCountCellOpt
+  - SortTxHashCell
+  - SortTxHashCellOpt
+  - SortType
+  - SortTypeDecl
+  - SortTypeDecls
+  - SortTypeDefn
+  - SortTypeIdsCell
+  - SortTypeIdsCellOpt
+  - SortTypeKeyWord
+  - SortTypeUse
+  - SortTypesCell
+  - SortTypesCellOpt
+  - SortTypesInfo
+  - SortVMOutput
+  - SortVal
+  - SortValStack
+  - SortValType
+  - SortValTypes
+  - SortValidatorRewardTx
+  - SortValstackCell
+  - SortValstackCellOpt
+  - SortVecType
+  - SortVmInputCell
+  - SortVmInputCellFragment
+  - SortVmInputCellOpt
+  - SortVmOutputCell
+  - SortVmOutputCellOpt
+  - SortWasmCell
+  - SortWasmCellFragment
+  - SortWasmCellOpt
+  - SortWasmInt
+  - SortWasmIntToken
+  - SortWasmStoreCell
+  - SortWasmStoreCellOpt
+  - SortWasmString
+  - SortWasmStringToken
+  - SortWrappedBytes
+  - SortWrappedInt
+Symbols: 2925
+  - Lbl<account>
+  - Lbl<account>-fragment
+  - Lbl<accounts>
+  - Lbl<accounts>-fragment
+  - Lbl<address>
+  - Lbl<asyncCalls>
+  - Lbl<balance>
+  - Lbl<bigIntHeap>
+  - Lbl<bufferHeap>
+  - Lbl<bytesStack>
+  - Lbl<callArgs>
+  - Lbl<callStack>
+  - Lbl<callState>
+  - Lbl<callState>-fragment
+  - Lbl<callType>
+  - Lbl<callValue>
+  - Lbl<callee>
+  - Lbl<caller>
+  - Lbl<checkedAccounts>
+  - Lbl<code>
+  - Lbl<commands>
+  - Lbl<contractModIdx>
+  - Lbl<curBlockEpoch>
+  - Lbl<curBlockNonce>
+  - Lbl<curBlockRandomSeed>
+  - Lbl<curBlockRound>
+  - Lbl<curBlockTimestamp>
+  - Lbl<curFrame>
+  - Lbl<curFrame>-fragment
+  - Lbl<curModIdx>
+  - Lbl<currentBlockInfo>
+  - Lbl<currentBlockInfo>-fragment
+  - Lbl<deterministicMemoryGrowth>
+  - Lbl<eAddr>
+  - Lbl<eType>
+  - Lbl<eValue>
+  - Lbl<elemAddrs>
+  - Lbl<elemIds>
+  - Lbl<elemInst>
+  - Lbl<elemInst>-fragment
+  - Lbl<elems>
+  - Lbl<elems>-fragment
+  - Lbl<elrond>
+  - Lbl<elrond>-fragment
+  - Lbl<esdtBalance>
+  - Lbl<esdtData>
+  - Lbl<esdtData>-fragment
+  - Lbl<esdtDatas>
+  - Lbl<esdtDatas>-fragment
+  - Lbl<esdtId>
+  - Lbl<esdtLastNonce>
+  - Lbl<esdtMetadata>
+  - Lbl<esdtProperties>
+  - Lbl<esdtRoles>
+  - Lbl<esdtTransfers>
+  - Lbl<exit-code>
+  - Lbl<exports>
+  - Lbl<fAddr>
+  - Lbl<fCode>
+  - Lbl<fLocal>
+  - Lbl<fModInst>
+  - Lbl<fType>
+  - Lbl<foundry>
+  - Lbl<foundry>-fragment
+  - Lbl<funcAddrs>
+  - Lbl<funcDef>
+  - Lbl<funcDef>-fragment
+  - Lbl<funcId>
+  - Lbl<funcIds>
+  - Lbl<funcMetadata>
+  - Lbl<funcMetadata>-fragment
+  - Lbl<funcs>
+  - Lbl<funcs>-fragment
+  - Lbl<function>
+  - Lbl<gAddr>
+  - Lbl<gMut>
+  - Lbl<gValue>
+  - Lbl<gasPrice>
+  - Lbl<gasProvided>
+  - Lbl<generatedCounter>
+  - Lbl<generatedTop>
+  - Lbl<generatedTop>-fragment
+  - Lbl<globIds>
+  - Lbl<globalAddrs>
+  - Lbl<globalInst>
+  - Lbl<globalInst>-fragment
+  - Lbl<globals>
+  - Lbl<globals>-fragment
+  - Lbl<instrs>
+  - Lbl<interimStates>
+  - Lbl<k>
+  - Lbl<localIds>
+  - Lbl<locals>
+  - Lbl<logging>
+  - Lbl<logs>
+  - Lbl<mAddr>
+  - Lbl<mainStore>
+  - Lbl<mainStore>-fragment
+  - Lbl<mandos>
+  - Lbl<mandos>-fragment
+  - Lbl<mdata>
+  - Lbl<memAddrs>
+  - Lbl<memIds>
+  - Lbl<memInst>
+  - Lbl<memInst>-fragment
+  - Lbl<mems>
+  - Lbl<mems>-fragment
+  - Lbl<mmax>
+  - Lbl<modIdx>
+  - Lbl<moduleFileName>
+  - Lbl<moduleId>
+  - Lbl<moduleIds>
+  - Lbl<moduleInst>
+  - Lbl<moduleInst>-fragment
+  - Lbl<moduleInstances>
+  - Lbl<moduleInstances>-fragment
+  - Lbl<moduleMetadata>
+  - Lbl<moduleMetadata>-fragment
+  - Lbl<moduleRegistry>
+  - Lbl<msize>
+  - Lbl<newAddresses>
+  - Lbl<nextElemAddr>
+  - Lbl<nextElemIdx>
+  - Lbl<nextFuncAddr>
+  - Lbl<nextFuncIdx>
+  - Lbl<nextGlobAddr>
+  - Lbl<nextGlobIdx>
+  - Lbl<nextMemAddr>
+  - Lbl<nextModuleIdx>
+  - Lbl<nextTabAddr>
+  - Lbl<nextTabIdx>
+  - Lbl<nextTypeIdx>
+  - Lbl<node>
+  - Lbl<node>-fragment
+  - Lbl<nonce>
+  - Lbl<out>
+  - Lbl<outputAccounts>
+  - Lbl<ownerAddress>
+  - Lbl<prank>
+  - Lbl<prevBlockEpoch>
+  - Lbl<prevBlockNonce>
+  - Lbl<prevBlockRandomSeed>
+  - Lbl<prevBlockRound>
+  - Lbl<prevBlockTimestamp>
+  - Lbl<previousBlockInfo>
+  - Lbl<previousBlockInfo>-fragment
+  - Lbl<storage>
+  - Lbl<tAddr>
+  - Lbl<tabAddrs>
+  - Lbl<tabIds>
+  - Lbl<tabInst>
+  - Lbl<tabInst>-fragment
+  - Lbl<tabs>
+  - Lbl<tabs>-fragment
+  - Lbl<tdata>
+  - Lbl<tmax>
+  - Lbl<txCount>
+  - Lbl<txHash>
+  - Lbl<typeIds>
+  - Lbl<types>
+  - Lbl<valstack>
+  - Lbl<vmInput>
+  - Lbl<vmInput>-fragment
+  - Lbl<vmOutput>
+  - Lbl<wasm>
+  - Lbl<wasm>-fragment
+  - Lbl<wasmStore>
+  - Lbl#ContextLookup(_,_)_WASM-DATA-COMMON_Int_Map_Index
+  - Lbl#DS2Bytes(_)_WASM-DATA-COMMON_Bytes_DataString
+  - Lbl#E2BIG
+  - Lbl#EACCES
+  - Lbl#EADDRINUSE
+  - Lbl#EADDRNOTAVAIL
+  - Lbl#EAFNOSUPPORT
+  - Lbl#EAGAIN
+  - Lbl#EALREADY
+  - Lbl#EBADF
+  - Lbl#EBUSY
+  - Lbl#ECHILD
+  - Lbl#ECONNABORTED
+  - Lbl#ECONNREFUSED
+  - Lbl#ECONNRESET
+  - Lbl#EDEADLK
+  - Lbl#EDESTADDRREQ
+  - Lbl#EDOM
+  - Lbl#EEXIST
+  - Lbl#EFAULT
+  - Lbl#EFBIG
+  - Lbl#EHOSTDOWN
+  - Lbl#EHOSTUNREACH
+  - Lbl#EINPROGRESS
+  - Lbl#EINTR
+  - Lbl#EINVAL
+  - Lbl#EIO
+  - Lbl#EISCONN
+  - Lbl#EISDIR
+  - Lbl#ELOOP
+  - Lbl#EMFILE
+  - Lbl#EMLINK
+  - Lbl#EMSGSIZE
+  - Lbl#ENAMETOOLONG
+  - Lbl#ENETDOWN
+  - Lbl#ENETRESET
+  - Lbl#ENETUNREACH
+  - Lbl#ENFILE
+  - Lbl#ENOBUFS
+  - Lbl#ENODEV
+  - Lbl#ENOENT
+  - Lbl#ENOEXEC
+  - Lbl#ENOLCK
+  - Lbl#ENOMEM
+  - Lbl#ENOPROTOOPT
+  - Lbl#ENOSPC
+  - Lbl#ENOSYS
+  - Lbl#ENOTCONN
+  - Lbl#ENOTDIR
+  - Lbl#ENOTEMPTY
+  - Lbl#ENOTSOCK
+  - Lbl#ENOTTY
+  - Lbl#ENXIO
+  - Lbl#EOF
+  - Lbl#EOPNOTSUPP
+  - Lbl#EOVERFLOW
+  - Lbl#EPERM
+  - Lbl#EPFNOSUPPORT
+  - Lbl#EPIPE
+  - Lbl#EPROTONOSUPPORT
+  - Lbl#EPROTOTYPE
+  - Lbl#ERANGE
+  - Lbl#EROFS
+  - Lbl#ESDTLocalBurn
+  - Lbl#ESDTLocalMint
+  - Lbl#ESDTNFTAddQuantity
+  - Lbl#ESDTNFTAddURI
+  - Lbl#ESDTNFTBurn
+  - Lbl#ESDTNFTCreate
+  - Lbl#ESDTNFTTransfer
+  - Lbl#ESDTTransfer
+  - Lbl#ESHUTDOWN
+  - Lbl#ESOCKTNOSUPPORT
+  - Lbl#ESPIPE
+  - Lbl#ESRCH
+  - Lbl#ETIMEDOUT
+  - Lbl#ETOOMANYREFS
+  - Lbl#EWOULDBLOCK
+  - Lbl#EXDEV
+  - Lbl#MultiESDTNFTTransfer
+  - Lbl#StorageAdded()_ELROND-CONFIG_Int
+  - Lbl#StorageDeleted()_ELROND-CONFIG_Int
+  - Lbl#StorageModified()_ELROND-CONFIG_Int
+  - Lbl#StorageUnmodified()_ELROND-CONFIG_Int
+  - Lbl#accept(_)_K-IO_IOInt_Int
+  - Lbl#address2Bytes(_)_ELROND-NODE_Bytes_Address
+  - Lbl#alignHexString(_)_ELROND-CONFIG_String_String
+  - Lbl#allReadable(_,_)_EEI-HELPERS_Bool_Bytes_Int
+  - Lbl#allValidRandom(_,_)_EEI-HELPERS_Bool_Bytes_Int
+  - Lbl#appendBytes_ELROND-NODE_BytesOp
+  - Lbl#appendBytesToBuffer(_)_MANBUFOPS_InternalInstr_Int
+  - Lbl#appendInstrs(_,_)_WASM-TEXT_Instrs_Instrs_Instrs
+  - Lbl#appendToOut(_)_ELROND-NODE_InternalInstr_Bytes
+  - Lbl#appendToOutFromBytesStack_ELROND-NODE_InternalInstr
+  - Lbl#autoAllocModules(_,_)_WASM-AUTO-ALLOCATE_Stmts_Defns_Map
+  - Lbl#bigIntGetESDTExternalBalance(_)_BIGINTOPS_InternalInstr_Int
+  - Lbl#bigIntSign(_)_ELROND-CONFIG_Int_Int
+  - Lbl#buffer(_)_K-IO_Stream_K
+  - Lbl#bytesEqual_ELROND-NODE_InternalInstr
+  - Lbl#callIndirect(_,_)_WASM_Instr_RefVal_FuncType
+  - Lbl#canGrow(_,_,_)_WASM_Bool_Int_Int_OptionalInt
+  - Lbl#canSaveId(_,_)_WASM-DATA-COMMON_Bool_Map_OptionalId
+  - Lbl#checkESDTRole(_)_KASMER_InternalInstr_ESDTLocalRole
+  - Lbl#chop(_)_WASM-DATA-COMMON_IVal_IVal
+  - Lbl#close(_)_K-IO_K_Int
+  - Lbl#concatDS(_,_)_WASM-DATA-COMMON_String_DataString_String
+  - Lbl#concatDS(_)_WASM-DATA-COMMON_String_DataString
+  - Lbl#createAsyncCallWithTypedArgs(_,_,_,_,_,_,_)_BASEOPS_InternalInstr_BytesResult_IntResult_BytesResult_ListBytesResult_Int_Int_BytesResult
+  - Lbl#ctz(_)_WASM-NUMERIC_Int_Int
+  - Lbl#drop(_,_)_WASM-DATA-COMMON_ValStack_Int_ValStack
+  - Lbl#dropBytes_ELROND-NODE_BytesOp
+  - Lbl#elemAux(_,_)_WASM_ElemDefn_Int_ElemMode
+  - Lbl#elemCheckSizeGTE(_,_)_WASM_Instr_Int_Int
+  - Lbl#emptyModule(_)_WASM_ModuleDecl_OptionalId
+  - Lbl#encodeUTF8(_)_WASM-DATA-COMMON_Bytes_Int
+  - Lbl#endWasm
+  - Lbl#esdtSCAddress_ESDT_Bytes
+  - Lbl#exception(_,_)_ELROND-NODE_InternalCmd_ExceptionCode_Bytes
+  - Lbl#executeOnDestContext(_,_,_,_,_,_)_BASEOPS_InternalInstr_Bytes_Int_List_Int_Bytes_ListBytes
+  - Lbl#executeOnDestContextWithTypedArgs(_,_,_,_,_,_)_BASEOPS_InternalInstr_BytesResult_IntResult_ListResult_Int_BytesResult_ListBytesResult
+  - Lbl#foundryRunner_KASMER_Bytes
+  - Lbl#freshCtx()_WASM-TEXT_Context
+  - Lbl#freshId(_)_WASM-DATA-COMMON_Identifier_Int
+  - Lbl#gatherTypes(_,_,_)_WASM_VecType_TypeKeyWord_TypeDecls_ValTypes
+  - Lbl#get(_)_WASM-DATA-COMMON_Int_IVal
+  - Lbl#getArgsFromMemory(_,_,_)_ELROND-CONFIG_InternalInstr_Int_Int_Int
+  - Lbl#getArgsFromMemoryAux(_,_,_,_,_)_ELROND-CONFIG_InternalInstr_Int_Int_Int_Int_Int
+  - Lbl#getBigInt(_,_)_BIGINT-HELPERS_InternalInstr_Int_Signedness
+  - Lbl#getBigIntOrCreate(_,_)_BIGINT-HELPERS_InternalInstr_Int_Signedness
+  - Lbl#getBuffer(_)_MANBUFOPS_InternalInstr_Int
+  - Lbl#getBytesRange(_,_,_)_WASM-DATA-COMMON_Bytes_SparseBytes_Int_Int
+  - Lbl#getESDTTokenData_MANAGEDEI_InternalInstr
+  - Lbl#getElemSegment(_,_)_WASM-DATA-COMMON_Index_ElemSegment_Int
+  - Lbl#getExternalBalance_BASEOPS_InternalInstr
+  - Lbl#getInts(_,_)_WASM-DATA-COMMON_Int_Ints_Int
+  - Lbl#getModuleCodePath(_)_MANDOS_OptionalString_ModuleDecl
+  - Lbl#getOffset(_)_WASM-TEXT_Int_MemArg
+  - Lbl#getRandomChars(_)_EEI-HELPERS_Bytes_Bytes
+  - Lbl#getRange(_,_,_)_WASM-DATA-COMMON_Int_SparseBytes_Int_Int
+  - Lbl#getTicker(_)_EEI-HELPERS_Bytes_Bytes
+  - Lbl#getc(_)_K-IO_IOInt_Int
+  - Lbl#growthAllowed(_,_)_WASM_Bool_Int_OptionalInt
+  - Lbl#hasPrefix(_,_)_ELROND-CONFIG_Bool_String_String
+  - Lbl#hashManBuffer(_,_,_)_CRYPTOEI-HELPERS_InternalInstr_Int_Int_HashBytesStackInstr
+  - Lbl#hashMemory(_,_,_,_)_CRYPTOEI-HELPERS_InternalInstr_Int_Int_Int_HashBytesStackInstr
+  - Lbl#idMaxLen_EEI-HELPERS_Int
+  - Lbl#idMinLen_EEI-HELPERS_Int
+  - Lbl#idcElems(_)_WASM-TEXT_Map_Defns
+  - Lbl#idcElemsAux(_,_,_)_WASM-TEXT_Map_Defns_Int_Map
+  - Lbl#idcFuncs(_,_)_WASM-TEXT_Map_Defns_Defns
+  - Lbl#idcFuncsAux(_,_,_,_)_WASM-TEXT_Map_Defns_Defns_Int_Map
+  - Lbl#idcGlobals(_,_)_WASM-TEXT_Map_Defns_Defns
+  - Lbl#idcGlobalsAux(_,_,_,_)_WASM-TEXT_Map_Defns_Defns_Int_Map
+  - Lbl#idcMems(_,_)_WASM-TEXT_Map_Defns_Defns
+  - Lbl#idcMemsAux(_,_,_,_)_WASM-TEXT_Map_Defns_Defns_Int_Map
+  - Lbl#idcTables(_,_)_WASM-TEXT_Map_Defns_Defns
+  - Lbl#idcTablesAux(_,_,_,_)_WASM-TEXT_Map_Defns_Defns_Int_Map
+  - Lbl#idcTypes(_)_WASM-TEXT_Map_Defns
+  - Lbl#idcTypesAux(_,_,_)_WASM-TEXT_Map_Defns_Int_Map
+  - Lbl#ids2Idxs(_,_,_)_WASM-TEXT_Map_Int_TypeUse_LocalDecls
+  - Lbl#ids2Idxs(_,_)_WASM-TEXT_Map_TypeUse_LocalDecls
+  - Lbl#idxCloseBracket(_,_)_WASM-DATA-COMMON_Int_String_Int
+  - Lbl#incBytes(_,_)_MANDOS_Bytes_Bytes_Int
+  - Lbl#init_locals___WASM-INTERNAL-SYNTAX_Instr_Int_ValStack
+  - Lbl#isInfinityOrNaN(_)_WASM-NUMERIC_Bool_Float
+  - Lbl#isReservedKey(_)_ELROND-CONFIG_InternalInstr_String
+  - Lbl#isSmartContract(_)_ELROND-CONFIG_Bool_Bytes
+  - Lbl#isTickerValid(_)_EEI-HELPERS_Bool_Bytes
+  - Lbl#istream(_)_K-IO_Stream_Int
+  - Lbl#keccakFromBytesStack_CRYPTOEI-HELPERS_HashBytesStackInstr
+  - Lbl#lambda__
+  - Lbl#lambda__2
+  - Lbl#lenElemExprs(_)_WASM-TEXT_Int_ElemExprs
+  - Lbl#lenElemSegment(_)_WASM-DATA-COMMON_Int_ElemSegment
+  - Lbl#lenInts(_)_WASM-DATA-COMMON_Int_Ints
+  - Lbl#lengthDataPages(_)_WASM-TEXT_Int_DataString
+  - Lbl#limitsMatchImport(_,_,_)_WASM_Bool_Int_OptionalInt_Limits
+  - Lbl#loadArgData(_,_,_,_,_,_)_ELROND-CONFIG_InternalInstr_Int_Int_Int_Int_Int_Int
+  - Lbl#loadArgDataWithLengthOnStack(_,_,_,_,_)_ELROND-CONFIG_InternalInstr_Int_Int_Int_Int_Int
+  - Lbl#loadBytesAsSInt64(_)_ELROND-CONFIG_InternalInstr_String
+  - Lbl#loadBytesAsUInt64(_)_ELROND-CONFIG_InternalInstr_String
+  - Lbl#locals2vectype(_,_)_WASM-TEXT_VecType_LocalDecls_ValTypes
+  - Lbl#lock(_,_)_K-IO_K_Int_Int
+  - Lbl#log
+  - Lbl#logToFile
+  - Lbl#lookupStorage(_,_)_ELROND-CONFIG_Bytes_MapBytesToBytes_Bytes
+  - Lbl#mBufferCopyByteSliceH(_,_,_)_MANBUFOPS_InternalInstr_Int_Int_Int
+  - Lbl#mBufferGetByteSliceH(_,_,_)_MANBUFOPS_InternalInstr_Int_Int_Int
+  - Lbl#maxMemorySize()_WASM-INTERNAL-SYNTAX_Int
+  - Lbl#maxTableSize()_WASM-INTERNAL-SYNTAX_Int
+  - Lbl#memLoad(_,_)_ELROND-CONFIG_InternalInstr_Int_Int
+  - Lbl#memStore(_,_)_ELROND-CONFIG_InternalInstr_Int_Bytes
+  - Lbl#memStoreFromBytesStack(_)_ELROND-CONFIG_InternalInstr_Int
+  - Lbl#mergeOutputs_ASYNC_InternalCmd
+  - Lbl#minWidth(_)_WASM-NUMERIC_Int_Int
+  - Lbl#mkstemp(_)_K-IO_IOFile_String
+  - Lbl#newKey(_)_BIGINT-HELPERS_Int_Map
+  - Lbl#newKey(_)_BIGINT-HELPERS_Int_MapIntToBytes
+  - Lbl#newKey(_)_BIGINT-HELPERS_Int_MapIntToInt
+  - Lbl#newKeyAux(_,_)_BIGINT-HELPERS_Int_Int_Map
+  - Lbl#newKeyAux(_,_)_BIGINT-HELPERS_Int_Int_MapIntToBytes
+  - Lbl#newKeyAux(_,_)_BIGINT-HELPERS_Int_Int_MapIntToInt
+  - Lbl#notBuiltin
+  - Lbl#numBytes(_)_WASM-DATA-COMMON_Int_IValType
+  - Lbl#open(_,_)_K-IO_IOInt_String_String
+  - Lbl#open(_)_K-IO_IOInt_String
+  - Lbl#ostream(_)_K-IO_Stream_Int
+  - Lbl#pageSize()_WASM-INTERNAL-SYNTAX_Int
+  - Lbl#parseHexBytes(_)_ELROND-CONFIG_Bytes_String
+  - Lbl#parseHexBytesAux(_)_ELROND-CONFIG_Bytes_String
+  - Lbl#parseInput(_,_)_K-IO_Stream_String_String
+  - Lbl#parseWasmString(_)_WASM-DATA-COMMON-SYNTAX_String_WasmStringToken
+  - Lbl#popcnt(_)_WASM-NUMERIC_Int_Int
+  - Lbl#pow(_)_WASM-DATA-INTERNAL-SYNTAX_Int_IValType
+  - Lbl#pow1(_)_WASM-DATA-INTERNAL-SYNTAX_Int_IValType
+  - Lbl#pushBytes(_)_ELROND-NODE_BytesOp_Bytes
+  - Lbl#putc(_,_)_K-IO_K_Int_Int
+  - Lbl#quoteUnparseWasmString(_)_ELROND-NODE_WasmStringToken_String
+  - Lbl#randomCharsAreValid(_)_EEI-HELPERS_Bool_Bytes
+  - Lbl#randomCharsLen_EEI-HELPERS_Int
+  - Lbl#read(_,_)_K-IO_IOString_Int_Int
+  - Lbl#readableChar(_)_EEI-HELPERS_Bool_Int
+  - Lbl#remove(_)_K-IO_K_String
+  - Lbl#removeEmptyBytes(_)_MANDOS_MapBytesToBytes_MapBytesToBytes
+  - Lbl#removeReservedKeys(_)_MANDOS_MapBytesToBytes_MapBytesToBytes
+  - Lbl#returnData(_,_)_BASEOPS_InternalInstr_Int_Int
+  - Lbl#returnIfSInt64(_,_)_ELROND-CONFIG_InternalInstr_Int_String
+  - Lbl#returnIfUInt64(_,_)_ELROND-CONFIG_InternalInstr_Int_String
+  - Lbl#returnLength_ELROND-NODE_InternalInstr
+  - Lbl#reverseDefns(_,_)_WASM-TEXT_Defns_Defns_Defns
+  - Lbl#reverseInstrs(_,_)_WASM-TEXT_Instrs_Instrs_Instrs
+  - Lbl#revs(_,_)_WASM-DATA-COMMON_ValStack_ValStack_ValStack
+  - Lbl#revs(_)_WASM-DATA-COMMON_ValStack_ValStack
+  - Lbl#revt(_,_)_WASM-DATA-COMMON_ValTypes_ValTypes_ValTypes
+  - Lbl#revt(_)_WASM-DATA-COMMON_ValTypes_ValTypes
+  - Lbl#round(_,_)_WASM-DATA-COMMON_FVal_FValType_Number
+  - Lbl#sameType(_,_)_WASM-DATA-INTERNAL-SYNTAX_Bool_Val_Val
+  - Lbl#saveId(_,_,_)_WASM-DATA-COMMON_Map_Map_OptionalId_Int
+  - Lbl#seek(_,_)_K-IO_K_Int_Int
+  - Lbl#seekEnd(_,_)_K-IO_K_Int_Int
+  - Lbl#setBalance(_,_)_KASMER_InternalInstr_BytesResult_IntResult
+  - Lbl#setBigInt(_,_,_)_BIGINT-HELPERS_InternalInstr_Int_Bytes_Signedness
+  - Lbl#setBigIntFromBytesStack(_,_)_BIGINT-HELPERS_InternalInstr_Int_Signedness
+  - Lbl#setBigIntValue(_,_)_BIGINT-HELPERS_InternalInstr_Int_Int
+  - Lbl#setBuffer(_,_)_MANBUFOPS_InternalInstr_Int_Bytes
+  - Lbl#setBufferFromBytesStack(_)_MANBUFOPS_InternalInstr_Int
+  - Lbl#setBytesRange(_,_,_)_WASM-DATA-COMMON_SparseBytes_SparseBytes_Int_Bytes
+  - Lbl#setESDTBalance(_)_KASMER_InternalInstr_IntResult
+  - Lbl#setESDTRole(_,_)_KASMER_InternalInstr_ESDTLocalRole_Bool
+  - Lbl#setRange(_,_,_,_)_WASM-DATA-COMMON_SparseBytes_SparseBytes_Int_Int_Int
+  - Lbl#setReturnDataIfExists(_,_)_MANAGEDEI_InternalInstr_Int_Int
+  - Lbl#setStorage(_,_)_ELROND-CONFIG_InternalInstr_Bytes_Bytes
+  - Lbl#setVMOutput
+  - Lbl#sha256FromBytesStack_CRYPTOEI-HELPERS_HashBytesStackInstr
+  - Lbl#shutdownWrite(_)_K-IO_K_Int
+  - Lbl#signalError_BASEOPS_InternalInstr
+  - Lbl#signed(_,_)_WASM-DATA-INTERNAL-SYNTAX_Int_IValType_Int
+  - Lbl#signedTotal
+  - Lbl#signedWidth(_,_)_WASM-DATA-INTERNAL-SYNTAX_Int_Int_Int
+  - Lbl#sliceBytes(_,_)_MANBUFOPS_InternalInstr_Int_Int
+  - Lbl#sliceBytesInBounds(_,_,_)_MANBUFOPS_Bool_Bytes_Int_Int
+  - Lbl#startPrank(_)_KASMER_InternalInstr_BytesResult
+  - Lbl#stderr_K-IO_Int
+  - Lbl#stdin_K-IO_Int
+  - Lbl#stdout_K-IO_Int
+  - Lbl#storageLoad_ELROND-CONFIG_InternalInstr
+  - Lbl#storageLoadFromAddress_ELROND-CONFIG_InternalInstr
+  - Lbl#storageStatus(_,_,_)_ELROND-CONFIG_Int_MapBytesToBytes_Bytes_Bytes
+  - Lbl#storageStore_ELROND-CONFIG_InternalInstr
+  - Lbl#stripQuotes(_)_WASM-AUTO-ALLOCATE_String_String
+  - Lbl#structureModule(_,_)_WASM-TEXT_ModuleDecl_Defns_ModuleDecl
+  - Lbl#system(_)_K-IO_KItem_String
+  - Lbl#systemResult
+  - Lbl#t2aDefn<_>(_)_WASM-TEXT_Defn_Context_Defn
+  - Lbl#t2aDefns<_>(_)_WASM-TEXT_Defns_Context_Defns
+  - Lbl#t2aElemExpr<_>(_)_WASM-TEXT_RefVal_Context_ElemExpr
+  - Lbl#t2aElemExprs<_>(_)_WASM-TEXT_ListRef_Context_ElemExprs
+  - Lbl#t2aElemList<_>(_)_WASM-TEXT_ListRef_Context_ElemList
+  - Lbl#t2aElemSegment<_>(_)_WASM-TEXT_ListRef_Context_ElemSegment
+  - Lbl#t2aInstr<_>(_)_WASM-TEXT_Instr_Context_Instr
+  - Lbl#t2aInstrs<_>(_)_WASM-TEXT_Instrs_Context_Instrs
+  - Lbl#t2aModule<_>(_)_WASM-TEXT_ModuleDecl_Context_ModuleDecl
+  - Lbl#t2aModuleDecl<_>(_)_WASM-TEXT_ModuleDecl_Context_ModuleDecl
+  - Lbl#t2aStmt<_>(_)_WASM-TEXT_Stmt_Context_Stmt
+  - Lbl#t2aStmts<_>(_)_WASM-TEXT_Stmts_Context_Stmts
+  - Lbl#tableCheckSizeGTE(_,_)_WASM_Instr_Int_Int
+  - Lbl#tableCopy(_,_,_,_,_)_WASM_Instr_Int_Int_Int_Int_Int
+  - Lbl#tableFill(_,_,_,_)_WASM_Instr_Int_Int_RefVal_Int
+  - Lbl#tableGet(_,_)_WASM_Instr_Int_Int
+  - Lbl#tableInit(_,_,_,_)_WASM_Instr_Int_Int_Int_ListRef
+  - Lbl#tableSet(_,_,_)_WASM_Instr_Int_RefVal_Int
+  - Lbl#take(_,_)_WASM-DATA-COMMON_ValStack_Int_ValStack
+  - Lbl#tell(_)_K-IO_IOInt_Int
+  - Lbl#tempFile
+  - Lbl#throwException(_,_)_ELROND-NODE_ThrowException_ExceptionCode_String
+  - Lbl#throwExceptionBs(_,_)_ELROND-NODE_ThrowException_ExceptionCode_Bytes
+  - Lbl#ti(_,_)_WASM-TEXT_TypesInfo_Map_Int
+  - Lbl#tickerMaxLen_EEI-HELPERS_Int
+  - Lbl#tickerMinLen_EEI-HELPERS_Int
+  - Lbl#time()_K-IO_Int
+  - Lbl#trace
+  - Lbl#traceK
+  - Lbl#transferESDTNFTExecuteWithTypedArgs(_,_,_,_,_)_BASEOPS_InternalInstr_BytesResult_ListResult_Int_BytesResult_ListBytesResult
+  - Lbl#transferValue_BASEOPS_InternalInstr
+  - Lbl#transferValueExecuteWithTypedArgs(_,_,_,_,_)_BASEOPS_InternalInstr_BytesResult_IntResult_Int_BytesResult_ListBytesResult
+  - Lbl#typeMatches(_,_)_WASM-DATA-INTERNAL-SYNTAX_Bool_ValType_Val
+  - Lbl#types2indices(_,_)_WASM-TEXT_TypesInfo_Defns_TypesInfo
+  - Lbl#unfoldDefns(_,_,_)_WASM-TEXT_Defns_Defns_Int_TypesInfo
+  - Lbl#unfoldElemExpr(_)_WASM-TEXT_ElemExpr_ElemExpr
+  - Lbl#unfoldElemExprs(_)_WASM-TEXT_ElemExprs_ElemExprs
+  - Lbl#unfoldElemList(_)_WASM-TEXT_ElemList_ElemList
+  - Lbl#unfoldInstrs(_,_,_)_WASM-TEXT_Instrs_Instrs_Int_Map
+  - Lbl#unknownIOError
+  - Lbl#unlock(_,_)_K-IO_K_Int_Int
+  - Lbl#unparseWasmString(_)_ELROND-NODE_WasmStringToken_String
+  - Lbl#unsigned(_,_)_WASM-DATA-INTERNAL-SYNTAX_Int_IValType_Int
+  - Lbl#updateFuncIds(_,_)_WASM-TEXT_Context_Context_Map
+  - Lbl#updateFuncIdsAux(_,_,_)_WASM-TEXT_Context_Context_Map_Bool
+  - Lbl#updateLocalIds(_,_)_WASM-TEXT_Context_Context_Map
+  - Lbl#updateLocalIdsAux(_,_,_)_WASM-TEXT_Context_Context_Map_Bool
+  - Lbl#validArgIdx(_,_)_BASEOPS_Bool_Int_ListBytes
+  - Lbl#validBufferId(_,_)_MANBUFOPS_Bool_Int_MapIntToBytes
+  - Lbl#validRandom(_)_EEI-HELPERS_Bool_Int
+  - Lbl#validateToken(_)_EEI-HELPERS_Bool_Bytes
+  - Lbl#wait_MANDOS_Step
+  - Lbl#waitCommands
+  - Lbl#waitWasm
+  - Lbl#width(_)_WASM-DATA-COMMON_Int_IValType
+  - Lbl#wrap(_,_)_WASM-DATA-COMMON_Int_Int_Int
+  - Lbl#write(_,_)_K-IO_K_Int_String
+  - Lbl#writeBytesToBuffer(_)_MANAGEDCONVERSIONS_InternalInstr_Bytes
+  - Lbl#writeEsdtToBytes(_)_MANAGEDCONVERSIONS_InternalInstr_ESDTTransfer
+  - Lbl#writeEsdtsToBytes(_)_MANAGEDCONVERSIONS_InternalInstr_List
+  - Lbl#writeEsdtsToBytesH(_)_MANAGEDCONVERSIONS_InternalInstr_List
+  - Lbl#writeListBytesToBuffers(_)_MANAGEDCONVERSIONS_InternalInstr_ListBytes
+  - Lbl#writeListBytesToBuffersH(_)_MANAGEDCONVERSIONS_InternalInstr_ListBytes
+  - Lbl#writeLog_ELROND-CONFIG_InternalInstr
+  - Lbl#writeLogAux(_,_,_)_ELROND-CONFIG_InternalInstr_Int_ListBytes_Bytes
+  - Lbl#writeManagedVecOfManagedBuffers(_,_)_MANAGEDCONVERSIONS_InternalInstr_ListBytes_Int
+  - Lbl#writeToStorage(_,_)_ELROND-CONFIG_InternalInstr_Bytes_Bytes
+  - Lbl#zero(_)_WASM-DATA-COMMON_ValStack_ValTypes
+  - Lbl{_}_ELROND-NODE_Accounts_AccountsCellFragment
+  - Lbl(block___)_WASM-TEXT-COMMON-SYNTAX_FoldedInstr_OptionalId_TypeDecls_Instrs
+  - Lbl(data_)_WASM-TEXT-COMMON-SYNTAX_MemorySpec_DataString
+  - Lbl(data__)_WASM-TEXT-COMMON-SYNTAX_DataDefn_Offset_DataString
+  - Lbl(data___)_WASM-TEXT-COMMON-SYNTAX_DataDefn_Index_Offset_DataString
+  - Lbl(elem_declare_)_WASM-TEXT-COMMON-SYNTAX_ElemDefn_OptionalId_ElemList
+  - Lbl(elem__)_WASM-TEXT-COMMON-SYNTAX_ElemDefn_OptionalId_ElemList
+  - Lbl(elem___)_WASM-TEXT-COMMON-SYNTAX_ElemDefn_OptionalId_Offset_ElemList
+  - Lbl(elem____)_WASM-TEXT-COMMON-SYNTAX_ElemDefn_OptionalId_TableUse_Offset_ElemList
+  - Lbl(export_(_))_WASM-TEXT-COMMON-SYNTAX_ExportDefn_WasmString_Externval
+  - Lbl(export_)_WASM-TEXT-COMMON-SYNTAX_InlineExport_WasmString
+  - Lbl(func__)_WASM-TEXT-COMMON-SYNTAX_FuncDefn_OptionalId_FuncSpec
+  - Lbl(func__)_WASM-TEXT-COMMON-SYNTAX_ImportDesc_OptionalId_TypeUse
+  - Lbl(global__)_WASM-TEXT-COMMON-SYNTAX_GlobalDefn_OptionalId_GlobalSpec
+  - Lbl(global__)_WASM-TEXT-COMMON-SYNTAX_ImportDesc_OptionalId_TextFormatGlobalType
+  - Lbl(if___(then_)(else_))_WASM-TEXT-COMMON-SYNTAX_FoldedInstr_OptionalId_TypeDecls_Instrs_Instrs_Instrs
+  - Lbl(if___(then_))_WASM-TEXT-COMMON-SYNTAX_FoldedInstr_OptionalId_TypeDecls_Instrs_Instrs
+  - Lbl(import__)_WASM-TEXT-COMMON-SYNTAX_InlineImport_WasmString_WasmString
+  - Lbl(import___)_WASM-TEXT-COMMON-SYNTAX_ImportDefn_WasmString_WasmString_ImportDesc
+  - Lbl(invoke_)_WASM_Instr_Int
+  - Lbl(item_)_WASM-TEXT-COMMON-SYNTAX_ElemExpr_Instrs
+  - Lbl(loop___)_WASM-TEXT-COMMON-SYNTAX_FoldedInstr_OptionalId_TypeDecls_Instrs
+  - Lbl(memory__)_WASM-TEXT-COMMON-SYNTAX_ImportDesc_OptionalId_MemType
+  - Lbl(memory__)_WASM-TEXT-COMMON-SYNTAX_MemoryDefn_OptionalId_MemorySpec
+  - Lbl(module__)_WASM-TEXT-COMMON-SYNTAX_ModuleDecl_OptionalId_Defns
+  - Lbl(mut_)_WASM-TEXT-COMMON-SYNTAX_TextFormatGlobalType_ValType
+  - Lbl(offset_)_WASM-TEXT-COMMON-SYNTAX_Offset_Instrs
+  - Lbl(start_)_WASM-TEXT-COMMON-SYNTAX_StartDefn_Index
+  - Lbl(table_)_WASM-TEXT-COMMON-SYNTAX_TableUse_Index
+  - Lbl(table__)_WASM-TEXT-COMMON-SYNTAX_ImportDesc_OptionalId_TableType
+  - Lbl(table__)_WASM-TEXT-COMMON-SYNTAX_TableDefn_OptionalId_TableSpec
+  - Lbl(type_(func_))_WASM-TEXT-COMMON-SYNTAX_TypeDefn_OptionalId_TypeDecls
+  - Lbl(type_)__WASM-COMMON-SYNTAX_TypeUse_Index_TypeDecls
+  - Lbl(_x_,_x_)_KRYPTO_G2Point_Int_Int_Int_Int
+  - Lbl(_,_)_KRYPTO_G1Point_Int_Int
+  - Lbl(_)_WASM-TEXT-COMMON-SYNTAX_ElemExpr_Instrs
+  - Lbl(_)_WASM-TEXT-COMMON-SYNTAX_FoldedInstr_PlainInstr
+  - Lbl(_)_WASM-TEXT-COMMON-SYNTAX_Offset_Instrs
+  - Lbl(__)_WASM-TEXT-COMMON-SYNTAX_FoldedInstr_PlainInstr_Instrs
+  - Lbl.AccountCellMap
+  - Lbl.Bytes_BYTES-HOOKED_Bytes
+  - Lbl.Code
+  - Lbl.ElemInstCellMap
+  - Lbl.EsdtDataCellMap
+  - Lbl.FuncDefCellMap
+  - Lbl.GlobalInstCellMap
+  - Lbl.Identifier
+  - Lbl.Int
+  - Lbl.List
+  - Lbl.List{"bytesStackList"}
+  - Lbl.List{"listIndex"}
+  - Lbl.List{"listInt"}
+  - Lbl.List{"listLocalDecl"}
+  - Lbl.List{"listStmt"}
+  - Lbl.List{"listTypeDecl"}
+  - Lbl.List{"listValTypes"}
+  - Lbl.List{"listWasmString"}
+  - Lbl.List{"mandosSteps"}
+  - Lbl.List{"___SPARSE-BYTES_SparseBytes_SBItemChunk_SparseBytes"}_SparseBytes
+  - Lbl.List{"___WASM-COMMON-SYNTAX_Defns_Defn_Defns"}_Defns
+  - Lbl.List{"___WASM-COMMON-SYNTAX_Instrs_Instr_Instrs"}_Instrs
+  - Lbl.List{"___WASM-COMMON-SYNTAX_Stmts_Stmt_Stmts"}_Stmts
+  - Lbl.List{"___WASM-TEXT-COMMON-SYNTAX_ElemExprs_ElemExpr_ElemExprs"}_ElemExprs
+  - Lbl.ListAsyncCall
+  - Lbl.ListBytes
+  - Lbl.ListInt
+  - Lbl.ListRef
+  - Lbl.Map
+  - Lbl.MapBytesToBytes
+  - Lbl.MapIntToBytes
+  - Lbl.MapIntToInt
+  - Lbl.MemInstCellMap
+  - Lbl.ModuleInstCellMap
+  - Lbl.Mut_WASM-DATA-COMMON_Mut
+  - Lbl.Set
+  - Lbl.String
+  - Lbl.TabInstCellMap
+  - Lbl.Type_WASM-DATA-INTERNAL-SYNTAX_Type
+  - Lbl.VMOutput
+  - Lbl.ValStack
+  - Lbl.WasmString_WASM-DATA-COMMON-SYNTAX_WasmString
+  - Lbl.esdtMetadata
+  - Lbl~Int_
+  - Lbl_-Float__FLOAT_Float_Float_Float
+  - Lbl_-Int_
+  - Lbl_-Map__MAP_Map_Map_Map
+  - Lbl_-Map__MAP-BYTES-TO-BYTES_MapBytesToBytes_MapBytesToBytes_MapBytesToBytes
+  - Lbl_-Map__MAP-INT-TO-BYTES_MapIntToBytes_MapIntToBytes_MapIntToBytes
+  - Lbl_-Map__MAP-INT-TO-INT_MapIntToInt_MapIntToInt_MapIntToInt
+  - Lbl_AccountCellMap_
+  - Lbl_Bytes2Bytes|->_
+  - Lbl_ElemInstCellMap_
+  - Lbl_EsdtDataCellMap_
+  - Lbl_FuncDefCellMap_
+  - Lbl_GlobalInstCellMap_
+  - Lbl_Int2Bytes|->_
+  - Lbl_Int2Int|->_
+  - Lbl_List_
+  - Lbl_ListAsyncCall_
+  - Lbl_ListBytes_
+  - Lbl_ListInt_
+  - Lbl_ListRef_
+  - Lbl_Map_
+  - Lbl_MapBytesToBytes[_<-undef]
+  - Lbl_MapBytesToBytes_
+  - Lbl_MapIntToBytes[_<-undef]
+  - Lbl_MapIntToBytes_
+  - Lbl_MapIntToInt[_<-undef]
+  - Lbl_MapIntToInt_
+  - Lbl_MemInstCellMap_
+  - Lbl_ModuleInstCellMap_
+  - Lbl_Set_
+  - Lbl_TabInstCellMap_
+  - Lbl_andBool_
+  - Lbl_andThenBool_
+  - Lbl_appendDefn__WASM-TEXT_Defns_Defns_Defn
+  - Lbl_appendInstrs__WASM-TEXT_Instrs_Instrs_Instrs
+  - Lbl_divInt_
+  - Lbl_dividesInt__INT-COMMON_Bool_Int_Int
+  - Lbl_impliesBool_
+  - Lbl_in_keys(_)_MAP_Bool_KItem_Map
+  - Lbl_in_keys(_)_MAP-BYTES-TO-BYTES_Bool_WrappedBytes_MapBytesToBytes
+  - Lbl_in_keys(_)_MAP-INT-TO-BYTES_Bool_WrappedInt_MapIntToBytes
+  - Lbl_in_keys(_)_MAP-INT-TO-INT_Bool_WrappedInt_MapIntToInt
+  - Lbl_in__LIST_Bool_KItem_List
+  - Lbl_inListAsyncCall_
+  - Lbl_inListBytes_
+  - Lbl_inListInt_
+  - Lbl_inListRef_
+  - Lbl_modInt_
+  - Lbl_orBool_
+  - Lbl_orElseBool_
+  - Lbl_up/Int__WASM_Int_Int_Int
+  - Lbl_xorBool_
+  - Lbl_xorInt_
+  - Lbl_>Float__FLOAT_Bool_Float_Float
+  - Lbl_>Int_
+  - Lbl_>String__STRING-COMMON_Bool_String_String
+  - Lbl_>>Int_
+  - Lbl_>=Float__FLOAT_Bool_Float_Float
+  - Lbl_>=Int_
+  - Lbl_>=String__STRING-COMMON_Bool_String_String
+  - Lbl_<Float__FLOAT_Bool_Float_Float
+  - Lbl_<Int_
+  - Lbl_<String__STRING-COMMON_Bool_String_String
+  - Lbl_<<Int_
+  - Lbl_<=Float__FLOAT_Bool_Float_Float
+  - Lbl_<=Int_
+  - Lbl_<=Map__MAP_Bool_Map_Map
+  - Lbl_<=Map__MAP-BYTES-TO-BYTES_Bool_MapBytesToBytes_MapBytesToBytes
+  - Lbl_<=Map__MAP-INT-TO-BYTES_Bool_MapIntToBytes_MapIntToBytes
+  - Lbl_<=Map__MAP-INT-TO-INT_Bool_MapIntToInt_MapIntToInt
+  - Lbl_<=Set__SET_Bool_Set_Set
+  - Lbl_<=String__STRING-COMMON_Bool_String_String
+  - Lbl_&Int_
+  - Lbl_==Bool_
+  - Lbl_==Float__FLOAT_Bool_Float_Float
+  - Lbl_==Int_
+  - Lbl_==K_
+  - Lbl_==String__STRING-COMMON_Bool_String_String
+  - Lbl_=/=Bool_
+  - Lbl_=/=Float__FLOAT_Bool_Float_Float
+  - Lbl_=/=Int_
+  - Lbl_=/=K_
+  - Lbl_=/=String__STRING-COMMON_Bool_String_String
+  - Lbl_(elem_)_WASM-TEXT-COMMON-SYNTAX_TableSpec_TableElemType_ElemExprs
+  - Lbl_(elem_)_WASM-TEXT-COMMON-SYNTAX_TableSpec_TableElemType_ElemSegment
+  - Lbl_[_<-_]_BYTES-HOOKED_Bytes_Bytes_Int_Int
+  - Lbl_[_<-_]_LIST_List_List_Int_KItem
+  - Lbl_[_<-undef]
+  - Lbl_[_]orDefault__MAP_KItem_Map_KItem_KItem
+  - Lbl_[_]_BYTES-HOOKED_Int_Bytes_Int
+  - Lbl_%Float__FLOAT_Float_Float_Float
+  - Lbl_%Int_
+  - Lbl_|->_
+  - Lbl_|Int_
+  - Lbl_|Set__SET_Set_Set_Set
+  - Lbl_+Bytes__BYTES-HOOKED_Bytes_Bytes_Bytes
+  - Lbl_+Float__FLOAT_Float_Float_Float
+  - Lbl_+Int_
+  - Lbl_+String__STRING-COMMON_String_String_String
+  - Lbl_++__WASM-DATA-COMMON_ValStack_ValStack_ValStack
+  - Lbl_+__WASM-DATA-COMMON_ValTypes_ValTypes_ValTypes
+  - Lbl_/Float__FLOAT_Float_Float_Float
+  - Lbl_/Int_
+  - Lbl_*Float__FLOAT_Float_Float_Float
+  - Lbl_*Int_
+  - Lbl_.__WASM-TEXT-COMMON-SYNTAX_PlainInstr_FValType_LoadOpM
+  - Lbl_.__WASM-TEXT-COMMON-SYNTAX_PlainInstr_FValType_StoreOpM
+  - Lbl_.__WASM-TEXT-COMMON-SYNTAX_PlainInstr_IValType_LoadOpM
+  - Lbl_.__WASM-TEXT-COMMON-SYNTAX_PlainInstr_IValType_StoreOpM
+  - Lbl_.___WASM_Instr_IValType_LoadOp_Int
+  - Lbl_.___WASM-NUMERIC_Val_FValType_FUnOp_Float
+  - Lbl_.___WASM-NUMERIC_Val_IValType_ExtendS_Int
+  - Lbl_.___WASM-NUMERIC_Val_IValType_IUnOp_Int
+  - Lbl_.___WASM-NUMERIC_Val_IValType_TestOp_Int
+  - Lbl_.___WASM-NUMERIC_Val_ValType_CvtOp_Number
+  - Lbl_.____WASM_Instr_IValType_StoreOp_Int_Int
+  - Lbl___SPARSE-BYTES_SparseBytes_SBItemChunk_SparseBytes
+  - Lbl___WASM-COMMON-SYNTAX_Defns_Defn_Defns
+  - Lbl___WASM-COMMON-SYNTAX_EmptyStmts_EmptyStmt_EmptyStmts
+  - Lbl___WASM-COMMON-SYNTAX_Instrs_Instr_Instrs
+  - Lbl___WASM-COMMON-SYNTAX_Stmts_Stmt_Stmts
+  - Lbl___WASM-COMMON-SYNTAX_TypeDecl_TypeKeyWord_ValTypes
+  - Lbl___WASM-DATA-COMMON-SYNTAX_Externval_AllocatedKind_Index
+  - Lbl___WASM-TEXT-COMMON-SYNTAX_ElemExprs_ElemExpr_ElemExprs
+  - Lbl___WASM-TEXT-COMMON-SYNTAX_ElemList_RefValType_ElemExprs
+  - Lbl___WASM-TEXT-COMMON-SYNTAX_FuncSpec_InlineExport_FuncSpec
+  - Lbl___WASM-TEXT-COMMON-SYNTAX_FuncSpec_InlineImport_TypeUse
+  - Lbl___WASM-TEXT-COMMON-SYNTAX_GlobalSpec_InlineExport_GlobalSpec
+  - Lbl___WASM-TEXT-COMMON-SYNTAX_GlobalSpec_InlineImport_TextFormatGlobalType
+  - Lbl___WASM-TEXT-COMMON-SYNTAX_GlobalSpec_TextFormatGlobalType_Instr
+  - Lbl___WASM-TEXT-COMMON-SYNTAX_LoadOpM_LoadOp_MemArg
+  - Lbl___WASM-TEXT-COMMON-SYNTAX_MemArg_OffsetArg_AlignArg
+  - Lbl___WASM-TEXT-COMMON-SYNTAX_MemorySpec_InlineExport_MemorySpec
+  - Lbl___WASM-TEXT-COMMON-SYNTAX_MemorySpec_InlineImport_MemType
+  - Lbl___WASM-TEXT-COMMON-SYNTAX_StoreOpM_StoreOp_MemArg
+  - Lbl___WASM-TEXT-COMMON-SYNTAX_TableSpec_InlineExport_TableSpec
+  - Lbl___WASM-TEXT-COMMON-SYNTAX_TableSpec_InlineImport_TableType
+  - Lbl___WASM-TEXT-COMMON-SYNTAX_TableType_TextLimits_TableElemType
+  - Lbl___WASM-TEXT-COMMON-SYNTAX_TextLimits_WasmInt_WasmInt
+  - Lbl____WASM-TEXT-COMMON-SYNTAX_FuncSpec_TypeUse_LocalDecls_Instrs
+  - Lbl_^Float__FLOAT_Float_Float_Float
+  - Lbl_^Int_
+  - Lbl_^%Int__
+  - Lbl--Float__FLOAT_Float_Float
+  - LblAccountCellMap:in_keys
+  - LblAccountCellMapItem
+  - LblAccountCellMapKey
+  - LblAccountCollision
+  - LblAsyncCall
+  - LblAsyncCallPending
+  - LblAsyncCallRejected
+  - LblAsyncCallResolved
+  - LblAsynchronousCall
+  - LblAsynchronousCallBack
+  - LblBN128Add(_,_)_KRYPTO_G1Point_G1Point_G1Point
+  - LblBN128AtePairing(_,_)_KRYPTO_Bool_List_List
+  - LblBN128Mul(_,_)_KRYPTO_G1Point_G1Point_Int
+  - LblBase2String(_,_)_STRING-COMMON_String_Int_Int
+  - LblBlake2Compress(_)_KRYPTO_String_Bytes
+  - LblBool2String(_)_STRING-COMMON_String_Bool
+  - LblBuiltinFunction2Bytes(_)_ELROND-NODE_Bytes_BuiltinFunction
+  - LblBytes2Int(_,_,_)_BYTES-HOOKED_Int_Bytes_Endianness_Signedness
+  - LblBytes2String(_)_BYTES-HOOKED_String_Bytes
+  - LblBytesResult2ListResult(_)_UTILS_ListBytesResult_BytesResult
+  - LblCallStackOverFlow
+  - LblContractInvalid
+  - LblContractNotFound
+  - LblDirectCall
+  - LblECDSAPubKey(_)_KRYPTO_String_Bytes
+  - LblECDSARecover(_,_,_,_)_KRYPTO_Bytes_Bytes_Int_Bytes_Bytes
+  - LblECDSASign(_,_)_KRYPTO_String_Bytes_Bytes
+  - LblESDTNFTCreate.meta(_,_)_ESDT_ESDTMetadata_Bytes_ListBytes
+  - LblESDTNFTCreate.qtty(_)_ESDT_Int_ListBytes
+  - LblESDTNFTCreate.token(_)_ESDT_Bytes_ListBytes
+  - LblESDTRoleLocalBurn
+  - LblESDTRoleLocalMint
+  - LblESDTRoleNFTAddQuantity
+  - LblESDTRoleNFTAddURI
+  - LblESDTRoleNFTBurn
+  - LblESDTRoleNFTCreate
+  - LblESDTRoleNFTUpdateAttributes
+  - LblESDTRoleNone
+  - LblESDTTransfer.token(_)_ESDT_Bytes_ListBytes
+  - LblESDTTransfer.value(_)_ESDT_Int_ListBytes
+  - LblESDTTransferRole
+  - LblElemInstCellMap:in_keys
+  - LblElemInstCellMapItem
+  - LblElemInstCellMapKey
+  - LblErr(_)_UTILS_Error_String
+  - LblEsdtDataCellMap:in_keys
+  - LblEsdtDataCellMapItem
+  - LblEsdtDataCellMapKey
+  - LblExecutionFailed
+  - LblFVal
+  - LblFloat2Int(_)_FLOAT_Int_Float
+  - LblFloat2String(_,_)_STRING-COMMON_String_Float_String
+  - LblFloat2String(_)_STRING-COMMON_String_Float
+  - LblFuncDefCellMap:in_keys
+  - LblFuncDefCellMapItem
+  - LblFuncDefCellMapKey
+  - LblFunctionNotFound
+  - LblFunctionWrongSignature
+  - LblGlobalInstCellMap:in_keys
+  - LblGlobalInstCellMapItem
+  - LblGlobalInstCellMapKey
+  - LblIVal
+  - LblId2String(_)_ID-COMMON_String_Id
+  - LblInt2Bytes(_,_,_)_BYTES-HOOKED_Bytes_Int_Endianness_Signedness
+  - LblInt2Bytes(_,_,_)_BYTES-HOOKED_Bytes_Int_Int_Endianness
+  - LblInt2ESDTRole(_)_KASMER_ESDTLocalRole_Int
+  - LblInt2Float(_,_,_)_FLOAT_Float_Int_Int_Int
+  - LblInt2String(_)_STRING-COMMON_String_Int
+  - LblIntResult2ListResult(_)_UTILS_ListResult_IntResult
+  - LblKeccak256(_)_KRYPTO_String_Bytes
+  - LblKeccak256raw(_)_KRYPTO_Bytes_Bytes
+  - LblList:get
+  - LblList:range
+  - LblList2Set(_)_COLLECTIONS_Set_List
+  - LblListAsyncCall:get
+  - LblListAsyncCall:range
+  - LblListAsyncCall:set
+  - LblListAsyncCallItem
+  - LblListBytes:get
+  - LblListBytes:getOrDefault
+  - LblListBytes:primitiveLookup
+  - LblListBytes:primitiveLookupOrDefault
+  - LblListBytes:range
+  - LblListBytes:rangeTotal
+  - LblListBytes:set
+  - LblListBytesItem
+  - LblListBytesItemWrap
+  - LblListInt:get
+  - LblListInt:getOrDefault
+  - LblListInt:primitiveLookup
+  - LblListInt:primitiveLookupOrDefault
+  - LblListInt:primitiveSet
+  - LblListInt:range
+  - LblListInt:set
+  - LblListIntItem
+  - LblListIntItemWrap
+  - LblListItem
+  - LblListRef:drop
+  - LblListRef:get
+  - LblListRef:getOrDefault
+  - LblListRef:getOrNull
+  - LblListRef:makeTotal
+  - LblListRef:range
+  - LblListRef:set
+  - LblListRefItem
+  - LblMap:lookup
+  - LblMap:update
+  - LblMapBytesToBytes:choice
+  - LblMapBytesToBytes:lookup
+  - LblMapBytesToBytes:lookupOrDefault
+  - LblMapBytesToBytes:primitiveInKeys
+  - LblMapBytesToBytes:primitiveLookup
+  - LblMapBytesToBytes:primitiveLookupOrDefault
+  - LblMapBytesToBytes:primitiveRemove
+  - LblMapBytesToBytes:primitiveUpdate
+  - LblMapBytesToBytes:update
+  - LblMapBytesToBytes.sizeMap
+  - LblMapIntToBytes:choice
+  - LblMapIntToBytes:lookup
+  - LblMapIntToBytes:lookupOrDefault
+  - LblMapIntToBytes:primitiveInKeys
+  - LblMapIntToBytes:primitiveLookup
+  - LblMapIntToBytes:primitiveLookupOrDefault
+  - LblMapIntToBytes:primitiveRemove
+  - LblMapIntToBytes:primitiveUpdate
+  - LblMapIntToBytes:update
+  - LblMapIntToBytes.sizeMap
+  - LblMapIntToInt:choice
+  - LblMapIntToInt:lookup
+  - LblMapIntToInt:lookupOrDefault
+  - LblMapIntToInt:primitiveInKeys
+  - LblMapIntToInt:primitiveLookup
+  - LblMapIntToInt:primitiveLookupOrDefault
+  - LblMapIntToInt:primitiveRemove
+  - LblMapIntToInt:primitiveUpdate
+  - LblMapIntToInt:update
+  - LblMapIntToInt.sizeMap
+  - LblMemInstCellMap:in_keys
+  - LblMemInstCellMapItem
+  - LblMemInstCellMapKey
+  - LblModuleInstCellMap:in_keys
+  - LblModuleInstCellMapItem
+  - LblModuleInstCellMapKey
+  - LblMultiESDTNFTTransfer.dest(_)_ESDT_Bytes_ListBytes
+  - LblMultiESDTNFTTransfer.num(_)_ESDT_Int_ListBytes
+  - LblOK
+  - LblOutOfFunds
+  - LblOutOfGas
+  - LblOutputAccount
+  - LblOutputTransfer
+  - LblRefVal
+  - LblRefValNull
+  - LblReturnCode2Int(_)_ELROND-NODE_Int_ReturnCode
+  - LblRipEmd160(_)_KRYPTO_String_Bytes
+  - LblRipEmd160raw(_)_KRYPTO_Bytes_Bytes
+  - LblSBChunk(_)_SPARSE-BYTES_SBItemChunk_SBItem
+  - LblSBItem:bytes
+  - LblSBItem:empty
+  - LblSBItem:size
+  - LblSBItem:substr
+  - LblSBItem:unwrap
+  - LblSet:difference
+  - LblSet:in
+  - LblSet2List(_)_COLLECTIONS_List_Set
+  - LblSetItem
+  - LblSha256(_)_KRYPTO_String_Bytes
+  - LblSha256raw(_)_KRYPTO_Bytes_Bytes
+  - LblSha3_256(_)_KRYPTO_String_Bytes
+  - LblSha3_256raw(_)_KRYPTO_Bytes_Bytes
+  - LblSha512(_)_KRYPTO_String_Bytes
+  - LblSha512_256(_)_KRYPTO_String_Bytes
+  - LblSha512_256raw(_)_KRYPTO_Bytes_Bytes
+  - LblSha512raw(_)_KRYPTO_Bytes_Bytes
+  - LblSimulateFailed
+  - LblSparseBytes:fromBytes
+  - LblSparseBytes:replaceAt
+  - LblSparseBytes:replaceAtB
+  - LblSparseBytes:replaceAtZ
+  - LblSparseBytes:size
+  - LblSparseBytes:substr
+  - LblSparseBytes:unwrap
+  - LblString2Base(_,_)_STRING-COMMON_Int_String_Int
+  - LblString2Bool(_)_STRING-COMMON_Bool_String
+  - LblString2Bytes(_)_BYTES-HOOKED_Bytes_String
+  - LblString2Float(_)_STRING-COMMON_Float_String
+  - LblString2Id(_)_ID-COMMON_Id_String
+  - LblString2Identifier(_)_WASM-TEXT_IdentifierToken_String
+  - LblString2Int(_)_STRING-COMMON_Int_String
+  - LblTabInstCellMap:in_keys
+  - LblTabInstCellMapItem
+  - LblTabInstCellMapKey
+  - LblUpgradeFailed
+  - LblUserError
+  - LblVMOutput
+  - LblWasmInt
+  - LblWasmIntToken2Int(_)_WASM-TEXT_Int_WasmIntToken
+  - LblWasmIntToken2String(_)_WASM-TEXT_String_WasmIntToken
+  - LblWasmIntTokenString2Int(_)_WASM-TEXT_Int_String
+  - LblaAbs
+  - LblaBlock
+  - LblaBr
+  - LblaBr_if
+  - LblaBr_table
+  - LblaCall
+  - LblaCall_indirect
+  - LblaCeil
+  - LblaClz
+  - LblaConvert_i32_s
+  - LblaConvert_i32_u
+  - LblaConvert_i64_s
+  - LblaConvert_i64_u
+  - LblaCtz
+  - LblaCvtOp
+  - LblaDataDefn
+  - LblaDemote_f64
+  - LblaDrop
+  - LblaElem.drop
+  - LblaElemActive
+  - LblaElemDeclarative
+  - LblaElemDefn
+  - LblaElemPassive
+  - LblaEqz
+  - LblaExportDefn
+  - LblaExtend_i32_s
+  - LblaExtend_i32_u
+  - LblaExtend16_s
+  - LblaExtend32_s
+  - LblaExtend8_s
+  - LblaExtendS
+  - LblaFBinOp
+  - LblaFConst
+  - LblaFRelOp
+  - LblaFUnOp
+  - LblaFloor
+  - LblaFuncDefn
+  - LblaFuncDesc
+  - LblaFuncType
+  - LblaGlobal.get
+  - LblaGlobal.set
+  - LblaGlobalDefn
+  - LblaGlobalDesc
+  - LblaGlobalType
+  - LblaGrow
+  - LblaIBinOp
+  - LblaIConst
+  - LblaIRelOp
+  - LblaIUnOp
+  - LblaIf
+  - LblaImportDefn
+  - LblaImportDefnHelper
+  - LblaLoad
+  - LblaLocal.get
+  - LblaLocal.set
+  - LblaLocal.tee
+  - LblaLoop
+  - LblaMemoryDefn
+  - LblaMemoryDesc
+  - LblaModuleDecl
+  - LblaNearest
+  - LblaNeg
+  - LblaNop
+  - LblaPopcnt
+  - LblaPromote_f32
+  - LblaRef.func
+  - LblaRef.is_null
+  - LblaRef.null
+  - LblaReturn
+  - LblaSelect
+  - LblaSize
+  - LblaSqrt
+  - LblaStartDefn
+  - LblaStore
+  - LblaTable.copy
+  - LblaTable.fill
+  - LblaTable.get
+  - LblaTable.grow
+  - LblaTable.init
+  - LblaTable.set
+  - LblaTable.size
+  - LblaTableDefn
+  - LblaTableDesc
+  - LblaTestOp
+  - LblaTrunc
+  - LblaTrunc_f32_s
+  - LblaTrunc_f32_u
+  - LblaTrunc_f64_s
+  - LblaTrunc_f64_u
+  - LblaTypeDefn
+  - LblaTypeUseIndex
+  - LblaUnreachable
+  - LblaVecType
+  - LblaWrap_i64
+  - LblabsFloat(_)_FLOAT_Float_Float
+  - LblabsInt(_)_INT-COMMON_Int_Int
+  - LblacosFloat(_)_FLOAT_Float_Float
+  - LbladdAsyncCall
+  - LbladdToESDTBalance(_,_,_,_)_ESDT_InternalCmd_Bytes_Bytes_Int_Bool
+  - Lblalign=__WASM-TEXT-COMMON-SYNTAX_AlignArg_WasmInt
+  - Lblallocelem(_,_,_)_WASM_Alloc_RefValType_ListRef_OptionalId
+  - Lblallocfunc(_,_,_,_,_,_)_WASM_Alloc_Int_Int_FuncType_VecType_Instrs_FuncMetadata
+  - Lblallocglobal(_,_)_WASM_Alloc_OptionalId_GlobalType
+  - Lblallocmemory(_,_,_)_WASM_Alloc_OptionalId_Int_OptionalInt
+  - Lblalloctable(_,_,_,_)_WASM_Alloc_OptionalId_Int_OptionalInt_RefValType
+  - Lblalloctype(_,_)_WASM_Alloc_OptionalId_FuncType
+  - LblappendToOutAccount
+  - LblappendToOutTransfers(_,_)_ELROND-NODE_OutputAccount_OutputAccount_OutputTransfer
+  - LblargsForCallback(_,_,_)_ASYNC_ListBytes_ReturnCode_Bytes_ListBytes
+  - LblasFuncType(_,_,_)_WASM_FuncType_Map_Map_TypeUse
+  - LblasFuncType(_)_WASM_FuncType_TypeDecls
+  - LblasGMut(_)_WASM-TEXT_GlobalType_TextFormatGlobalType
+  - LblasinFloat(_)_FLOAT_Float_Float
+  - LblasyncExecute
+  - Lblatan2Float(_,_)_FLOAT_Float_Float_Float
+  - LblatanFloat(_)_FLOAT_Float_Float
+  - LblautoAllocModules(_,_)_WASM-AUTO-ALLOCATE_Stmts_ModuleDecl_Map
+  - LblbigEndianBytes
+  - LblbitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int
+  - Lblblock___end__WASM-TEXT-COMMON-SYNTAX_BlockInstr_OptionalId_TypeDecls_Instrs_OptionalId
+  - LblblockEpoch
+  - LblblockNonce
+  - LblblockRandomSeed
+  - LblblockRound
+  - LblblockTimestamp
+  - LblboolToInt
+  - Lblbr_if__WASM-TEXT-COMMON-SYNTAX_PlainInstr_Index
+  - Lblbr_table__WASM-TEXT-COMMON-SYNTAX_PlainInstr_ElemSegment
+  - Lblbr__WASM-TEXT-COMMON-SYNTAX_PlainInstr_Index
+  - LblbsMid(_,_)_BIGINT-HELPERS_Int_Int_Int
+  - LblbytesStackList
+  - Lblcall_indirect__WASM-TEXT-COMMON-SYNTAX_PlainInstr_TypeUse
+  - Lblcall_indirect___WASM-TEXT-COMMON-SYNTAX_PlainInstr_Index_TypeUse
+  - Lblcall__WASM-TEXT-COMMON-SYNTAX_PlainInstr_Index
+  - LblcallContractCb(_,_,_)_ASYNC_InternalCmd_Bytes_String_VmInputCell
+  - LblcallContractString
+  - LblcallContractWasmString
+  - LblcallTx
+  - LblcallTxAux
+  - LblcatListBytesResult(_,_)_UTILS_ListBytesResult_ListBytesResult_ListBytesResult
+  - LblcatListResult(_,_)_UTILS_ListResult_ListResult_ListResult
+  - LblcategoryChar(_)_STRING-COMMON_String_String
+  - LblceilFloat(_)_FLOAT_Float_Float
+  - LblcheckAccountBalance
+  - LblcheckAccountBalanceAux
+  - LblcheckAccountCode
+  - LblcheckAccountCodeAux
+  - LblcheckAccountESDTBalance
+  - LblcheckAccountESDTBalanceAux
+  - LblcheckAccountExists(_)_ELROND-NODE_InternalCmd_Bytes
+  - LblcheckAccountNonce
+  - LblcheckAccountNonceAux
+  - LblcheckAccountStorage
+  - LblcheckAccountStorageAux
+  - LblcheckAllowedToExecute
+  - LblcheckBool
+  - LblcheckESDTBalance(_,_,_)_ESDT_InternalCmd_Bytes_Bytes_Int
+  - LblcheckEsdtRoles
+  - LblcheckExpectLogs
+  - LblcheckExpectMessage
+  - LblcheckExpectOut
+  - LblcheckExpectStatus
+  - LblcheckFailed
+  - LblcheckIsSmartContract
+  - LblcheckNoAdditionalAccounts
+  - LblcheckedAccount
+  - LblcheckedAccountAux
+  - Lblchoice(_)_MAP_KItem_Map
+  - Lblchoice(_)_SET_KItem_Set
+  - LblchooseCallback(_,_)_ASYNC_String_ReturnCode_AsyncCall
+  - LblchrChar(_)_STRING-COMMON_String_Int
+  - Lblchunks2buffers(_)_MANAGEDCONVERSIONS_ListBytesResult_Bytes
+  - LblclearCheckedAccounts
+  - LblcmpInt
+  - LblconcatValStack
+  - LblcosFloat(_)_FLOAT_Float_Float
+  - LblcountAllOccurrences(_,_)_STRING-COMMON_Int_String_String
+  - LblcreateAccount
+  - LblcreateAndSetAccountAfterInitCodeModule(_,_,_,_)_MANDOS_Step_Bytes_Int_Int_Map
+  - LblcreateAndSetAccountWithEmptyCode(_,_,_,_)_MANDOS_Step_Bytes_Int_Int_Map
+  - Lblctx(_,_,_,_,_,_,_)_WASM-TEXT_Context_Map_Map_Map_Map_Map_Map_Map
+  - Lbldata{__}_WASM_DataDefn_Int_Bytes
+  - LbldecodeBytes(_,_)_BYTES-STRING-ENCODE_String_String_Bytes
+  - LbldefinedBytesListLookup(_,_)_UTILS-CEILS_Bool_ListBytes_Int
+  - LbldefinedListLookup(_,_)_UTILS-CEILS_Bool_List_Int
+  - LbldefinedMapElementConcat(_,_,_)_MAP-BYTES-TO-BYTES-KORE-SYMBOLIC_Bool_WrappedBytes_WrappedBytes_MapBytesToBytes
+  - LbldefinedMapElementConcat(_,_,_)_MAP-INT-TO-BYTES-KORE-SYMBOLIC_Bool_WrappedInt_WrappedBytes_MapIntToBytes
+  - LbldefinedMapElementConcat(_,_,_)_MAP-INT-TO-INT-KORE-SYMBOLIC_Bool_WrappedInt_WrappedInt_MapIntToInt
+  - LbldefinedPrimitiveLookup(_,_)_MAP-BYTES-TO-BYTES-PRIMITIVE-SYMBOLIC_Bool_MapBytesToBytes_Bytes
+  - LbldefinedPrimitiveLookup(_,_)_MAP-INT-TO-BYTES-PRIMITIVE-SYMBOLIC_Bool_MapIntToBytes_Int
+  - LbldefinedPrimitiveLookup(_,_)_MAP-INT-TO-INT-PRIMITIVE-SYMBOLIC_Bool_MapIntToInt_Int
+  - LbldefinedSigned(_,_)_WASM-DATA-COMMON_Bool_IValType_Int
+  - LbldefinedUnsigned(_,_)_WASM-DATA-COMMON_Bool_IValType_Int
+  - LbldeployTx
+  - LbldeployTxAux
+  - LbldetermineIsSCCallAfter
+  - LbldirectionalityChar(_)_STRING-COMMON_String_String
+  - LbldropAsyncLocalCall
+  - LbldropCallState
+  - LbldropWorldState
+  - Lblelem.drop__WASM-TEXT-COMMON-SYNTAX_PlainInstr_Index
+  - LblelemSegment2Indices(_,_,_)_WASM-TEXT_ElemSegment_ElemSegment_Int_Map
+  - LblelemSegment2Ints(_)_WASM-DATA-COMMON_Ints_ElemSegment
+  - LblencodeBytes(_,_)_BYTES-STRING-ENCODE_Bytes_String_String
+  - LblendFoundryImmediately
+  - LblesdtLocalBurn
+  - LblesdtLocalMint
+  - LblesdtMetadata
+  - LblesdtNftAddQuantity(_,_,_,_)_ESDT_InternalCmd_Bytes_Bytes_Int_Int
+  - LblesdtNftAddUri(_,_,_)_ESDT_InternalCmd_Bytes_Bytes_ListBytes
+  - LblesdtNftBurn(_,_,_,_)_ESDT_InternalCmd_Bytes_Bytes_Int_Int
+  - LblesdtNftCreate
+  - LblesdtTransfer
+  - LblexecuteAsyncLocalCall
+  - LblexecuteAsyncLocalCallback
+  - LblexecuteAsyncLocalCalls
+  - LblexpFloat(_)_FLOAT_Float_Float
+  - LblexponentBitsFloat(_)_FLOAT_Int_Float
+  - LblexponentFloat(_)_FLOAT_Int_Float
+  - Lblextends
+  - Lblextern
+  - Lblexternref
+  - LblextractLastEsdt(_,_)_ASYNC_List_Bytes_VMOutput
+  - LblextractLastEsdtAux(_)_ASYNC_List_TransferValue
+  - LblextractLastValue(_,_)_ASYNC_Int_Bytes_VMOutput
+  - LblextractLastValueAux(_)_ASYNC_Int_TransferValue
+  - Lblf32
+  - Lblf64
+  - LblfillList(_,_,_,_)_ASYNC-CALL_ListAsyncCall_ListAsyncCall_Int_Int_AsyncCall
+  - LblfillList(_,_,_,_)_LIST_List_List_Int_Int_KItem
+  - LblfillList(_,_,_,_)_LIST-BYTES_ListBytes_ListBytes_Int_Int_WrappedBytes
+  - LblfillList(_,_,_,_)_LIST-INT_ListInt_ListInt_Int_Int_WrappedInt
+  - LblfillList(_,_,_,_)_LIST-REF_ListRef_ListRef_Int_Int_RefVal
+  - LblfindChar(_,_,_)_STRING-COMMON_Int_String_String_Int
+  - LblfindString(_,_,_)_STRING-COMMON_Int_String_String_Int
+  - LblfinishExecuteOnDestContext
+  - LblfloatAdd
+  - LblfloatBinOp
+  - LblfloatCopysign
+  - LblfloatDiv
+  - LblfloatEq
+  - LblfloatGe
+  - LblfloatGt
+  - LblfloatLe
+  - LblfloatLt
+  - LblfloatMax
+  - LblfloatMin
+  - LblfloatMul
+  - LblfloatNe
+  - LblfloatRelOp
+  - LblfloatSub
+  - LblfloorFloat(_)_FLOAT_Float_Float
+  - LblfoundryAssert
+  - LblfoundryAssume
+  - LblfoundryCreateAccount(_,_,_)_KASMER_InternalInstr_BytesResult_Int_IntResult
+  - LblfoundryDeployContract(_,_,_,_,_,_)_KASMER_InternalInstr_BytesResult_Int_IntResult_BytesResult_ListBytesResult_Int
+  - LblfoundryRegisterNewAddress(_,_,_)_KASMER_InternalInstr_BytesResult_Int_BytesResult
+  - LblfoundryWriteToStorage_KASMER_InternalInstr
+  - Lblframe_____WASM_Frame_Int_ValTypes_ValStack_Map
+  - LblfreshId(_)_ID-COMMON_Id_Int
+  - LblfreshInt(_)_INT_Int_Int
+  - Lblfunc
+  - Lblfunc_WASM-DATA-COMMON-SYNTAX_AllocatedKind
+  - Lblfunc__WASM-TEXT-COMMON-SYNTAX_ElemList_ElemSegment
+  - LblfuncMeta
+  - Lblfuncref
+  - LblgatherTypes(_,_)_WASM_VecType_TypeKeyWord_TypeDecls
+  - LblgetArg(_,_)_ESDT_Bytes_ListBytes_Int
+  - LblgetArgUInt(_,_)_ESDT_Int_ListBytes_Int
+  - LblgetBigInt(_)_BIGINT-HELPERS_IntResult_Int
+  - LblgetBuffer(_)_MANBUFOPS_BytesResult_Int
+  - LblgetCallArgs(_,_)_ESDT_ListBytes_BuiltinFunction_ListBytes
+  - LblgetCallFunc(_,_)_ESDT_Bytes_BuiltinFunction_ListBytes
+  - LblgetCurrentESDTNFTNonce
+  - LblgetESDTLocalRoles
+  - LblgetElemType(_)_WASM-TEXT_RefValType_ElemList
+  - LblgetExitCode
+  - LblgetGeneratedCounterCell
+  - LblgetLatestNonce(_,_)_ESDT_Int_Bytes_Bytes
+  - Lblglobal.get__WASM-TEXT-COMMON-SYNTAX_PlainInstr_Index
+  - Lblglobal.set__WASM-TEXT-COMMON-SYNTAX_PlainInstr_Index
+  - Lblglobal_WASM-DATA-COMMON-SYNTAX_AllocatedKind
+  - Lblgrow__WASM_Instr_Int
+  - LblhostCall(_,_,_)_WASM-AUTO-ALLOCATE_Instr_String_String_FuncType
+  - Lbli32
+  - Lbli64
+  - LblidxLookup(_,_)_WASM-TEXT_Int_Map_Index
+  - Lblif___else__end__WASM-TEXT-COMMON-SYNTAX_BlockInstr_OptionalId_TypeDecls_Instrs_OptionalId_Instrs_OptionalId
+  - Lblif___end__WASM-TEXT-COMMON-SYNTAX_BlockInstr_OptionalId_TypeDecls_Instrs_OptionalId
+  - Lblinit_local___WASM-INTERNAL-SYNTAX_Instr_Int_Val
+  - Lblinit_locals__WASM-INTERNAL-SYNTAX_Instr_ValStack
+  - LblinitAccountCell
+  - LblinitAccountsCell
+  - LblinitAddressCell
+  - LblinitAsyncCallsCell
+  - LblinitBalanceCell
+  - LblinitBigIntHeapCell
+  - LblinitBufferHeapCell
+  - LblinitBytesStackCell
+  - LblinitCallArgsCell
+  - LblinitCallStackCell
+  - LblinitCallStateCell
+  - LblinitCallTypeCell
+  - LblinitCallValueCell
+  - LblinitCalleeCell
+  - LblinitCallerCell
+  - LblinitCheckedAccountsCell
+  - LblinitCodeCell
+  - LblinitCommandsCell
+  - LblinitContractModIdxCell
+  - LblinitContractModule(_)_ELROND-CONFIG_K_ModuleDecl
+  - LblinitCurBlockEpochCell
+  - LblinitCurBlockNonceCell
+  - LblinitCurBlockRandomSeedCell
+  - LblinitCurBlockRoundCell
+  - LblinitCurBlockTimestampCell
+  - LblinitCurFrameCell
+  - LblinitCurModIdxCell
+  - LblinitCurrentBlockInfoCell
+  - LblinitDeterministicMemoryGrowthCell
+  - LblinitEAddrCell
+  - LblinitETypeCell
+  - LblinitEValueCell
+  - LblinitElemAddrsCell
+  - LblinitElemIdsCell
+  - LblinitElemInstCell
+  - LblinitElemsCell
+  - LblinitElrondCell
+  - LblinitEsdtBalanceCell
+  - LblinitEsdtDataCell
+  - LblinitEsdtDatasCell
+  - LblinitEsdtIdCell
+  - LblinitEsdtLastNonceCell
+  - LblinitEsdtMetadataCell
+  - LblinitEsdtPropertiesCell
+  - LblinitEsdtRolesCell
+  - LblinitEsdtTransfersCell
+  - LblinitExitCodeCell
+  - LblinitExportsCell
+  - LblinitFAddrCell
+  - LblinitFCodeCell
+  - LblinitFLocalCell
+  - LblinitFModInstCell
+  - LblinitFTypeCell
+  - LblinitFoundryCell
+  - LblinitFuncAddrsCell
+  - LblinitFuncDefCell
+  - LblinitFuncIdCell
+  - LblinitFuncIdsCell
+  - LblinitFuncMetadataCell
+  - LblinitFuncsCell
+  - LblinitFunctionCell
+  - LblinitGAddrCell
+  - LblinitGMutCell
+  - LblinitGValueCell
+  - LblinitGasPriceCell
+  - LblinitGasProvidedCell
+  - LblinitGeneratedCounterCell
+  - LblinitGeneratedTopCell
+  - LblinitGlobIdsCell
+  - LblinitGlobalAddrsCell
+  - LblinitGlobalInstCell
+  - LblinitGlobalsCell
+  - LblinitInstrsCell
+  - LblinitInterimStatesCell
+  - LblinitKCell
+  - LblinitLocalIdsCell
+  - LblinitLocalsCell
+  - LblinitLoggingCell
+  - LblinitLogsCell
+  - LblinitMAddrCell
+  - LblinitMainStoreCell
+  - LblinitMandosCell
+  - LblinitMdataCell
+  - LblinitMemAddrsCell
+  - LblinitMemIdsCell
+  - LblinitMemInstCell
+  - LblinitMemsCell
+  - LblinitMmaxCell
+  - LblinitModIdxCell
+  - LblinitModuleFileNameCell
+  - LblinitModuleIdCell
+  - LblinitModuleIdsCell
+  - LblinitModuleInstCell
+  - LblinitModuleInstancesCell
+  - LblinitModuleMetadataCell
+  - LblinitModuleRegistryCell
+  - LblinitMsizeCell
+  - LblinitNewAddressesCell
+  - LblinitNextElemAddrCell
+  - LblinitNextElemIdxCell
+  - LblinitNextFuncAddrCell
+  - LblinitNextFuncIdxCell
+  - LblinitNextGlobAddrCell
+  - LblinitNextGlobIdxCell
+  - LblinitNextMemAddrCell
+  - LblinitNextModuleIdxCell
+  - LblinitNextTabAddrCell
+  - LblinitNextTabIdxCell
+  - LblinitNextTypeIdxCell
+  - LblinitNodeCell
+  - LblinitNonceCell
+  - LblinitOutCell
+  - LblinitOutputAccountsCell
+  - LblinitOwnerAddressCell
+  - LblinitPrankCell
+  - LblinitPrevBlockEpochCell
+  - LblinitPrevBlockNonceCell
+  - LblinitPrevBlockRandomSeedCell
+  - LblinitPrevBlockRoundCell
+  - LblinitPrevBlockTimestampCell
+  - LblinitPreviousBlockInfoCell
+  - LblinitStorageCell
+  - LblinitTAddrCell
+  - LblinitTabAddrsCell
+  - LblinitTabIdsCell
+  - LblinitTabInstCell
+  - LblinitTabsCell
+  - LblinitTdataCell
+  - LblinitTmaxCell
+  - LblinitTxCountCell
+  - LblinitTxHashCell
+  - LblinitTypeIdsCell
+  - LblinitTypesCell
+  - LblinitValstackCell
+  - LblinitVmInputCell
+  - LblinitVmOutputCell
+  - LblinitWasmCell
+  - LblinitWasmStoreCell
+  - LblintAdd
+  - LblintAnd
+  - LblintBinOp
+  - LblintDiv_s
+  - LblintDiv_u
+  - LblintEq
+  - LblintGe_s
+  - LblintGe_u
+  - LblintGt_s
+  - LblintGt_u
+  - LblintLe_s
+  - LblintLe_u
+  - LblintLt_s
+  - LblintLt_u
+  - LblintMul
+  - LblintNe
+  - LblintOr
+  - LblintRelOp
+  - LblintRem_s
+  - LblintRem_u
+  - LblintRotl
+  - LblintRotr
+  - LblintShl
+  - LblintShr_s
+  - LblintShr_u
+  - LblintSub
+  - LblintXor
+  - LblintersectSet(_,_)_SET_Set_Set_Set
+  - Lblis#Layout
+  - LblisAccountCell
+  - LblisAccountCellFragment
+  - LblisAccountCellMap
+  - LblisAccounts
+  - LblisAccountsCell
+  - LblisAccountsCellFragment
+  - LblisAccountsCellOpt
+  - LblisAddress
+  - LblisAddressCell
+  - LblisAddressCellOpt
+  - LblisAddressNonce
+  - LblisAlignArg
+  - LblisAlloc
+  - LblisAllocatedKind
+  - LblisAsyncCall
+  - LblisAsyncCallStatus
+  - LblisAsyncCallsCell
+  - LblisAsyncCallsCellOpt
+  - LblisBYTES
+  - LblisBalanceCell
+  - LblisBalanceCellOpt
+  - LblisBigIntHeapCell
+  - LblisBigIntHeapCellOpt
+  - LblisBlockInfo
+  - LblisBlockInstr
+  - LblisBlockMetaData
+  - LblisBool
+  - LblisBufferHeapCell
+  - LblisBufferHeapCellOpt
+  - LblisBuiltin(_)_ELROND-NODE_Bool_String
+  - LblisBuiltin(_)_ELROND-NODE_Bool_WasmStringToken
+  - LblisBuiltinFunction
+  - LblisBytes
+  - LblisBytesOp
+  - LblisBytesResult
+  - LblisBytesStack
+  - LblisBytesStackCell
+  - LblisBytesStackCellOpt
+  - LblisCallArgsCell
+  - LblisCallArgsCellOpt
+  - LblisCallAsync(_)_ASYNC-HELPERS_Bool_CallType
+  - LblisCallAsyncOnStack(_)_ASYNC_Bool_List
+  - LblisCallStackCell
+  - LblisCallStackCellOpt
+  - LblisCallStateAsync(_)_ASYNC_Bool_CallStateCell
+  - LblisCallStateCell
+  - LblisCallStateCellFragment
+  - LblisCallStateCellOpt
+  - LblisCallType
+  - LblisCallTypeCell
+  - LblisCallTypeCellOpt
+  - LblisCallValueCell
+  - LblisCallValueCellOpt
+  - LblisCalleeCell
+  - LblisCalleeCellOpt
+  - LblisCallerCell
+  - LblisCallerCellOpt
+  - LblisCheckedAccountsCell
+  - LblisCheckedAccountsCellOpt
+  - LblisCode
+  - LblisCodeCell
+  - LblisCodeCellOpt
+  - LblisCommandsCell
+  - LblisCommandsCellOpt
+  - LblisContext
+  - LblisContractModIdxCell
+  - LblisContractModIdxCellOpt
+  - LblisCurBlockEpochCell
+  - LblisCurBlockEpochCellOpt
+  - LblisCurBlockNonceCell
+  - LblisCurBlockNonceCellOpt
+  - LblisCurBlockRandomSeedCell
+  - LblisCurBlockRandomSeedCellOpt
+  - LblisCurBlockRoundCell
+  - LblisCurBlockRoundCellOpt
+  - LblisCurBlockTimestampCell
+  - LblisCurBlockTimestampCellOpt
+  - LblisCurFrameCell
+  - LblisCurFrameCellFragment
+  - LblisCurFrameCellOpt
+  - LblisCurModIdxCell
+  - LblisCurModIdxCellOpt
+  - LblisCurrentBlockInfoCell
+  - LblisCurrentBlockInfoCellFragment
+  - LblisCurrentBlockInfoCellOpt
+  - LblisCvtOp
+  - LblisCvtf32Op
+  - LblisCvtf64Op
+  - LblisCvti32Op
+  - LblisCvti64Op
+  - LblisDataDefn
+  - LblisDataString
+  - LblisDefn
+  - LblisDefns
+  - LblisDeterministicMemoryGrowthCell
+  - LblisDeterministicMemoryGrowthCellOpt
+  - LblisEAddrCell
+  - LblisEAddrCellOpt
+  - LblisESDTLocalRole
+  - LblisESDTMetadata
+  - LblisESDTTransfer
+  - LblisETypeCell
+  - LblisETypeCellOpt
+  - LblisEValueCell
+  - LblisEValueCellOpt
+  - LblisElemAddrsCell
+  - LblisElemAddrsCellOpt
+  - LblisElemDefn
+  - LblisElemExpr
+  - LblisElemExprs
+  - LblisElemIdsCell
+  - LblisElemIdsCellOpt
+  - LblisElemInstCell
+  - LblisElemInstCellFragment
+  - LblisElemInstCellMap
+  - LblisElemList
+  - LblisElemMode
+  - LblisElemSegment
+  - LblisElemsCell
+  - LblisElemsCellFragment
+  - LblisElemsCellOpt
+  - LblisElrondCell
+  - LblisElrondCellFragment
+  - LblisElrondCellOpt
+  - LblisEmptyStmt
+  - LblisEmptyStmts
+  - LblisEndianness
+  - LblisError
+  - LblisEsdtBalanceCell
+  - LblisEsdtBalanceCellOpt
+  - LblisEsdtDataCell
+  - LblisEsdtDataCellFragment
+  - LblisEsdtDataCellMap
+  - LblisEsdtDatasCell
+  - LblisEsdtDatasCellFragment
+  - LblisEsdtDatasCellOpt
+  - LblisEsdtIdCell
+  - LblisEsdtIdCellOpt
+  - LblisEsdtLastNonceCell
+  - LblisEsdtLastNonceCellOpt
+  - LblisEsdtMetadataCell
+  - LblisEsdtMetadataCellOpt
+  - LblisEsdtPropertiesCell
+  - LblisEsdtPropertiesCellOpt
+  - LblisEsdtRolesCell
+  - LblisEsdtRolesCellOpt
+  - LblisEsdtTransfersCell
+  - LblisEsdtTransfersCellOpt
+  - LblisExceptionCode
+  - LblisExitCodeCell
+  - LblisExitCodeCellOpt
+  - LblisExportDefn
+  - LblisExportsCell
+  - LblisExportsCellOpt
+  - LblisExtendS
+  - LblisExternval
+  - LblisFAddrCell
+  - LblisFAddrCellOpt
+  - LblisFBinOp
+  - LblisFCodeCell
+  - LblisFCodeCellOpt
+  - LblisFLocalCell
+  - LblisFLocalCellOpt
+  - LblisFModInstCell
+  - LblisFModInstCellOpt
+  - LblisFRelOp
+  - LblisFTypeCell
+  - LblisFTypeCellOpt
+  - LblisFUnOp
+  - LblisFVal
+  - LblisFValType
+  - LblisFloat
+  - LblisFoldedInstr
+  - LblisFoundryCell
+  - LblisFoundryCellFragment
+  - LblisFoundryCellOpt
+  - LblisFrame
+  - LblisFuncAddrsCell
+  - LblisFuncAddrsCellOpt
+  - LblisFuncDefCell
+  - LblisFuncDefCellFragment
+  - LblisFuncDefCellMap
+  - LblisFuncDefn
+  - LblisFuncIdCell
+  - LblisFuncIdCellOpt
+  - LblisFuncIdsCell
+  - LblisFuncIdsCellOpt
+  - LblisFuncMetadata
+  - LblisFuncMetadataCell
+  - LblisFuncMetadataCellFragment
+  - LblisFuncMetadataCellOpt
+  - LblisFuncSpec
+  - LblisFuncType
+  - LblisFuncsCell
+  - LblisFuncsCellFragment
+  - LblisFuncsCellOpt
+  - LblisFunctionCell
+  - LblisFunctionCellOpt
+  - LblisG1Point
+  - LblisG2Point
+  - LblisGAddrCell
+  - LblisGAddrCellOpt
+  - LblisGMutCell
+  - LblisGMutCellOpt
+  - LblisGValueCell
+  - LblisGValueCellOpt
+  - LblisGasPriceCell
+  - LblisGasPriceCellOpt
+  - LblisGasProvidedCell
+  - LblisGasProvidedCellOpt
+  - LblisGeneratedCounterCell
+  - LblisGeneratedCounterCellOpt
+  - LblisGeneratedTopCell
+  - LblisGeneratedTopCellFragment
+  - LblisGlobIdsCell
+  - LblisGlobIdsCellOpt
+  - LblisGlobalAddrsCell
+  - LblisGlobalAddrsCellOpt
+  - LblisGlobalDefn
+  - LblisGlobalInstCell
+  - LblisGlobalInstCellFragment
+  - LblisGlobalInstCellMap
+  - LblisGlobalSpec
+  - LblisGlobalType
+  - LblisGlobalsCell
+  - LblisGlobalsCellFragment
+  - LblisGlobalsCellOpt
+  - LblisHashBytesStackInstr
+  - LblisHeapType
+  - LblisIBinOp
+  - LblisIOError
+  - LblisIOFile
+  - LblisIOInt
+  - LblisIOString
+  - LblisIRelOp
+  - LblisIUnOp
+  - LblisIVal
+  - LblisIValType
+  - LblisId
+  - LblisIdentifier
+  - LblisIdentifierToken
+  - LblisImportDefn
+  - LblisImportDesc
+  - LblisIndex
+  - LblisInfinite(_)_FLOAT_Bool_Float
+  - LblisInlineExport
+  - LblisInlineImport
+  - LblisInstr
+  - LblisInstrs
+  - LblisInstrsCell
+  - LblisInstrsCellOpt
+  - LblisInt
+  - LblisIntResult
+  - LblisInterimStatesCell
+  - LblisInterimStatesCellOpt
+  - LblisInternalCmd
+  - LblisInternalInstr
+  - LblisInts
+  - LblisIternalInstr
+  - LblisK
+  - LblisKCell
+  - LblisKCellOpt
+  - LblisKConfigVar
+  - LblisKItem
+  - LblisLabel
+  - LblisLimits
+  - LblisList
+  - LblisListAsyncCall
+  - LblisListBytes
+  - LblisListBytesResult
+  - LblisListIndex(_,_)_WASM-DATA-TOOLS_Bool_Int_ListInt
+  - LblisListInt
+  - LblisListRef
+  - LblisListResult
+  - LblisLoadOp
+  - LblisLoadOpM
+  - LblisLocalDecl
+  - LblisLocalDecls
+  - LblisLocalIdsCell
+  - LblisLocalIdsCellOpt
+  - LblisLocalsCell
+  - LblisLocalsCellOpt
+  - LblisLogEntry
+  - LblisLoggingCell
+  - LblisLoggingCellOpt
+  - LblisLogsCell
+  - LblisLogsCellOpt
+  - LblisMAddrCell
+  - LblisMAddrCellOpt
+  - LblisMainStoreCell
+  - LblisMainStoreCellFragment
+  - LblisMainStoreCellOpt
+  - LblisMandosCell
+  - LblisMandosCellFragment
+  - LblisMandosCellOpt
+  - LblisMap
+  - LblisMapBytesToBytes
+  - LblisMapIntToBytes
+  - LblisMapIntToInt
+  - LblisMdataCell
+  - LblisMdataCellOpt
+  - LblisMemAddrsCell
+  - LblisMemAddrsCellOpt
+  - LblisMemArg
+  - LblisMemIdsCell
+  - LblisMemIdsCellOpt
+  - LblisMemInstCell
+  - LblisMemInstCellFragment
+  - LblisMemInstCellMap
+  - LblisMemType
+  - LblisMemoryDefn
+  - LblisMemorySpec
+  - LblisMemsCell
+  - LblisMemsCellFragment
+  - LblisMemsCellOpt
+  - LblisMmaxCell
+  - LblisMmaxCellOpt
+  - LblisModIdxCell
+  - LblisModIdxCellOpt
+  - LblisModuleDecl
+  - LblisModuleFileNameCell
+  - LblisModuleFileNameCellOpt
+  - LblisModuleIdCell
+  - LblisModuleIdCellOpt
+  - LblisModuleIdsCell
+  - LblisModuleIdsCellOpt
+  - LblisModuleInstCell
+  - LblisModuleInstCellFragment
+  - LblisModuleInstCellMap
+  - LblisModuleInstancesCell
+  - LblisModuleInstancesCellFragment
+  - LblisModuleInstancesCellOpt
+  - LblisModuleMetadata
+  - LblisModuleMetadataCell
+  - LblisModuleMetadataCellFragment
+  - LblisModuleMetadataCellOpt
+  - LblisModuleRegistryCell
+  - LblisModuleRegistryCellOpt
+  - LblisMsizeCell
+  - LblisMsizeCellOpt
+  - LblisMultilevelAsync(_,_)_ASYNC_Bool_CallType_List
+  - LblisMut
+  - LblisNaN(_)_FLOAT_Bool_Float
+  - LblisNewAddressesCell
+  - LblisNewAddressesCellOpt
+  - LblisNextElemAddrCell
+  - LblisNextElemAddrCellOpt
+  - LblisNextElemIdxCell
+  - LblisNextElemIdxCellOpt
+  - LblisNextFuncAddrCell
+  - LblisNextFuncAddrCellOpt
+  - LblisNextFuncIdxCell
+  - LblisNextFuncIdxCellOpt
+  - LblisNextGlobAddrCell
+  - LblisNextGlobAddrCellOpt
+  - LblisNextGlobIdxCell
+  - LblisNextGlobIdxCellOpt
+  - LblisNextMemAddrCell
+  - LblisNextMemAddrCellOpt
+  - LblisNextModuleIdxCell
+  - LblisNextModuleIdxCellOpt
+  - LblisNextTabAddrCell
+  - LblisNextTabAddrCellOpt
+  - LblisNextTabIdxCell
+  - LblisNextTabIdxCellOpt
+  - LblisNextTypeIdxCell
+  - LblisNextTypeIdxCellOpt
+  - LblisNodeCell
+  - LblisNodeCellFragment
+  - LblisNodeCellOpt
+  - LblisNonceCell
+  - LblisNonceCellOpt
+  - LblisNumber
+  - LblisOffset
+  - LblisOffsetArg
+  - LblisOptionalId
+  - LblisOptionalInt
+  - LblisOptionalString
+  - LblisOutCell
+  - LblisOutCellOpt
+  - LblisOutputAccount
+  - LblisOutputAccountsCell
+  - LblisOutputAccountsCellOpt
+  - LblisOutputTransfer
+  - LblisOwnerAddressCell
+  - LblisOwnerAddressCellOpt
+  - LblisPlainInstr
+  - LblisPrankCell
+  - LblisPrankCellOpt
+  - LblisPrevBlockEpochCell
+  - LblisPrevBlockEpochCellOpt
+  - LblisPrevBlockNonceCell
+  - LblisPrevBlockNonceCellOpt
+  - LblisPrevBlockRandomSeedCell
+  - LblisPrevBlockRandomSeedCellOpt
+  - LblisPrevBlockRoundCell
+  - LblisPrevBlockRoundCellOpt
+  - LblisPrevBlockTimestampCell
+  - LblisPrevBlockTimestampCellOpt
+  - LblisPreviousBlockInfoCell
+  - LblisPreviousBlockInfoCellFragment
+  - LblisPreviousBlockInfoCellOpt
+  - LblisRefVal
+  - LblisRefValType
+  - LblisReturnCode
+  - LblisSBItem
+  - LblisSBItemChunk
+  - LblisSet
+  - LblisSignedness
+  - LblisSparseBytes
+  - LblisStartDefn
+  - LblisStep
+  - LblisSteps
+  - LblisStmt
+  - LblisStmts
+  - LblisStorageCell
+  - LblisStorageCellOpt
+  - LblisStoreOp
+  - LblisStoreOpM
+  - LblisStream
+  - LblisString
+  - LblisTAddrCell
+  - LblisTAddrCellOpt
+  - LblisTabAddrsCell
+  - LblisTabAddrsCellOpt
+  - LblisTabIdsCell
+  - LblisTabIdsCellOpt
+  - LblisTabInstCell
+  - LblisTabInstCellFragment
+  - LblisTabInstCellMap
+  - LblisTableDefn
+  - LblisTableElemType
+  - LblisTableSpec
+  - LblisTableType
+  - LblisTableUse
+  - LblisTabsCell
+  - LblisTabsCellFragment
+  - LblisTabsCellOpt
+  - LblisTdataCell
+  - LblisTdataCellOpt
+  - LblisTestOp
+  - LblisTextFormatGlobalType
+  - LblisTextLimits
+  - LblisThrowException
+  - LblisTmaxCell
+  - LblisTmaxCellOpt
+  - LblisTransferTx
+  - LblisTransferValue
+  - LblisTxCountCell
+  - LblisTxCountCellOpt
+  - LblisTxHashCell
+  - LblisTxHashCellOpt
+  - LblisType
+  - LblisTypeDecl
+  - LblisTypeDecls
+  - LblisTypeDefn
+  - LblisTypeIdsCell
+  - LblisTypeIdsCellOpt
+  - LblisTypeKeyWord
+  - LblisTypeUse
+  - LblisTypesCell
+  - LblisTypesCellOpt
+  - LblisTypesInfo
+  - LblisVMOutput
+  - LblisVal
+  - LblisValStack
+  - LblisValType
+  - LblisValTypes
+  - LblisValidPoint(_)_KRYPTO_Bool_G1Point
+  - LblisValidPoint(_)_KRYPTO_Bool_G2Point
+  - LblisValidatorRewardTx
+  - LblisValstackCell
+  - LblisValstackCellOpt
+  - LblisVecType
+  - LblisVmInputCell
+  - LblisVmInputCellFragment
+  - LblisVmInputCellOpt
+  - LblisVmOutputCell
+  - LblisVmOutputCellOpt
+  - LblisWasmCell
+  - LblisWasmCellFragment
+  - LblisWasmCellOpt
+  - LblisWasmInt
+  - LblisWasmIntToken
+  - LblisWasmStoreCell
+  - LblisWasmStoreCellOpt
+  - LblisWasmString
+  - LblisWasmStringToken
+  - LblisWrappedBytes
+  - LblisWrappedInt
+  - Lblite
+  - LbljoinUntil(_,_,_)_SPARSE-BYTES_SparseBytes_Bytes_SparseBytes_Int
+  - LblkeyWithNonce(_,_)_ESDT_Bytes_Bytes_Int
+  - Lblkeys(_)_MAP_Set_Map
+  - Lblkeys(_)_MAP-BYTES-TO-BYTES_Set_MapBytesToBytes
+  - Lblkeys(_)_MAP-INT-TO-BYTES_Set_MapIntToBytes
+  - Lblkeys(_)_MAP-INT-TO-INT_Set_MapIntToInt
+  - Lblkeys_list(_)_MAP_List_Map
+  - Lblkeys_list(_)_MAP-BYTES-TO-BYTES_ListBytes_MapBytesToBytes
+  - Lblkeys_list(_)_MAP-INT-TO-BYTES_List_MapIntToBytes
+  - Lblkeys_list(_)_MAP-INT-TO-INT_ListInt_MapIntToInt
+  - Lbllabel_{_}__WASM_Label_VecType_Instrs_ValStack
+  - LbllastTransfer(_,_)_ASYNC_TransferValue_Bytes_Map
+  - LbllastTransferAux(_)_ASYNC_TransferValue_KItem
+  - LbllengthBytes(_)_BYTES-HOOKED_Int_Bytes
+  - LbllengthString(_)_STRING-COMMON_Int_String
+  - LbllengthValTypes(_)_WASM-DATA-COMMON_Int_ValTypes
+  - LbllimitsMin
+  - LbllimitsMinMax
+  - LbllistIndex
+  - LbllistInt
+  - LbllistLocalDecl
+  - LbllistLookupTotal
+  - LbllistTypeDecl
+  - LbllistValTypes
+  - LbllistWasmString
+  - LbllittleEndianBytes
+  - Lblload{____}_WASM_Instr_IValType_Int_Int_Signedness
+  - Lblload{_____}_WASM_Instr_IValType_Int_Int_Signedness_Int
+  - Lblload{_____}_WASM_Instr_IValType_Int_Int_Signedness_SparseBytes
+  - LblloadOpLoad
+  - LblloadOpLoad16_s
+  - LblloadOpLoad16_u
+  - LblloadOpLoad32_s
+  - LblloadOpLoad32_u
+  - LblloadOpLoad8_s
+  - LblloadOpLoad8_u
+  - Lbllocal.get__WASM-TEXT-COMMON-SYNTAX_PlainInstr_Index
+  - Lbllocal.set__WASM-TEXT-COMMON-SYNTAX_PlainInstr_Index
+  - Lbllocal.tee__WASM-TEXT-COMMON-SYNTAX_PlainInstr_Index
+  - Lbllocal__WASM-TEXT-COMMON-SYNTAX_LocalDecl_ValTypes
+  - Lbllocal___WASM-TEXT-COMMON-SYNTAX_LocalDecl_Identifier_ValType
+  - Lbllocals2vectype(_)_WASM-TEXT_VecType_LocalDecls
+  - Lbllog2Int(_)_INT-COMMON_Int_Int
+  - LbllogEntry
+  - LbllogFloat(_)_FLOAT_Float_Float
+  - Lblloop___end__WASM-TEXT-COMMON-SYNTAX_BlockInstr_OptionalId_TypeDecls_Instrs_OptionalId
+  - LblmakeList(_,_)_LIST_List_Int_KItem
+  - LblmakeListAsyncCall(_,_)_ASYNC-CALL_ListAsyncCall_Int_AsyncCall
+  - LblmakeListBytes(_,_)_LIST-BYTES_ListBytes_Int_WrappedBytes
+  - LblmakeListInt(_,_)_LIST-INT_ListInt_Int_WrappedInt
+  - LblmakeListRef(_,_)_LIST-REF_ListRef_Int_RefVal
+  - LblmandosSteps
+  - LblmaxFloat(_,_)_FLOAT_Float_Float_Float
+  - LblmaxInt(_,_)_INT-COMMON_Int_Int_Int
+  - LblmaxSInt32_ELROND-CONFIG_Int
+  - LblmaxSInt64_ELROND-CONFIG_Int
+  - LblmaxUInt32_ELROND-CONFIG_Int
+  - LblmaxUInt64_ELROND-CONFIG_Int
+  - LblmaxValueFloat(_,_)_FLOAT_Float_Int_Int
+  - Lblmemory_WASM-DATA-COMMON-SYNTAX_AllocatedKind
+  - LblmemsetBytes(_,_,_,_)_BYTES-HOOKED_Bytes_Bytes_Int_Int_Int
+  - LblminFloat(_,_)_FLOAT_Float_Float_Float
+  - LblminInt(_,_)_INT-COMMON_Int_Int_Int
+  - LblminSInt32_ELROND-CONFIG_Int
+  - LblminSInt64_ELROND-CONFIG_Int
+  - LblminUInt32_ELROND-CONFIG_Int
+  - LblminUInt64_ELROND-CONFIG_Int
+  - LblminValueFloat(_,_)_FLOAT_Float_Int_Int
+  - LblmkCall(_,_,_)_ELROND-NODE_InternalCmd_Bytes_WasmString_VmInputCell
+  - LblmkEsdtTransferFromResults(_,_,_)_MANAGEDCONVERSIONS_ListResult_BytesResult_IntResult_IntResult
+  - LblmkTxHash(_)_MANDOS_Bytes_Int
+  - LblmkVmInputDeploy(_,_,_,_,_,_)_MANDOS_VmInputCell_Bytes_Int_ListBytes_Int_Int_Bytes
+  - LblmkVmInputEsdtExec(_,_,_,_,_,_)_ESDT_VmInputCell_Bytes_BuiltinFunction_ListBytes_Int_Int_Bytes
+  - LblmkVmInputQuery(_,_,_)_MANDOS_VmInputCell_Bytes_ListBytes_Bytes
+  - LblmkVmInputSCCall(_,_,_,_,_,_,_)_MANDOS_VmInputCell_Bytes_ListBytes_Int_List_Int_Int_Bytes
+  - LblmoduleMeta
+  - LblmoveNFTToDestination(_,_,_,_)_ESDT_InternalCmd_Bytes_Bytes_Bytes_Int
+  - LblmutConst
+  - LblmutVar
+  - LblnewAddress
+  - LblnewAddressAux
+  - LblnewEmptyModule__WASM-AUTO-ALLOCATE_Stmt_WasmString
+  - LblnewUUID_STRING-COMMON_String
+  - LblnewWasmInstance
+  - LblnoAccountsCell
+  - LblnoAddressCell
+  - LblnoAsyncCallsCell
+  - LblnoBalanceCell
+  - LblnoBigIntHeapCell
+  - LblnoBufferHeapCell
+  - LblnoBytesStackCell
+  - LblnoCallArgsCell
+  - LblnoCallStackCell
+  - LblnoCallStateCell
+  - LblnoCallTypeCell
+  - LblnoCallValueCell
+  - LblnoCalleeCell
+  - LblnoCallerCell
+  - LblnoCheckedAccountsCell
+  - LblnoCodeCell
+  - LblnoCommandsCell
+  - LblnoContractModIdxCell
+  - LblnoCurBlockEpochCell
+  - LblnoCurBlockNonceCell
+  - LblnoCurBlockRandomSeedCell
+  - LblnoCurBlockRoundCell
+  - LblnoCurBlockTimestampCell
+  - LblnoCurFrameCell
+  - LblnoCurModIdxCell
+  - LblnoCurrentBlockInfoCell
+  - LblnoDeterministicMemoryGrowthCell
+  - LblnoEAddrCell
+  - LblnoETypeCell
+  - LblnoEValueCell
+  - LblnoElemAddrsCell
+  - LblnoElemIdsCell
+  - LblnoElemsCell
+  - LblnoElrondCell
+  - LblnoEsdtBalanceCell
+  - LblnoEsdtDatasCell
+  - LblnoEsdtIdCell
+  - LblnoEsdtLastNonceCell
+  - LblnoEsdtMetadataCell
+  - LblnoEsdtPropertiesCell
+  - LblnoEsdtRolesCell
+  - LblnoEsdtTransfersCell
+  - LblnoExitCodeCell
+  - LblnoExportsCell
+  - LblnoFAddrCell
+  - LblnoFCodeCell
+  - LblnoFLocalCell
+  - LblnoFModInstCell
+  - LblnoFTypeCell
+  - LblnoFoundryCell
+  - LblnoFuncAddrsCell
+  - LblnoFuncIdCell
+  - LblnoFuncIdsCell
+  - LblnoFuncMetadataCell
+  - LblnoFuncsCell
+  - LblnoFunctionCell
+  - LblnoGAddrCell
+  - LblnoGMutCell
+  - LblnoGValueCell
+  - LblnoGasPriceCell
+  - LblnoGasProvidedCell
+  - LblnoGeneratedCounterCell
+  - LblnoGlobIdsCell
+  - LblnoGlobalAddrsCell
+  - LblnoGlobalsCell
+  - LblnoInstrsCell
+  - LblnoInterimStatesCell
+  - LblnoKCell
+  - LblnoLocalIdsCell
+  - LblnoLocalsCell
+  - LblnoLoggingCell
+  - LblnoLogsCell
+  - LblnoMAddrCell
+  - LblnoMainStoreCell
+  - LblnoMandosCell
+  - LblnoMdataCell
+  - LblnoMemAddrsCell
+  - LblnoMemIdsCell
+  - LblnoMemsCell
+  - LblnoMmaxCell
+  - LblnoModIdxCell
+  - LblnoModuleFileNameCell
+  - LblnoModuleIdCell
+  - LblnoModuleIdsCell
+  - LblnoModuleInstancesCell
+  - LblnoModuleMetadataCell
+  - LblnoModuleRegistryCell
+  - LblnoMsizeCell
+  - LblnoNewAddressesCell
+  - LblnoNextElemAddrCell
+  - LblnoNextElemIdxCell
+  - LblnoNextFuncAddrCell
+  - LblnoNextFuncIdxCell
+  - LblnoNextGlobAddrCell
+  - LblnoNextGlobIdxCell
+  - LblnoNextMemAddrCell
+  - LblnoNextModuleIdxCell
+  - LblnoNextTabAddrCell
+  - LblnoNextTabIdxCell
+  - LblnoNextTypeIdxCell
+  - LblnoNodeCell
+  - LblnoNonceCell
+  - LblnoOutCell
+  - LblnoOutputAccountsCell
+  - LblnoOwnerAddressCell
+  - LblnoPrankCell
+  - LblnoPrevBlockEpochCell
+  - LblnoPrevBlockNonceCell
+  - LblnoPrevBlockRandomSeedCell
+  - LblnoPrevBlockRoundCell
+  - LblnoPrevBlockTimestampCell
+  - LblnoPreviousBlockInfoCell
+  - LblnoStorageCell
+  - LblnoTAddrCell
+  - LblnoTabAddrsCell
+  - LblnoTabIdsCell
+  - LblnoTabsCell
+  - LblnoTdataCell
+  - LblnoTmaxCell
+  - LblnoTxCountCell
+  - LblnoTxHashCell
+  - LblnoTypeIdsCell
+  - LblnoTypesCell
+  - LblnoValstackCell
+  - LblnoVmInputCell
+  - LblnoVmOutputCell
+  - LblnoWasmCell
+  - LblnoWasmStoreCell
+  - LblnonZeroOutputTransfer(_)_ELROND-NODE_Bool_OutputTransfer
+  - LblnotBool_
+  - Lbloffset=__WASM-TEXT-COMMON-SYNTAX_OffsetArg_WasmInt
+  - LblordChar(_)_STRING-COMMON_Int_String
+  - LblpadLeftBytes(_,_,_)_BYTES-HOOKED_Bytes_Bytes_Int_Int
+  - LblpadRightBytes(_,_,_)_BYTES-HOOKED_Bytes_Bytes_Int_Int
+  - Lblparam_WASM-COMMON-SYNTAX_TypeKeyWord
+  - Lblparam___WASM-COMMON-SYNTAX_TypeDecl_Identifier_ValType
+  - LblparseESDTTransfers(_,_)_ESDT_List_BuiltinFunction_ListBytes
+  - LblparseESDTTransfersH(_,_)_ESDT_List_Int_ListBytes
+  - LblpopCallState
+  - LblpopWorldState
+  - LblprecisionFloat(_)_FLOAT_Int_Float
+  - LblprepareIndirectContractCallInput(_,_,_,_,_,_)_BASEOPS_VmInputCell_Bytes_Int_List_Int_ListBytes_Bytes
+  - LblprocessBuiltinFunction
+  - Lblproject:AccountCell
+  - Lblproject:AccountCellFragment
+  - Lblproject:AccountCellMap
+  - Lblproject:Accounts
+  - Lblproject:AccountsCell
+  - Lblproject:AccountsCellFragment
+  - Lblproject:AccountsCellOpt
+  - Lblproject:Address
+  - Lblproject:AddressCell
+  - Lblproject:AddressCellOpt
+  - Lblproject:AddressNonce
+  - Lblproject:AlignArg
+  - Lblproject:Alloc
+  - Lblproject:AllocatedKind
+  - Lblproject:AsyncCall
+  - Lblproject:AsyncCall:args
+  - Lblproject:AsyncCall:closure
+  - Lblproject:AsyncCall:dest
+  - Lblproject:AsyncCall:errorCallback
+  - Lblproject:AsyncCall:func
+  - Lblproject:AsyncCall:gas
+  - Lblproject:AsyncCall:successCallback
+  - Lblproject:AsyncCall:valueBytes
+  - Lblproject:AsyncCallStatus
+  - Lblproject:AsyncCallsCell
+  - Lblproject:AsyncCallsCellOpt
+  - Lblproject:BYTES
+  - Lblproject:BalanceCell
+  - Lblproject:BalanceCellOpt
+  - Lblproject:BigIntHeapCell
+  - Lblproject:BigIntHeapCellOpt
+  - Lblproject:BlockInfo
+  - Lblproject:BlockInstr
+  - Lblproject:BlockMetaData
+  - Lblproject:Bool
+  - Lblproject:BufferHeapCell
+  - Lblproject:BufferHeapCellOpt
+  - Lblproject:BuiltinFunction
+  - Lblproject:Bytes
+  - Lblproject:BytesOp
+  - Lblproject:BytesResult
+  - Lblproject:BytesStack
+  - Lblproject:BytesStackCell
+  - Lblproject:BytesStackCellOpt
+  - Lblproject:CallArgsCell
+  - Lblproject:CallArgsCellOpt
+  - Lblproject:CallStackCell
+  - Lblproject:CallStackCellOpt
+  - Lblproject:CallStateCell
+  - Lblproject:CallStateCellFragment
+  - Lblproject:CallStateCellOpt
+  - Lblproject:CallType
+  - Lblproject:CallTypeCell
+  - Lblproject:CallTypeCellOpt
+  - Lblproject:CallValueCell
+  - Lblproject:CallValueCellOpt
+  - Lblproject:CalleeCell
+  - Lblproject:CalleeCellOpt
+  - Lblproject:CallerCell
+  - Lblproject:CallerCellOpt
+  - Lblproject:CheckedAccountsCell
+  - Lblproject:CheckedAccountsCellOpt
+  - Lblproject:Code
+  - Lblproject:CodeCell
+  - Lblproject:CodeCellOpt
+  - Lblproject:CommandsCell
+  - Lblproject:CommandsCellOpt
+  - Lblproject:Context
+  - Lblproject:ContractModIdxCell
+  - Lblproject:ContractModIdxCellOpt
+  - Lblproject:CurBlockEpochCell
+  - Lblproject:CurBlockEpochCellOpt
+  - Lblproject:CurBlockNonceCell
+  - Lblproject:CurBlockNonceCellOpt
+  - Lblproject:CurBlockRandomSeedCell
+  - Lblproject:CurBlockRandomSeedCellOpt
+  - Lblproject:CurBlockRoundCell
+  - Lblproject:CurBlockRoundCellOpt
+  - Lblproject:CurBlockTimestampCell
+  - Lblproject:CurBlockTimestampCellOpt
+  - Lblproject:CurFrameCell
+  - Lblproject:CurFrameCellFragment
+  - Lblproject:CurFrameCellOpt
+  - Lblproject:CurModIdxCell
+  - Lblproject:CurModIdxCellOpt
+  - Lblproject:CurrentBlockInfoCell
+  - Lblproject:CurrentBlockInfoCellFragment
+  - Lblproject:CurrentBlockInfoCellOpt
+  - Lblproject:CvtOp
+  - Lblproject:Cvtf32Op
+  - Lblproject:Cvtf64Op
+  - Lblproject:Cvti32Op
+  - Lblproject:Cvti64Op
+  - Lblproject:DataDefn
+  - Lblproject:DataString
+  - Lblproject:Defn
+  - Lblproject:Defns
+  - Lblproject:DeterministicMemoryGrowthCell
+  - Lblproject:DeterministicMemoryGrowthCellOpt
+  - Lblproject:EAddrCell
+  - Lblproject:EAddrCellOpt
+  - Lblproject:ESDTLocalRole
+  - Lblproject:ESDTMetadata
+  - Lblproject:ESDTTransfer
+  - Lblproject:ETypeCell
+  - Lblproject:ETypeCellOpt
+  - Lblproject:EValueCell
+  - Lblproject:EValueCellOpt
+  - Lblproject:ElemAddrsCell
+  - Lblproject:ElemAddrsCellOpt
+  - Lblproject:ElemDefn
+  - Lblproject:ElemExpr
+  - Lblproject:ElemExprs
+  - Lblproject:ElemIdsCell
+  - Lblproject:ElemIdsCellOpt
+  - Lblproject:ElemInstCell
+  - Lblproject:ElemInstCellFragment
+  - Lblproject:ElemInstCellMap
+  - Lblproject:ElemList
+  - Lblproject:ElemMode
+  - Lblproject:ElemSegment
+  - Lblproject:ElemsCell
+  - Lblproject:ElemsCellFragment
+  - Lblproject:ElemsCellOpt
+  - Lblproject:ElrondCell
+  - Lblproject:ElrondCellFragment
+  - Lblproject:ElrondCellOpt
+  - Lblproject:EmptyStmt
+  - Lblproject:EmptyStmts
+  - Lblproject:Endianness
+  - Lblproject:Error
+  - Lblproject:EsdtBalanceCell
+  - Lblproject:EsdtBalanceCellOpt
+  - Lblproject:EsdtDataCell
+  - Lblproject:EsdtDataCellFragment
+  - Lblproject:EsdtDataCellMap
+  - Lblproject:EsdtDatasCell
+  - Lblproject:EsdtDatasCellFragment
+  - Lblproject:EsdtDatasCellOpt
+  - Lblproject:EsdtIdCell
+  - Lblproject:EsdtIdCellOpt
+  - Lblproject:EsdtLastNonceCell
+  - Lblproject:EsdtLastNonceCellOpt
+  - Lblproject:EsdtMetadataCell
+  - Lblproject:EsdtMetadataCellOpt
+  - Lblproject:EsdtPropertiesCell
+  - Lblproject:EsdtPropertiesCellOpt
+  - Lblproject:EsdtRolesCell
+  - Lblproject:EsdtRolesCellOpt
+  - Lblproject:EsdtTransfersCell
+  - Lblproject:EsdtTransfersCellOpt
+  - Lblproject:ExceptionCode
+  - Lblproject:ExitCodeCell
+  - Lblproject:ExitCodeCellOpt
+  - Lblproject:ExportDefn
+  - Lblproject:ExportsCell
+  - Lblproject:ExportsCellOpt
+  - Lblproject:ExtendS
+  - Lblproject:Externval
+  - Lblproject:FAddrCell
+  - Lblproject:FAddrCellOpt
+  - Lblproject:FBinOp
+  - Lblproject:FCodeCell
+  - Lblproject:FCodeCellOpt
+  - Lblproject:FLocalCell
+  - Lblproject:FLocalCellOpt
+  - Lblproject:FModInstCell
+  - Lblproject:FModInstCellOpt
+  - Lblproject:FRelOp
+  - Lblproject:FTypeCell
+  - Lblproject:FTypeCellOpt
+  - Lblproject:FUnOp
+  - Lblproject:FVal
+  - Lblproject:FValType
+  - Lblproject:Float
+  - Lblproject:FoldedInstr
+  - Lblproject:FoundryCell
+  - Lblproject:FoundryCellFragment
+  - Lblproject:FoundryCellOpt
+  - Lblproject:Frame
+  - Lblproject:FuncAddrsCell
+  - Lblproject:FuncAddrsCellOpt
+  - Lblproject:FuncDefCell
+  - Lblproject:FuncDefCellFragment
+  - Lblproject:FuncDefCellMap
+  - Lblproject:FuncDefn
+  - Lblproject:FuncIdCell
+  - Lblproject:FuncIdCellOpt
+  - Lblproject:FuncIdsCell
+  - Lblproject:FuncIdsCellOpt
+  - Lblproject:FuncMetadata
+  - Lblproject:FuncMetadataCell
+  - Lblproject:FuncMetadataCellFragment
+  - Lblproject:FuncMetadataCellOpt
+  - Lblproject:FuncSpec
+  - Lblproject:FuncType
+  - Lblproject:FuncsCell
+  - Lblproject:FuncsCellFragment
+  - Lblproject:FuncsCellOpt
+  - Lblproject:FunctionCell
+  - Lblproject:FunctionCellOpt
+  - Lblproject:G1Point
+  - Lblproject:G2Point
+  - Lblproject:GAddrCell
+  - Lblproject:GAddrCellOpt
+  - Lblproject:GMutCell
+  - Lblproject:GMutCellOpt
+  - Lblproject:GValueCell
+  - Lblproject:GValueCellOpt
+  - Lblproject:GasPriceCell
+  - Lblproject:GasPriceCellOpt
+  - Lblproject:GasProvidedCell
+  - Lblproject:GasProvidedCellOpt
+  - Lblproject:GeneratedCounterCell
+  - Lblproject:GeneratedCounterCellOpt
+  - Lblproject:GeneratedTopCell
+  - Lblproject:GeneratedTopCellFragment
+  - Lblproject:GlobIdsCell
+  - Lblproject:GlobIdsCellOpt
+  - Lblproject:GlobalAddrsCell
+  - Lblproject:GlobalAddrsCellOpt
+  - Lblproject:GlobalDefn
+  - Lblproject:GlobalInstCell
+  - Lblproject:GlobalInstCellFragment
+  - Lblproject:GlobalInstCellMap
+  - Lblproject:GlobalSpec
+  - Lblproject:GlobalType
+  - Lblproject:GlobalsCell
+  - Lblproject:GlobalsCellFragment
+  - Lblproject:GlobalsCellOpt
+  - Lblproject:HashBytesStackInstr
+  - Lblproject:HeapType
+  - Lblproject:IBinOp
+  - Lblproject:IOError
+  - Lblproject:IOFile
+  - Lblproject:IOInt
+  - Lblproject:IOString
+  - Lblproject:IRelOp
+  - Lblproject:IUnOp
+  - Lblproject:IVal
+  - Lblproject:IValType
+  - Lblproject:Id
+  - Lblproject:Identifier
+  - Lblproject:IdentifierToken
+  - Lblproject:ImportDefn
+  - Lblproject:ImportDesc
+  - Lblproject:Index
+  - Lblproject:InlineExport
+  - Lblproject:InlineImport
+  - Lblproject:Instr
+  - Lblproject:Instrs
+  - Lblproject:InstrsCell
+  - Lblproject:InstrsCellOpt
+  - Lblproject:Int
+  - Lblproject:IntResult
+  - Lblproject:InterimStatesCell
+  - Lblproject:InterimStatesCellOpt
+  - Lblproject:InternalCmd
+  - Lblproject:InternalInstr
+  - Lblproject:Ints
+  - Lblproject:IternalInstr
+  - Lblproject:K
+  - Lblproject:KCell
+  - Lblproject:KCellOpt
+  - Lblproject:KItem
+  - Lblproject:Label
+  - Lblproject:Limits
+  - Lblproject:List
+  - Lblproject:ListAsyncCall
+  - Lblproject:ListBytes
+  - Lblproject:ListBytesResult
+  - Lblproject:ListInt
+  - Lblproject:ListRef
+  - Lblproject:ListResult
+  - Lblproject:LoadOp
+  - Lblproject:LoadOpM
+  - Lblproject:LocalDecl
+  - Lblproject:LocalDecls
+  - Lblproject:LocalIdsCell
+  - Lblproject:LocalIdsCellOpt
+  - Lblproject:LocalsCell
+  - Lblproject:LocalsCellOpt
+  - Lblproject:LogEntry
+  - Lblproject:LoggingCell
+  - Lblproject:LoggingCellOpt
+  - Lblproject:LogsCell
+  - Lblproject:LogsCellOpt
+  - Lblproject:MAddrCell
+  - Lblproject:MAddrCellOpt
+  - Lblproject:MainStoreCell
+  - Lblproject:MainStoreCellFragment
+  - Lblproject:MainStoreCellOpt
+  - Lblproject:MandosCell
+  - Lblproject:MandosCellFragment
+  - Lblproject:MandosCellOpt
+  - Lblproject:Map
+  - Lblproject:MapBytesToBytes
+  - Lblproject:MapIntToBytes
+  - Lblproject:MapIntToInt
+  - Lblproject:MdataCell
+  - Lblproject:MdataCellOpt
+  - Lblproject:MemAddrsCell
+  - Lblproject:MemAddrsCellOpt
+  - Lblproject:MemArg
+  - Lblproject:MemIdsCell
+  - Lblproject:MemIdsCellOpt
+  - Lblproject:MemInstCell
+  - Lblproject:MemInstCellFragment
+  - Lblproject:MemInstCellMap
+  - Lblproject:MemType
+  - Lblproject:MemoryDefn
+  - Lblproject:MemorySpec
+  - Lblproject:MemsCell
+  - Lblproject:MemsCellFragment
+  - Lblproject:MemsCellOpt
+  - Lblproject:MmaxCell
+  - Lblproject:MmaxCellOpt
+  - Lblproject:ModIdxCell
+  - Lblproject:ModIdxCellOpt
+  - Lblproject:ModuleDecl
+  - Lblproject:ModuleFileNameCell
+  - Lblproject:ModuleFileNameCellOpt
+  - Lblproject:ModuleIdCell
+  - Lblproject:ModuleIdCellOpt
+  - Lblproject:ModuleIdsCell
+  - Lblproject:ModuleIdsCellOpt
+  - Lblproject:ModuleInstCell
+  - Lblproject:ModuleInstCellFragment
+  - Lblproject:ModuleInstCellMap
+  - Lblproject:ModuleInstancesCell
+  - Lblproject:ModuleInstancesCellFragment
+  - Lblproject:ModuleInstancesCellOpt
+  - Lblproject:ModuleMetadata
+  - Lblproject:ModuleMetadataCell
+  - Lblproject:ModuleMetadataCellFragment
+  - Lblproject:ModuleMetadataCellOpt
+  - Lblproject:ModuleRegistryCell
+  - Lblproject:ModuleRegistryCellOpt
+  - Lblproject:MsizeCell
+  - Lblproject:MsizeCellOpt
+  - Lblproject:Mut
+  - Lblproject:NewAddressesCell
+  - Lblproject:NewAddressesCellOpt
+  - Lblproject:NextElemAddrCell
+  - Lblproject:NextElemAddrCellOpt
+  - Lblproject:NextElemIdxCell
+  - Lblproject:NextElemIdxCellOpt
+  - Lblproject:NextFuncAddrCell
+  - Lblproject:NextFuncAddrCellOpt
+  - Lblproject:NextFuncIdxCell
+  - Lblproject:NextFuncIdxCellOpt
+  - Lblproject:NextGlobAddrCell
+  - Lblproject:NextGlobAddrCellOpt
+  - Lblproject:NextGlobIdxCell
+  - Lblproject:NextGlobIdxCellOpt
+  - Lblproject:NextMemAddrCell
+  - Lblproject:NextMemAddrCellOpt
+  - Lblproject:NextModuleIdxCell
+  - Lblproject:NextModuleIdxCellOpt
+  - Lblproject:NextTabAddrCell
+  - Lblproject:NextTabAddrCellOpt
+  - Lblproject:NextTabIdxCell
+  - Lblproject:NextTabIdxCellOpt
+  - Lblproject:NextTypeIdxCell
+  - Lblproject:NextTypeIdxCellOpt
+  - Lblproject:NodeCell
+  - Lblproject:NodeCellFragment
+  - Lblproject:NodeCellOpt
+  - Lblproject:NonceCell
+  - Lblproject:NonceCellOpt
+  - Lblproject:Number
+  - Lblproject:Offset
+  - Lblproject:OffsetArg
+  - Lblproject:OptionalId
+  - Lblproject:OptionalInt
+  - Lblproject:OptionalString
+  - Lblproject:OutCell
+  - Lblproject:OutCellOpt
+  - Lblproject:OutputAccount
+  - Lblproject:OutputAccount:addr
+  - Lblproject:OutputAccount:transfers
+  - Lblproject:OutputAccountsCell
+  - Lblproject:OutputAccountsCellOpt
+  - Lblproject:OutputTransfer
+  - Lblproject:OutputTransfer:sender
+  - Lblproject:OutputTransfer:value
+  - Lblproject:OwnerAddressCell
+  - Lblproject:OwnerAddressCellOpt
+  - Lblproject:PlainInstr
+  - Lblproject:PrankCell
+  - Lblproject:PrankCellOpt
+  - Lblproject:PrevBlockEpochCell
+  - Lblproject:PrevBlockEpochCellOpt
+  - Lblproject:PrevBlockNonceCell
+  - Lblproject:PrevBlockNonceCellOpt
+  - Lblproject:PrevBlockRandomSeedCell
+  - Lblproject:PrevBlockRandomSeedCellOpt
+  - Lblproject:PrevBlockRoundCell
+  - Lblproject:PrevBlockRoundCellOpt
+  - Lblproject:PrevBlockTimestampCell
+  - Lblproject:PrevBlockTimestampCellOpt
+  - Lblproject:PreviousBlockInfoCell
+  - Lblproject:PreviousBlockInfoCellFragment
+  - Lblproject:PreviousBlockInfoCellOpt
+  - Lblproject:RefVal
+  - Lblproject:RefValType
+  - Lblproject:ReturnCode
+  - Lblproject:SBItem
+  - Lblproject:SBItemChunk
+  - Lblproject:Set
+  - Lblproject:Signedness
+  - Lblproject:SparseBytes
+  - Lblproject:StartDefn
+  - Lblproject:Step
+  - Lblproject:Steps
+  - Lblproject:Stmt
+  - Lblproject:Stmts
+  - Lblproject:StorageCell
+  - Lblproject:StorageCellOpt
+  - Lblproject:StoreOp
+  - Lblproject:StoreOpM
+  - Lblproject:Stream
+  - Lblproject:String
+  - Lblproject:TAddrCell
+  - Lblproject:TAddrCellOpt
+  - Lblproject:TabAddrsCell
+  - Lblproject:TabAddrsCellOpt
+  - Lblproject:TabIdsCell
+  - Lblproject:TabIdsCellOpt
+  - Lblproject:TabInstCell
+  - Lblproject:TabInstCellFragment
+  - Lblproject:TabInstCellMap
+  - Lblproject:TableDefn
+  - Lblproject:TableElemType
+  - Lblproject:TableSpec
+  - Lblproject:TableType
+  - Lblproject:TableUse
+  - Lblproject:TabsCell
+  - Lblproject:TabsCellFragment
+  - Lblproject:TabsCellOpt
+  - Lblproject:TdataCell
+  - Lblproject:TdataCellOpt
+  - Lblproject:TestOp
+  - Lblproject:TextFormatGlobalType
+  - Lblproject:TextLimits
+  - Lblproject:ThrowException
+  - Lblproject:TmaxCell
+  - Lblproject:TmaxCellOpt
+  - Lblproject:TransferTx
+  - Lblproject:TransferValue
+  - Lblproject:TxCountCell
+  - Lblproject:TxCountCellOpt
+  - Lblproject:TxHashCell
+  - Lblproject:TxHashCellOpt
+  - Lblproject:Type
+  - Lblproject:TypeDecl
+  - Lblproject:TypeDecls
+  - Lblproject:TypeDefn
+  - Lblproject:TypeIdsCell
+  - Lblproject:TypeIdsCellOpt
+  - Lblproject:TypeKeyWord
+  - Lblproject:TypeUse
+  - Lblproject:TypesCell
+  - Lblproject:TypesCellOpt
+  - Lblproject:TypesInfo
+  - Lblproject:VMOutput
+  - Lblproject:VMOutput:logs
+  - Lblproject:VMOutput:out
+  - Lblproject:VMOutput:outputAccounts
+  - Lblproject:VMOutput:returnCode
+  - Lblproject:VMOutput:returnMessage
+  - Lblproject:Val
+  - Lblproject:ValStack
+  - Lblproject:ValType
+  - Lblproject:ValTypes
+  - Lblproject:ValidatorRewardTx
+  - Lblproject:ValstackCell
+  - Lblproject:ValstackCellOpt
+  - Lblproject:VecType
+  - Lblproject:VmInputCell
+  - Lblproject:VmInputCellFragment
+  - Lblproject:VmInputCellOpt
+  - Lblproject:VmOutputCell
+  - Lblproject:VmOutputCellOpt
+  - Lblproject:WasmCell
+  - Lblproject:WasmCellFragment
+  - Lblproject:WasmCellOpt
+  - Lblproject:WasmInt
+  - Lblproject:WasmIntToken
+  - Lblproject:WasmStoreCell
+  - Lblproject:WasmStoreCellOpt
+  - Lblproject:WasmString
+  - Lblproject:WasmStringToken
+  - Lblproject:WrappedBytes
+  - Lblproject:WrappedInt
+  - Lblproject:aDataDefn:data
+  - Lblproject:aDataDefn:index
+  - Lblproject:aDataDefn:offset
+  - Lblproject:aElemActive:offset
+  - Lblproject:aElemActive:table
+  - Lblproject:aElemDefn:elemSegment
+  - Lblproject:aElemDefn:mode
+  - Lblproject:aElemDefn:oid
+  - Lblproject:aElemDefn:type
+  - Lblproject:aExportDefn:index
+  - Lblproject:aExportDefn:name
+  - Lblproject:aFuncDefn:body
+  - Lblproject:aFuncDefn:locals
+  - Lblproject:aFuncDefn:metadata
+  - Lblproject:aFuncDefn:type
+  - Lblproject:aFuncDesc:id
+  - Lblproject:aFuncDesc:type
+  - Lblproject:aGlobalDefn:init
+  - Lblproject:aGlobalDefn:metadata
+  - Lblproject:aGlobalDefn:type
+  - Lblproject:aGlobalDesc:id
+  - Lblproject:aGlobalDesc:type
+  - Lblproject:aIf:blockInfo
+  - Lblproject:aIf:else
+  - Lblproject:aIf:then
+  - Lblproject:aImportDefn:mod
+  - Lblproject:aImportDefn:name
+  - Lblproject:aImportDefnHelper:importedAddr
+  - Lblproject:aLoad:offset
+  - Lblproject:aMemoryDefn:limits
+  - Lblproject:aMemoryDefn:metadata
+  - Lblproject:aMemoryDesc:id
+  - Lblproject:aMemoryDesc:type
+  - Lblproject:aModuleDecl:data
+  - Lblproject:aModuleDecl:elem
+  - Lblproject:aModuleDecl:exports
+  - Lblproject:aModuleDecl:funcs
+  - Lblproject:aModuleDecl:globals
+  - Lblproject:aModuleDecl:importDefns
+  - Lblproject:aModuleDecl:mems
+  - Lblproject:aModuleDecl:metadata
+  - Lblproject:aModuleDecl:start
+  - Lblproject:aModuleDecl:tables
+  - Lblproject:aModuleDecl:types
+  - Lblproject:aStore:offset
+  - Lblproject:aTableDefn:limits
+  - Lblproject:aTableDefn:metadata
+  - Lblproject:aTableDefn:type
+  - Lblproject:aTableDesc:id
+  - Lblproject:aTableDesc:type
+  - Lblproject:aTypeDefn:metadata
+  - Lblproject:aTypeDefn:type
+  - Lblproject:addToESDTBalance(_,_,_,_)_ESDT_InternalCmd_Bytes_Bytes_Int_Bool:account
+  - Lblproject:addToESDTBalance(_,_,_,_)_ESDT_InternalCmd_Bytes_Bytes_Int_Bool:allowNew
+  - Lblproject:addToESDTBalance(_,_,_,_)_ESDT_InternalCmd_Bytes_Bytes_Int_Bool:delta
+  - Lblproject:addToESDTBalance(_,_,_,_)_ESDT_InternalCmd_Bytes_Bytes_Int_Bool:token
+  - Lblproject:callTx:args
+  - Lblproject:callTx:esdtValue
+  - Lblproject:callTx:from
+  - Lblproject:callTx:func
+  - Lblproject:callTx:gasLimit
+  - Lblproject:callTx:gasPrice
+  - Lblproject:callTx:to
+  - Lblproject:callTx:value
+  - Lblproject:callTxAux:args
+  - Lblproject:callTxAux:esdtValue
+  - Lblproject:callTxAux:from
+  - Lblproject:callTxAux:func
+  - Lblproject:callTxAux:gasLimit
+  - Lblproject:callTxAux:gasPrice
+  - Lblproject:callTxAux:to
+  - Lblproject:callTxAux:value
+  - Lblproject:checkAllowedToExecute:account
+  - Lblproject:checkAllowedToExecute:role
+  - Lblproject:checkAllowedToExecute:token
+  - Lblproject:checkESDTBalance(_,_,_)_ESDT_InternalCmd_Bytes_Bytes_Int:account
+  - Lblproject:checkESDTBalance(_,_,_)_ESDT_InternalCmd_Bytes_Bytes_Int:token
+  - Lblproject:checkESDTBalance(_,_,_)_ESDT_InternalCmd_Bytes_Bytes_Int:value
+  - Lblproject:ctx(_,_,_,_,_,_,_)_WASM-TEXT_Context_Map_Map_Map_Map_Map_Map_Map:elemIds
+  - Lblproject:ctx(_,_,_,_,_,_,_)_WASM-TEXT_Context_Map_Map_Map_Map_Map_Map_Map:funcIds
+  - Lblproject:ctx(_,_,_,_,_,_,_)_WASM-TEXT_Context_Map_Map_Map_Map_Map_Map_Map:globalIds
+  - Lblproject:ctx(_,_,_,_,_,_,_)_WASM-TEXT_Context_Map_Map_Map_Map_Map_Map_Map:localIds
+  - Lblproject:ctx(_,_,_,_,_,_,_)_WASM-TEXT_Context_Map_Map_Map_Map_Map_Map_Map:memoryIds
+  - Lblproject:ctx(_,_,_,_,_,_,_)_WASM-TEXT_Context_Map_Map_Map_Map_Map_Map_Map:tableIds
+  - Lblproject:ctx(_,_,_,_,_,_,_)_WASM-TEXT_Context_Map_Map_Map_Map_Map_Map_Map:typeIds
+  - Lblproject:esdtLocalBurn:account
+  - Lblproject:esdtLocalBurn:token
+  - Lblproject:esdtLocalBurn:value
+  - Lblproject:esdtLocalMint:account
+  - Lblproject:esdtLocalMint:token
+  - Lblproject:esdtLocalMint:value
+  - Lblproject:esdtMetadata:attributes
+  - Lblproject:esdtMetadata:creator
+  - Lblproject:esdtMetadata:hash
+  - Lblproject:esdtMetadata:name
+  - Lblproject:esdtMetadata:nonce
+  - Lblproject:esdtMetadata:royalties
+  - Lblproject:esdtMetadata:uris
+  - Lblproject:esdtTransfer:tokenName
+  - Lblproject:esdtTransfer:tokenNonce
+  - Lblproject:esdtTransfer:tokenValue
+  - Lblproject:funcMeta:id
+  - Lblproject:funcMeta:localIds
+  - Lblproject:moduleMeta:filename
+  - Lblproject:moduleMeta:funcIds
+  - Lblproject:moduleMeta:id
+  - Lblproject:queryTx:args
+  - Lblproject:queryTx:func
+  - Lblproject:queryTx:to
+  - Lblproject:queryTxAux:args
+  - Lblproject:queryTxAux:func
+  - Lblproject:queryTxAux:to
+  - Lblproject:setAccount:address
+  - Lblproject:setAccount:balance
+  - Lblproject:setAccount:code
+  - Lblproject:setAccount:nonce
+  - Lblproject:setAccount:owner
+  - Lblproject:setAccount:storage
+  - Lblproject:setAccountAux:address
+  - Lblproject:setAccountAux:balance
+  - Lblproject:setAccountAux:code
+  - Lblproject:setAccountAux:nonce
+  - Lblproject:setAccountAux:owner
+  - Lblproject:setAccountAux:storage
+  - Lblproject:transferTx:from
+  - Lblproject:transferTx:to
+  - Lblproject:transferTx:value
+  - Lblproject:transferTxAux:from
+  - Lblproject:transferTxAux:to
+  - Lblproject:transferTxAux:value
+  - Lblproject:validatorRewardTx:to
+  - Lblproject:validatorRewardTx:value
+  - Lblproject:validatorRewardTxAux:to
+  - Lblproject:validatorRewardTxAux:value
+  - Lblproject:#createAsyncCallWithTypedArgs(_,_,_,_,_,_,_)_BASEOPS_InternalInstr_BytesResult_IntResult_BytesResult_ListBytesResult_Int_Int_BytesResult:args
+  - Lblproject:#createAsyncCallWithTypedArgs(_,_,_,_,_,_,_)_BASEOPS_InternalInstr_BytesResult_IntResult_BytesResult_ListBytesResult_Int_Int_BytesResult:callbackClosure
+  - Lblproject:#createAsyncCallWithTypedArgs(_,_,_,_,_,_,_)_BASEOPS_InternalInstr_BytesResult_IntResult_BytesResult_ListBytesResult_Int_Int_BytesResult:dest
+  - Lblproject:#createAsyncCallWithTypedArgs(_,_,_,_,_,_,_)_BASEOPS_InternalInstr_BytesResult_IntResult_BytesResult_ListBytesResult_Int_Int_BytesResult:extraGasForCallBack
+  - Lblproject:#createAsyncCallWithTypedArgs(_,_,_,_,_,_,_)_BASEOPS_InternalInstr_BytesResult_IntResult_BytesResult_ListBytesResult_Int_Int_BytesResult:func
+  - Lblproject:#createAsyncCallWithTypedArgs(_,_,_,_,_,_,_)_BASEOPS_InternalInstr_BytesResult_IntResult_BytesResult_ListBytesResult_Int_Int_BytesResult:gas
+  - Lblproject:#createAsyncCallWithTypedArgs(_,_,_,_,_,_,_)_BASEOPS_InternalInstr_BytesResult_IntResult_BytesResult_ListBytesResult_Int_Int_BytesResult:value
+  - Lblproject:#elemAux(_,_)_WASM_ElemDefn_Int_ElemMode:mode
+  - Lblproject:#elemAux(_,_)_WASM_ElemDefn_Int_ElemMode:segmentLen
+  - Lblproject:#elemCheckSizeGTE(_,_)_WASM_Instr_Int_Int:addr
+  - Lblproject:#elemCheckSizeGTE(_,_)_WASM_Instr_Int_Int:n
+  - Lblproject:#getBigInt(_,_)_BIGINT-HELPERS_InternalInstr_Int_Signedness:idx
+  - Lblproject:#getBigIntOrCreate(_,_)_BIGINT-HELPERS_InternalInstr_Int_Signedness:idx
+  - Lblproject:#getBuffer(_)_MANBUFOPS_InternalInstr_Int:idx
+  - Lblproject:#memLoad(_,_)_ELROND-CONFIG_InternalInstr_Int_Int:length
+  - Lblproject:#memLoad(_,_)_ELROND-CONFIG_InternalInstr_Int_Int:offset
+  - Lblproject:#memStore(_,_)_ELROND-CONFIG_InternalInstr_Int_Bytes:bytes
+  - Lblproject:#memStore(_,_)_ELROND-CONFIG_InternalInstr_Int_Bytes:offset
+  - Lblproject:#setBigInt(_,_,_)_BIGINT-HELPERS_InternalInstr_Int_Bytes_Signedness:idx
+  - Lblproject:#setBigInt(_,_,_)_BIGINT-HELPERS_InternalInstr_Int_Bytes_Signedness:value
+  - Lblproject:#setBigIntFromBytesStack(_,_)_BIGINT-HELPERS_InternalInstr_Int_Signedness:idx
+  - Lblproject:#setBuffer(_,_)_MANBUFOPS_InternalInstr_Int_Bytes:idx
+  - Lblproject:#setBuffer(_,_)_MANBUFOPS_InternalInstr_Int_Bytes:value
+  - Lblproject:#setBufferFromBytesStack(_)_MANBUFOPS_InternalInstr_Int:idx
+  - Lblproject:#tableCheckSizeGTE(_,_)_WASM_Instr_Int_Int:addr
+  - Lblproject:#tableCheckSizeGTE(_,_)_WASM_Instr_Int_Int:n
+  - Lblproject:#tableCopy(_,_,_,_,_)_WASM_Instr_Int_Int_Int_Int_Int:d
+  - Lblproject:#tableCopy(_,_,_,_,_)_WASM_Instr_Int_Int_Int_Int_Int:n
+  - Lblproject:#tableCopy(_,_,_,_,_)_WASM_Instr_Int_Int_Int_Int_Int:s
+  - Lblproject:#tableCopy(_,_,_,_,_)_WASM_Instr_Int_Int_Int_Int_Int:tix
+  - Lblproject:#tableCopy(_,_,_,_,_)_WASM_Instr_Int_Int_Int_Int_Int:tiy
+  - Lblproject:#tableGet(_,_)_WASM_Instr_Int_Int:addr
+  - Lblproject:#tableGet(_,_)_WASM_Instr_Int_Int:index
+  - Lblproject:#tableInit(_,_,_,_)_WASM_Instr_Int_Int_Int_ListRef:d
+  - Lblproject:#tableInit(_,_,_,_)_WASM_Instr_Int_Int_Int_ListRef:es
+  - Lblproject:#tableInit(_,_,_,_)_WASM_Instr_Int_Int_Int_ListRef:n
+  - Lblproject:#tableInit(_,_,_,_)_WASM_Instr_Int_Int_Int_ListRef:tidx
+  - Lblproject:#tableSet(_,_,_)_WASM_Instr_Int_RefVal_Int:addr
+  - Lblproject:#tableSet(_,_,_)_WASM_Instr_Int_RefVal_Int:idx
+  - Lblproject:#tableSet(_,_,_)_WASM_Instr_Int_RefVal_Int:val
+  - Lblproject:#tempFile:fd
+  - Lblproject:#tempFile:path
+  - Lblproject:#ti(_,_)_WASM-TEXT_TypesInfo_Map_Int:count
+  - Lblproject:#ti(_,_)_WASM-TEXT_TypesInfo_Map_Int:t2i
+  - Lblproject:#unknownIOError:errno
+  - LblpushCallState
+  - LblpushList
+  - LblpushWorldState
+  - LblqueryTx
+  - LblqueryTxAux
+  - LblrandInt(_)_INT-COMMON_Int_Int
+  - LblrangeDefined(_,_,_)_LIST-BYTES-EXTENSIONS_Bool_ListBytes_Int_Int
+  - LblreadESDTTransfer(_)_MANAGEDCONVERSIONS_ListResult_Bytes
+  - LblreadESDTTransfers(_)_MANAGEDCONVERSIONS_ListResult_Int
+  - LblreadESDTTransfersH(_)_MANAGEDCONVERSIONS_ListResult_Bytes
+  - LblreadESDTTransfersR(_)_MANAGEDCONVERSIONS_ListResult_BytesResult
+  - LblreadManagedVecOfManagedBuffers(_)_MANAGEDCONVERSIONS_ListBytesResult_Int
+  - Lblref.func__WASM-TEXT-COMMON-SYNTAX_PlainInstr_Index
+  - Lblref.is_null_WASM-TEXT-COMMON-SYNTAX_PlainInstr
+  - Lblregister
+  - LblregisterAsyncCall
+  - LblremoveAll(_,_)_MAP_Map_Map_Set
+  - LblremoveAll(_,_)_MAP-BYTES-TO-BYTES_MapBytesToBytes_MapBytesToBytes_Set
+  - LblremoveAll(_,_)_MAP-INT-TO-BYTES_MapIntToBytes_MapIntToBytes_Set
+  - LblremoveAll(_,_)_MAP-INT-TO-INT_MapIntToInt_MapIntToInt_Set
+  - LblremoveEmptyNft(_,_)_ESDT_InternalCmd_Bytes_Bytes
+  - Lblreplace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int
+  - LblreplaceAll(_,_,_)_STRING-COMMON_String_String_String_String
+  - LblreplaceAtBytes(_,_,_)_BYTES-HOOKED_Bytes_Bytes_Int_Bytes
+  - LblreplaceFirst(_,_,_)_STRING-COMMON_String_String_String_String
+  - LblresetCallState
+  - LblresolveAddrs(_,_)_WASM_ListRef_ListInt_ListRef
+  - LblresolveErrorFromOutput(_,_)_BASEOPS_InternalInstr_ExceptionCode_Bytes
+  - Lblresult_WASM-COMMON-SYNTAX_TypeKeyWord
+  - LblreverseBytes(_)_BYTES-HOOKED_Bytes_Bytes
+  - LblrfindChar(_,_,_)_STRING-COMMON_Int_String_String_Int
+  - LblrfindString(_,_,_)_STRING-COMMON_Int_String_String_Int
+  - LblrolesToInt(_)_MANAGEDEI_Int_Set
+  - LblrootFloat(_,_)_FLOAT_Float_Float_Int
+  - LblroundFloat(_,_,_)_FLOAT_Float_Float_Int_Int
+  - LblsaveLatestNonce
+  - LblsaveNFT
+  - LblsequenceDefns(_)_WASM_K_Defns
+  - LblsequenceInstrs(_)_WASM_K_Instrs
+  - LblsequenceStmts(_)_WASM_K_Stmts
+  - LblsetAccount
+  - LblsetAccountAux
+  - LblsetAccountCode
+  - LblsetAccountFields
+  - LblsetAccountOwner(_,_)_ELROND-CONFIG_InternalCmd_Bytes_Bytes
+  - LblsetContractModIdx_ELROND-CONFIG_InternalCmd
+  - LblsetCurBlockInfo
+  - LblsetEsdtBalance
+  - LblsetEsdtBalanceAux
+  - LblsetEsdtLastNonce
+  - LblsetEsdtRoles
+  - LblsetExitCode
+  - LblsetExtend(_,_,_,_)_WASM-DATA-TOOLS_ListInt_ListInt_Int_Int_Int
+  - LblsetPrevBlockInfo
+  - LblsignExtendBitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int
+  - LblsignFloat(_)_FLOAT_Bool_Float
+  - LblsignedBytes
+  - LblsinFloat(_)_FLOAT_Float_Float
+  - Lblsize(_)_LIST_Int_List
+  - Lblsize(_)_MAP_Int_Map
+  - Lblsize(_)_SET_Int_Set
+  - LblsizeListAsyncCall
+  - LblsizeListBytes
+  - LblsizeListInt
+  - LblsizeListRef
+  - LblsqrtBS(_,_,_)_BIGINT-HELPERS_Int_Int_Int_Int
+  - LblsqrtFloat(_)_FLOAT_Float_Float
+  - LblsqrtInt(_)_BIGINT-HELPERS_Int_Int
+  - LblsquareInt(_)_BIGINT-HELPERS_Int_Int
+  - LblsrandInt(_)_INT-COMMON_K_Int
+  - Lblstore{___}_WASM_Instr_Int_Int_Number
+  - Lblstore{____}_WASM_Instr_Int_Int_Number_Int
+  - LblstoreOpStore
+  - LblstoreOpStore16
+  - LblstoreOpStore32
+  - LblstoreOpStore8
+  - LblstructureModule(_,_)_WASM-TEXT_ModuleDecl_Defns_OptionalId
+  - LblstructureModules(_)_WASM-TEXT_Stmts_Stmts
+  - LblsubstrBytes(_,_,_)_BYTES-HOOKED_Bytes_Bytes_Int_Int
+  - LblsubstrString(_,_,_)_STRING-COMMON_String_String_Int_Int
+  - Lblt2aLimits(_)_WASM-TEXT_Limits_TextLimits
+  - Lbltable.copy_WASM-TEXT-COMMON-SYNTAX_PlainInstr
+  - Lbltable.copy___WASM-TEXT-COMMON-SYNTAX_PlainInstr_Index_Index
+  - Lbltable.fill__WASM-TEXT-COMMON-SYNTAX_PlainInstr_Index
+  - Lbltable.get__WASM-TEXT-COMMON-SYNTAX_PlainInstr_Index
+  - Lbltable.grow__WASM-TEXT-COMMON-SYNTAX_PlainInstr_Index
+  - Lbltable.init__WASM-TEXT-COMMON-SYNTAX_PlainInstr_Index
+  - Lbltable.init___WASM-TEXT-COMMON-SYNTAX_PlainInstr_Index_Index
+  - Lbltable.set__WASM-TEXT-COMMON-SYNTAX_PlainInstr_Index
+  - Lbltable.size__WASM-TEXT-COMMON-SYNTAX_PlainInstr_Index
+  - Lbltable_WASM-DATA-COMMON-SYNTAX_AllocatedKind
+  - LbltanFloat(_)_FLOAT_Float_Float
+  - Lbltext2abstract(_)_WASM_Stmts_Stmts
+  - LbltoBuiltinFunction(_)_ELROND-NODE_BuiltinFunction_String
+  - LbltoBuiltinFunction(_)_ELROND-NODE_BuiltinFunction_WasmStringToken
+  - Lbltransfer
+  - LbltransferESDT(_,_,_)_ESDT_InternalCmd_Bytes_Bytes_ESDTTransfer
+  - LbltransferESDTs(_,_,_)_ESDT_InternalCmd_Bytes_Bytes_List
+  - LbltransferESDTsAux(_,_,_)_ESDT_InternalCmd_Bytes_Bytes_List
+  - LbltransferFunds(_,_,_)_ELROND-CONFIG_InternalCmd_Bytes_Bytes_Int
+  - LbltransferFundsH(_,_,_)_ELROND-CONFIG_InternalCmd_Bytes_Bytes_Int
+  - LbltransferTx
+  - LbltransferTxAux
+  - Lbltrap_WASM_Instr
+  - LbltruncFloat(_)_FLOAT_Float_Float
+  - Lbltuple(_,_)_MANDOS_AddressNonce_Bytes_Int
+  - LbltypeUse2typeIdx(_,_)_WASM-TEXT_Int_TypeUse_Map
+  - Lbltypes2indices(_)_WASM-TEXT_TypesInfo_Defns
+  - Lblundefined_WASM-DATA-INTERNAL-SYNTAX_Val
+  - Lblunescape(_,_,_)_WASM-DATA-COMMON_String_String_Int_String
+  - Lblunescape(_)_WASM-DATA-COMMON_String_String
+  - LblunfoldDefns(_)_WASM-TEXT_Defns_Defns
+  - LblunfoldInstrs(_)_WASM-TEXT_Instrs_Instrs
+  - LblunfoldStmts(_)_WASM-TEXT_Stmts_Stmts
+  - LblunsignedBytes
+  - LblunwrapBytes
+  - LblunwrapInt
+  - LblupdateList(_,_,_)_ASYNC-CALL_ListAsyncCall_ListAsyncCall_Int_ListAsyncCall
+  - LblupdateList(_,_,_)_LIST_List_List_Int_List
+  - LblupdateList(_,_,_)_LIST-BYTES_ListBytes_ListBytes_Int_ListBytes
+  - LblupdateList(_,_,_)_LIST-INT_ListInt_ListInt_Int_ListInt
+  - LblupdateList(_,_,_)_LIST-REF_ListRef_ListRef_Int_ListRef
+  - LblupdateMap(_,_)_MAP_Map_Map_Map
+  - LblupdateMap(_,_)_MAP-BYTES-TO-BYTES_MapBytesToBytes_MapBytesToBytes_MapBytesToBytes
+  - LblupdateMap(_,_)_MAP-INT-TO-BYTES_MapIntToBytes_MapIntToBytes_MapIntToBytes
+  - LblupdateMap(_,_)_MAP-INT-TO-INT_MapIntToInt_MapIntToInt_MapIntToInt
+  - LblupdateSet(_,_,_)_KASMER_Set_Set_KItem_Bool
+  - LblvalidIdx(_,_)_WASM-TEXT_Bool_Map_Index
+  - LblvalidatorReward
+  - LblvalidatorRewardTx
+  - LblvalidatorRewardTxAux
+  - Lblvalues(_)_MAP_List_Map
+  - Lblvalues(_)_MAP-BYTES-TO-BYTES_ListBytes_MapBytesToBytes
+  - Lblvalues(_)_MAP-INT-TO-BYTES_ListBytes_MapIntToBytes
+  - Lblvalues(_)_MAP-INT-TO-INT_ListInt_MapIntToInt
+  - LblwasmString2StringStripped(_)_WASM-AUTO-ALLOCATE_String_WasmString
+  - LblwrapBytes
+  - LblwrapInt
+  - Lblzeros
+  - append
+  - dotk
+  - inj
+  - kseq
+Partial function symbols: 1067
+Axioms: 575
+Axioms preserving definedness: 502
+Axioms containing AC symbols: 0
+Subsorts:
+- Sort#Layout: Sort#Layout
+- SortAccountCell: SortAccountCell
+- SortAccountCellFragment: SortAccountCellFragment
+- SortAccountCellMap: 2
+  - SortAccountCell
+  - SortAccountCellMap
+- SortAccounts: SortAccounts
+- SortAccountsCell: SortAccountsCell
+- SortAccountsCellFragment: SortAccountsCellFragment
+- SortAccountsCellOpt: 2
+  - SortAccountsCell
+  - SortAccountsCellOpt
+- SortAddress: 3
+  - SortAddress
+  - SortBytes
+  - SortWasmStringToken
+- SortAddressCell: SortAddressCell
+- SortAddressCellOpt: 2
+  - SortAddressCell
+  - SortAddressCellOpt
+- SortAddressNonce: SortAddressNonce
+- SortAlignArg: SortAlignArg
+- SortAlloc: 3
+  - SortAlloc
+  - SortExportDefn
+  - SortImportDefn
+- SortAllocatedKind: SortAllocatedKind
+- SortAsyncCall: SortAsyncCall
+- SortAsyncCallStatus: SortAsyncCallStatus
+- SortAsyncCallsCell: SortAsyncCallsCell
+- SortAsyncCallsCellOpt: 2
+  - SortAsyncCallsCell
+  - SortAsyncCallsCellOpt
+- SortBYTES: SortBYTES
+- SortBalanceCell: SortBalanceCell
+- SortBalanceCellOpt: 2
+  - SortBalanceCell
+  - SortBalanceCellOpt
+- SortBigIntHeapCell: SortBigIntHeapCell
+- SortBigIntHeapCellOpt: 2
+  - SortBigIntHeapCell
+  - SortBigIntHeapCellOpt
+- SortBlockInfo: SortBlockInfo
+- SortBlockInstr: SortBlockInstr
+- SortBlockMetaData: 3
+  - SortBlockMetaData
+  - SortInt
+  - SortOptionalInt
+- SortBool: SortBool
+- SortBufferHeapCell: SortBufferHeapCell
+- SortBufferHeapCellOpt: 2
+  - SortBufferHeapCell
+  - SortBufferHeapCellOpt
+- SortBuiltinFunction: SortBuiltinFunction
+- SortBytes: SortBytes
+- SortBytesOp: SortBytesOp
+- SortBytesResult: 3
+  - SortBytes
+  - SortBytesResult
+  - SortError
+- SortBytesStack: SortBytesStack
+- SortBytesStackCell: SortBytesStackCell
+- SortBytesStackCellOpt: 2
+  - SortBytesStackCell
+  - SortBytesStackCellOpt
+- SortCallArgsCell: SortCallArgsCell
+- SortCallArgsCellOpt: 2
+  - SortCallArgsCell
+  - SortCallArgsCellOpt
+- SortCallStackCell: SortCallStackCell
+- SortCallStackCellOpt: 2
+  - SortCallStackCell
+  - SortCallStackCellOpt
+- SortCallStateCell: SortCallStateCell
+- SortCallStateCellFragment: SortCallStateCellFragment
+- SortCallStateCellOpt: 2
+  - SortCallStateCell
+  - SortCallStateCellOpt
+- SortCallType: SortCallType
+- SortCallTypeCell: SortCallTypeCell
+- SortCallTypeCellOpt: 2
+  - SortCallTypeCell
+  - SortCallTypeCellOpt
+- SortCallValueCell: SortCallValueCell
+- SortCallValueCellOpt: 2
+  - SortCallValueCell
+  - SortCallValueCellOpt
+- SortCalleeCell: SortCalleeCell
+- SortCalleeCellOpt: 2
+  - SortCalleeCell
+  - SortCalleeCellOpt
+- SortCallerCell: SortCallerCell
+- SortCallerCellOpt: 2
+  - SortCallerCell
+  - SortCallerCellOpt
+- SortCheckedAccountsCell: SortCheckedAccountsCell
+- SortCheckedAccountsCellOpt: 2
+  - SortCheckedAccountsCell
+  - SortCheckedAccountsCellOpt
+- SortCode: 2
+  - SortCode
+  - SortModuleDecl
+- SortCodeCell: SortCodeCell
+- SortCodeCellOpt: 2
+  - SortCodeCell
+  - SortCodeCellOpt
+- SortCommandsCell: SortCommandsCell
+- SortCommandsCellOpt: 2
+  - SortCommandsCell
+  - SortCommandsCellOpt
+- SortContext: SortContext
+- SortContractModIdxCell: SortContractModIdxCell
+- SortContractModIdxCellOpt: 2
+  - SortContractModIdxCell
+  - SortContractModIdxCellOpt
+- SortCurBlockEpochCell: SortCurBlockEpochCell
+- SortCurBlockEpochCellOpt: 2
+  - SortCurBlockEpochCell
+  - SortCurBlockEpochCellOpt
+- SortCurBlockNonceCell: SortCurBlockNonceCell
+- SortCurBlockNonceCellOpt: 2
+  - SortCurBlockNonceCell
+  - SortCurBlockNonceCellOpt
+- SortCurBlockRandomSeedCell: SortCurBlockRandomSeedCell
+- SortCurBlockRandomSeedCellOpt: 2
+  - SortCurBlockRandomSeedCell
+  - SortCurBlockRandomSeedCellOpt
+- SortCurBlockRoundCell: SortCurBlockRoundCell
+- SortCurBlockRoundCellOpt: 2
+  - SortCurBlockRoundCell
+  - SortCurBlockRoundCellOpt
+- SortCurBlockTimestampCell: SortCurBlockTimestampCell
+- SortCurBlockTimestampCellOpt: 2
+  - SortCurBlockTimestampCell
+  - SortCurBlockTimestampCellOpt
+- SortCurFrameCell: SortCurFrameCell
+- SortCurFrameCellFragment: SortCurFrameCellFragment
+- SortCurFrameCellOpt: 2
+  - SortCurFrameCell
+  - SortCurFrameCellOpt
+- SortCurModIdxCell: SortCurModIdxCell
+- SortCurModIdxCellOpt: 2
+  - SortCurModIdxCell
+  - SortCurModIdxCellOpt
+- SortCurrentBlockInfoCell: SortCurrentBlockInfoCell
+- SortCurrentBlockInfoCellFragment: SortCurrentBlockInfoCellFragment
+- SortCurrentBlockInfoCellOpt: 2
+  - SortCurrentBlockInfoCell
+  - SortCurrentBlockInfoCellOpt
+- SortCvtOp: 5
+  - SortCvtOp
+  - SortCvtf32Op
+  - SortCvtf64Op
+  - SortCvti32Op
+  - SortCvti64Op
+- SortCvtf32Op: SortCvtf32Op
+- SortCvtf64Op: SortCvtf64Op
+- SortCvti32Op: SortCvti32Op
+- SortCvti64Op: SortCvti64Op
+- SortDataDefn: SortDataDefn
+- SortDataString: SortDataString
+- SortDefn: 12
+  - SortDataDefn
+  - SortDefn
+  - SortElemDefn
+  - SortEmptyStmt
+  - SortExportDefn
+  - SortFuncDefn
+  - SortGlobalDefn
+  - SortImportDefn
+  - SortMemoryDefn
+  - SortStartDefn
+  - SortTableDefn
+  - SortTypeDefn
+- SortDefns: 2
+  - SortDefns
+  - SortEmptyStmts
+- SortDeterministicMemoryGrowthCell: SortDeterministicMemoryGrowthCell
+- SortDeterministicMemoryGrowthCellOpt: 2
+  - SortDeterministicMemoryGrowthCell
+  - SortDeterministicMemoryGrowthCellOpt
+- SortEAddrCell: SortEAddrCell
+- SortEAddrCellOpt: 2
+  - SortEAddrCell
+  - SortEAddrCellOpt
+- SortESDTLocalRole: SortESDTLocalRole
+- SortESDTMetadata: SortESDTMetadata
+- SortESDTTransfer: SortESDTTransfer
+- SortETypeCell: SortETypeCell
+- SortETypeCellOpt: 2
+  - SortETypeCell
+  - SortETypeCellOpt
+- SortEValueCell: SortEValueCell
+- SortEValueCellOpt: 2
+  - SortEValueCell
+  - SortEValueCellOpt
+- SortElemAddrsCell: SortElemAddrsCell
+- SortElemAddrsCellOpt: 2
+  - SortElemAddrsCell
+  - SortElemAddrsCellOpt
+- SortElemDefn: SortElemDefn
+- SortElemExpr: SortElemExpr
+- SortElemExprs: SortElemExprs
+- SortElemIdsCell: SortElemIdsCell
+- SortElemIdsCellOpt: 2
+  - SortElemIdsCell
+  - SortElemIdsCellOpt
+- SortElemInstCell: SortElemInstCell
+- SortElemInstCellFragment: SortElemInstCellFragment
+- SortElemInstCellMap: 2
+  - SortElemInstCell
+  - SortElemInstCellMap
+- SortElemList: 2
+  - SortElemList
+  - SortElemSegment
+- SortElemMode: SortElemMode
+- SortElemSegment: SortElemSegment
+- SortElemsCell: SortElemsCell
+- SortElemsCellFragment: SortElemsCellFragment
+- SortElemsCellOpt: 2
+  - SortElemsCell
+  - SortElemsCellOpt
+- SortElrondCell: SortElrondCell
+- SortElrondCellFragment: SortElrondCellFragment
+- SortElrondCellOpt: 2
+  - SortElrondCell
+  - SortElrondCellOpt
+- SortEmptyStmt: SortEmptyStmt
+- SortEmptyStmts: SortEmptyStmts
+- SortEndianness: SortEndianness
+- SortError: SortError
+- SortEsdtBalanceCell: SortEsdtBalanceCell
+- SortEsdtBalanceCellOpt: 2
+  - SortEsdtBalanceCell
+  - SortEsdtBalanceCellOpt
+- SortEsdtDataCell: SortEsdtDataCell
+- SortEsdtDataCellFragment: SortEsdtDataCellFragment
+- SortEsdtDataCellMap: 2
+  - SortEsdtDataCell
+  - SortEsdtDataCellMap
+- SortEsdtDatasCell: SortEsdtDatasCell
+- SortEsdtDatasCellFragment: SortEsdtDatasCellFragment
+- SortEsdtDatasCellOpt: 2
+  - SortEsdtDatasCell
+  - SortEsdtDatasCellOpt
+- SortEsdtIdCell: SortEsdtIdCell
+- SortEsdtIdCellOpt: 2
+  - SortEsdtIdCell
+  - SortEsdtIdCellOpt
+- SortEsdtLastNonceCell: SortEsdtLastNonceCell
+- SortEsdtLastNonceCellOpt: 2
+  - SortEsdtLastNonceCell
+  - SortEsdtLastNonceCellOpt
+- SortEsdtMetadataCell: SortEsdtMetadataCell
+- SortEsdtMetadataCellOpt: 2
+  - SortEsdtMetadataCell
+  - SortEsdtMetadataCellOpt
+- SortEsdtPropertiesCell: SortEsdtPropertiesCell
+- SortEsdtPropertiesCellOpt: 2
+  - SortEsdtPropertiesCell
+  - SortEsdtPropertiesCellOpt
+- SortEsdtRolesCell: SortEsdtRolesCell
+- SortEsdtRolesCellOpt: 2
+  - SortEsdtRolesCell
+  - SortEsdtRolesCellOpt
+- SortEsdtTransfersCell: SortEsdtTransfersCell
+- SortEsdtTransfersCellOpt: 2
+  - SortEsdtTransfersCell
+  - SortEsdtTransfersCellOpt
+- SortExceptionCode: SortExceptionCode
+- SortExitCodeCell: SortExitCodeCell
+- SortExitCodeCellOpt: 2
+  - SortExitCodeCell
+  - SortExitCodeCellOpt
+- SortExportDefn: SortExportDefn
+- SortExportsCell: SortExportsCell
+- SortExportsCellOpt: 2
+  - SortExportsCell
+  - SortExportsCellOpt
+- SortExtendS: SortExtendS
+- SortExternval: SortExternval
+- SortFAddrCell: SortFAddrCell
+- SortFAddrCellOpt: 2
+  - SortFAddrCell
+  - SortFAddrCellOpt
+- SortFBinOp: SortFBinOp
+- SortFCodeCell: SortFCodeCell
+- SortFCodeCellOpt: 2
+  - SortFCodeCell
+  - SortFCodeCellOpt
+- SortFLocalCell: SortFLocalCell
+- SortFLocalCellOpt: 2
+  - SortFLocalCell
+  - SortFLocalCellOpt
+- SortFModInstCell: SortFModInstCell
+- SortFModInstCellOpt: 2
+  - SortFModInstCell
+  - SortFModInstCellOpt
+- SortFRelOp: SortFRelOp
+- SortFTypeCell: SortFTypeCell
+- SortFTypeCellOpt: 2
+  - SortFTypeCell
+  - SortFTypeCellOpt
+- SortFUnOp: SortFUnOp
+- SortFVal: SortFVal
+- SortFValType: SortFValType
+- SortFloat: SortFloat
+- SortFoldedInstr: SortFoldedInstr
+- SortFoundryCell: SortFoundryCell
+- SortFoundryCellFragment: SortFoundryCellFragment
+- SortFoundryCellOpt: 2
+  - SortFoundryCell
+  - SortFoundryCellOpt
+- SortFrame: SortFrame
+- SortFuncAddrsCell: SortFuncAddrsCell
+- SortFuncAddrsCellOpt: 2
+  - SortFuncAddrsCell
+  - SortFuncAddrsCellOpt
+- SortFuncDefCell: SortFuncDefCell
+- SortFuncDefCellFragment: SortFuncDefCellFragment
+- SortFuncDefCellMap: 2
+  - SortFuncDefCell
+  - SortFuncDefCellMap
+- SortFuncDefn: SortFuncDefn
+- SortFuncIdCell: SortFuncIdCell
+- SortFuncIdCellOpt: 2
+  - SortFuncIdCell
+  - SortFuncIdCellOpt
+- SortFuncIdsCell: SortFuncIdsCell
+- SortFuncIdsCellOpt: 2
+  - SortFuncIdsCell
+  - SortFuncIdsCellOpt
+- SortFuncMetadata: SortFuncMetadata
+- SortFuncMetadataCell: SortFuncMetadataCell
+- SortFuncMetadataCellFragment: SortFuncMetadataCellFragment
+- SortFuncMetadataCellOpt: 2
+  - SortFuncMetadataCell
+  - SortFuncMetadataCellOpt
+- SortFuncSpec: SortFuncSpec
+- SortFuncType: SortFuncType
+- SortFuncsCell: SortFuncsCell
+- SortFuncsCellFragment: SortFuncsCellFragment
+- SortFuncsCellOpt: 2
+  - SortFuncsCell
+  - SortFuncsCellOpt
+- SortFunctionCell: SortFunctionCell
+- SortFunctionCellOpt: 2
+  - SortFunctionCell
+  - SortFunctionCellOpt
+- SortG1Point: SortG1Point
+- SortG2Point: SortG2Point
+- SortGAddrCell: SortGAddrCell
+- SortGAddrCellOpt: 2
+  - SortGAddrCell
+  - SortGAddrCellOpt
+- SortGMutCell: SortGMutCell
+- SortGMutCellOpt: 2
+  - SortGMutCell
+  - SortGMutCellOpt
+- SortGValueCell: SortGValueCell
+- SortGValueCellOpt: 2
+  - SortGValueCell
+  - SortGValueCellOpt
+- SortGasPriceCell: SortGasPriceCell
+- SortGasPriceCellOpt: 2
+  - SortGasPriceCell
+  - SortGasPriceCellOpt
+- SortGasProvidedCell: SortGasProvidedCell
+- SortGasProvidedCellOpt: 2
+  - SortGasProvidedCell
+  - SortGasProvidedCellOpt
+- SortGeneratedCounterCell: SortGeneratedCounterCell
+- SortGeneratedCounterCellOpt: 2
+  - SortGeneratedCounterCell
+  - SortGeneratedCounterCellOpt
+- SortGeneratedTopCell: SortGeneratedTopCell
+- SortGeneratedTopCellFragment: SortGeneratedTopCellFragment
+- SortGlobIdsCell: SortGlobIdsCell
+- SortGlobIdsCellOpt: 2
+  - SortGlobIdsCell
+  - SortGlobIdsCellOpt
+- SortGlobalAddrsCell: SortGlobalAddrsCell
+- SortGlobalAddrsCellOpt: 2
+  - SortGlobalAddrsCell
+  - SortGlobalAddrsCellOpt
+- SortGlobalDefn: SortGlobalDefn
+- SortGlobalInstCell: SortGlobalInstCell
+- SortGlobalInstCellFragment: SortGlobalInstCellFragment
+- SortGlobalInstCellMap: 2
+  - SortGlobalInstCell
+  - SortGlobalInstCellMap
+- SortGlobalSpec: SortGlobalSpec
+- SortGlobalType: SortGlobalType
+- SortGlobalsCell: SortGlobalsCell
+- SortGlobalsCellFragment: SortGlobalsCellFragment
+- SortGlobalsCellOpt: 2
+  - SortGlobalsCell
+  - SortGlobalsCellOpt
+- SortHashBytesStackInstr: SortHashBytesStackInstr
+- SortHeapType: SortHeapType
+- SortIBinOp: SortIBinOp
+- SortIOError: SortIOError
+- SortIOFile: 2
+  - SortIOError
+  - SortIOFile
+- SortIOInt: 3
+  - SortIOError
+  - SortIOInt
+  - SortInt
+- SortIOString: 3
+  - SortIOError
+  - SortIOString
+  - SortString
+- SortIRelOp: SortIRelOp
+- SortIUnOp: SortIUnOp
+- SortIVal: SortIVal
+- SortIValType: SortIValType
+- SortId: SortId
+- SortIdentifier: 2
+  - SortIdentifier
+  - SortIdentifierToken
+- SortIdentifierToken: SortIdentifierToken
+- SortImportDefn: SortImportDefn
+- SortImportDesc: SortImportDesc
+- SortIndex: 5
+  - SortIdentifier
+  - SortIdentifierToken
+  - SortIndex
+  - SortInt
+  - SortWasmInt
+- SortInlineExport: SortInlineExport
+- SortInlineImport: SortInlineImport
+- SortInstr: 5
+  - SortBlockInstr
+  - SortEmptyStmt
+  - SortFoldedInstr
+  - SortInstr
+  - SortPlainInstr
+- SortInstrs: 2
+  - SortEmptyStmts
+  - SortInstrs
+- SortInstrsCell: SortInstrsCell
+- SortInstrsCellOpt: 2
+  - SortInstrsCell
+  - SortInstrsCellOpt
+- SortInt: SortInt
+- SortIntResult: 3
+  - SortError
+  - SortInt
+  - SortIntResult
+- SortInterimStatesCell: SortInterimStatesCell
+- SortInterimStatesCellOpt: 2
+  - SortInterimStatesCell
+  - SortInterimStatesCellOpt
+- SortInternalCmd: 2
+  - SortInternalCmd
+  - SortThrowException
+- SortInternalInstr: 2
+  - SortInternalInstr
+  - SortThrowException
+- SortInts: SortInts
+- SortIternalInstr: SortIternalInstr
+- SortK: SortK
+- SortKCell: SortKCell
+- SortKCellOpt: 2
+  - SortKCell
+  - SortKCellOpt
+- SortKConfigVar: SortKConfigVar
+- SortKItem: 478
+  - SortAccountCell
+  - SortAccountCellFragment
+  - SortAccountCellMap
+  - SortAccounts
+  - SortAccountsCell
+  - SortAccountsCellFragment
+  - SortAccountsCellOpt
+  - SortAddress
+  - SortAddressCell
+  - SortAddressCellOpt
+  - SortAddressNonce
+  - SortAlignArg
+  - SortAlloc
+  - SortAllocatedKind
+  - SortAsyncCall
+  - SortAsyncCallStatus
+  - SortAsyncCallsCell
+  - SortAsyncCallsCellOpt
+  - SortBYTES
+  - SortBalanceCell
+  - SortBalanceCellOpt
+  - SortBigIntHeapCell
+  - SortBigIntHeapCellOpt
+  - SortBlockInfo
+  - SortBlockInstr
+  - SortBlockMetaData
+  - SortBool
+  - SortBufferHeapCell
+  - SortBufferHeapCellOpt
+  - SortBuiltinFunction
+  - SortBytes
+  - SortBytesOp
+  - SortBytesResult
+  - SortBytesStack
+  - SortBytesStackCell
+  - SortBytesStackCellOpt
+  - SortCallArgsCell
+  - SortCallArgsCellOpt
+  - SortCallStackCell
+  - SortCallStackCellOpt
+  - SortCallStateCell
+  - SortCallStateCellFragment
+  - SortCallStateCellOpt
+  - SortCallType
+  - SortCallTypeCell
+  - SortCallTypeCellOpt
+  - SortCallValueCell
+  - SortCallValueCellOpt
+  - SortCalleeCell
+  - SortCalleeCellOpt
+  - SortCallerCell
+  - SortCallerCellOpt
+  - SortCheckedAccountsCell
+  - SortCheckedAccountsCellOpt
+  - SortCode
+  - SortCodeCell
+  - SortCodeCellOpt
+  - SortCommandsCell
+  - SortCommandsCellOpt
+  - SortContext
+  - SortContractModIdxCell
+  - SortContractModIdxCellOpt
+  - SortCurBlockEpochCell
+  - SortCurBlockEpochCellOpt
+  - SortCurBlockNonceCell
+  - SortCurBlockNonceCellOpt
+  - SortCurBlockRandomSeedCell
+  - SortCurBlockRandomSeedCellOpt
+  - SortCurBlockRoundCell
+  - SortCurBlockRoundCellOpt
+  - SortCurBlockTimestampCell
+  - SortCurBlockTimestampCellOpt
+  - SortCurFrameCell
+  - SortCurFrameCellFragment
+  - SortCurFrameCellOpt
+  - SortCurModIdxCell
+  - SortCurModIdxCellOpt
+  - SortCurrentBlockInfoCell
+  - SortCurrentBlockInfoCellFragment
+  - SortCurrentBlockInfoCellOpt
+  - SortCvtOp
+  - SortCvtf32Op
+  - SortCvtf64Op
+  - SortCvti32Op
+  - SortCvti64Op
+  - SortDataDefn
+  - SortDataString
+  - SortDefn
+  - SortDefns
+  - SortDeterministicMemoryGrowthCell
+  - SortDeterministicMemoryGrowthCellOpt
+  - SortEAddrCell
+  - SortEAddrCellOpt
+  - SortESDTLocalRole
+  - SortESDTMetadata
+  - SortESDTTransfer
+  - SortETypeCell
+  - SortETypeCellOpt
+  - SortEValueCell
+  - SortEValueCellOpt
+  - SortElemAddrsCell
+  - SortElemAddrsCellOpt
+  - SortElemDefn
+  - SortElemExpr
+  - SortElemExprs
+  - SortElemIdsCell
+  - SortElemIdsCellOpt
+  - SortElemInstCell
+  - SortElemInstCellFragment
+  - SortElemInstCellMap
+  - SortElemList
+  - SortElemMode
+  - SortElemSegment
+  - SortElemsCell
+  - SortElemsCellFragment
+  - SortElemsCellOpt
+  - SortElrondCell
+  - SortElrondCellFragment
+  - SortElrondCellOpt
+  - SortEmptyStmt
+  - SortEmptyStmts
+  - SortEndianness
+  - SortError
+  - SortEsdtBalanceCell
+  - SortEsdtBalanceCellOpt
+  - SortEsdtDataCell
+  - SortEsdtDataCellFragment
+  - SortEsdtDataCellMap
+  - SortEsdtDatasCell
+  - SortEsdtDatasCellFragment
+  - SortEsdtDatasCellOpt
+  - SortEsdtIdCell
+  - SortEsdtIdCellOpt
+  - SortEsdtLastNonceCell
+  - SortEsdtLastNonceCellOpt
+  - SortEsdtMetadataCell
+  - SortEsdtMetadataCellOpt
+  - SortEsdtPropertiesCell
+  - SortEsdtPropertiesCellOpt
+  - SortEsdtRolesCell
+  - SortEsdtRolesCellOpt
+  - SortEsdtTransfersCell
+  - SortEsdtTransfersCellOpt
+  - SortExceptionCode
+  - SortExitCodeCell
+  - SortExitCodeCellOpt
+  - SortExportDefn
+  - SortExportsCell
+  - SortExportsCellOpt
+  - SortExtendS
+  - SortExternval
+  - SortFAddrCell
+  - SortFAddrCellOpt
+  - SortFBinOp
+  - SortFCodeCell
+  - SortFCodeCellOpt
+  - SortFLocalCell
+  - SortFLocalCellOpt
+  - SortFModInstCell
+  - SortFModInstCellOpt
+  - SortFRelOp
+  - SortFTypeCell
+  - SortFTypeCellOpt
+  - SortFUnOp
+  - SortFVal
+  - SortFValType
+  - SortFloat
+  - SortFoldedInstr
+  - SortFoundryCell
+  - SortFoundryCellFragment
+  - SortFoundryCellOpt
+  - SortFrame
+  - SortFuncAddrsCell
+  - SortFuncAddrsCellOpt
+  - SortFuncDefCell
+  - SortFuncDefCellFragment
+  - SortFuncDefCellMap
+  - SortFuncDefn
+  - SortFuncIdCell
+  - SortFuncIdCellOpt
+  - SortFuncIdsCell
+  - SortFuncIdsCellOpt
+  - SortFuncMetadata
+  - SortFuncMetadataCell
+  - SortFuncMetadataCellFragment
+  - SortFuncMetadataCellOpt
+  - SortFuncSpec
+  - SortFuncType
+  - SortFuncsCell
+  - SortFuncsCellFragment
+  - SortFuncsCellOpt
+  - SortFunctionCell
+  - SortFunctionCellOpt
+  - SortG1Point
+  - SortG2Point
+  - SortGAddrCell
+  - SortGAddrCellOpt
+  - SortGMutCell
+  - SortGMutCellOpt
+  - SortGValueCell
+  - SortGValueCellOpt
+  - SortGasPriceCell
+  - SortGasPriceCellOpt
+  - SortGasProvidedCell
+  - SortGasProvidedCellOpt
+  - SortGeneratedCounterCell
+  - SortGeneratedCounterCellOpt
+  - SortGeneratedTopCell
+  - SortGeneratedTopCellFragment
+  - SortGlobIdsCell
+  - SortGlobIdsCellOpt
+  - SortGlobalAddrsCell
+  - SortGlobalAddrsCellOpt
+  - SortGlobalDefn
+  - SortGlobalInstCell
+  - SortGlobalInstCellFragment
+  - SortGlobalInstCellMap
+  - SortGlobalSpec
+  - SortGlobalType
+  - SortGlobalsCell
+  - SortGlobalsCellFragment
+  - SortGlobalsCellOpt
+  - SortHashBytesStackInstr
+  - SortHeapType
+  - SortIBinOp
+  - SortIOError
+  - SortIOFile
+  - SortIOInt
+  - SortIOString
+  - SortIRelOp
+  - SortIUnOp
+  - SortIVal
+  - SortIValType
+  - SortId
+  - SortIdentifier
+  - SortIdentifierToken
+  - SortImportDefn
+  - SortImportDesc
+  - SortIndex
+  - SortInlineExport
+  - SortInlineImport
+  - SortInstr
+  - SortInstrs
+  - SortInstrsCell
+  - SortInstrsCellOpt
+  - SortInt
+  - SortIntResult
+  - SortInterimStatesCell
+  - SortInterimStatesCellOpt
+  - SortInternalCmd
+  - SortInternalInstr
+  - SortInts
+  - SortIternalInstr
+  - SortKCell
+  - SortKCellOpt
+  - SortKConfigVar
+  - SortKItem
+  - SortLabel
+  - SortLimits
+  - SortList
+  - SortListAsyncCall
+  - SortListBytes
+  - SortListBytesResult
+  - SortListInt
+  - SortListRef
+  - SortListResult
+  - SortLoadOp
+  - SortLoadOpM
+  - SortLocalDecl
+  - SortLocalDecls
+  - SortLocalIdsCell
+  - SortLocalIdsCellOpt
+  - SortLocalsCell
+  - SortLocalsCellOpt
+  - SortLogEntry
+  - SortLoggingCell
+  - SortLoggingCellOpt
+  - SortLogsCell
+  - SortLogsCellOpt
+  - SortMAddrCell
+  - SortMAddrCellOpt
+  - SortMainStoreCell
+  - SortMainStoreCellFragment
+  - SortMainStoreCellOpt
+  - SortMandosCell
+  - SortMandosCellFragment
+  - SortMandosCellOpt
+  - SortMap
+  - SortMapBytesToBytes
+  - SortMapIntToBytes
+  - SortMapIntToInt
+  - SortMdataCell
+  - SortMdataCellOpt
+  - SortMemAddrsCell
+  - SortMemAddrsCellOpt
+  - SortMemArg
+  - SortMemIdsCell
+  - SortMemIdsCellOpt
+  - SortMemInstCell
+  - SortMemInstCellFragment
+  - SortMemInstCellMap
+  - SortMemType
+  - SortMemoryDefn
+  - SortMemorySpec
+  - SortMemsCell
+  - SortMemsCellFragment
+  - SortMemsCellOpt
+  - SortMmaxCell
+  - SortMmaxCellOpt
+  - SortModIdxCell
+  - SortModIdxCellOpt
+  - SortModuleDecl
+  - SortModuleFileNameCell
+  - SortModuleFileNameCellOpt
+  - SortModuleIdCell
+  - SortModuleIdCellOpt
+  - SortModuleIdsCell
+  - SortModuleIdsCellOpt
+  - SortModuleInstCell
+  - SortModuleInstCellFragment
+  - SortModuleInstCellMap
+  - SortModuleInstancesCell
+  - SortModuleInstancesCellFragment
+  - SortModuleInstancesCellOpt
+  - SortModuleMetadata
+  - SortModuleMetadataCell
+  - SortModuleMetadataCellFragment
+  - SortModuleMetadataCellOpt
+  - SortModuleRegistryCell
+  - SortModuleRegistryCellOpt
+  - SortMsizeCell
+  - SortMsizeCellOpt
+  - SortMut
+  - SortNewAddressesCell
+  - SortNewAddressesCellOpt
+  - SortNextElemAddrCell
+  - SortNextElemAddrCellOpt
+  - SortNextElemIdxCell
+  - SortNextElemIdxCellOpt
+  - SortNextFuncAddrCell
+  - SortNextFuncAddrCellOpt
+  - SortNextFuncIdxCell
+  - SortNextFuncIdxCellOpt
+  - SortNextGlobAddrCell
+  - SortNextGlobAddrCellOpt
+  - SortNextGlobIdxCell
+  - SortNextGlobIdxCellOpt
+  - SortNextMemAddrCell
+  - SortNextMemAddrCellOpt
+  - SortNextModuleIdxCell
+  - SortNextModuleIdxCellOpt
+  - SortNextTabAddrCell
+  - SortNextTabAddrCellOpt
+  - SortNextTabIdxCell
+  - SortNextTabIdxCellOpt
+  - SortNextTypeIdxCell
+  - SortNextTypeIdxCellOpt
+  - SortNodeCell
+  - SortNodeCellFragment
+  - SortNodeCellOpt
+  - SortNonceCell
+  - SortNonceCellOpt
+  - SortNumber
+  - SortOffset
+  - SortOffsetArg
+  - SortOptionalId
+  - SortOptionalInt
+  - SortOptionalString
+  - SortOutCell
+  - SortOutCellOpt
+  - SortOutputAccount
+  - SortOutputAccountsCell
+  - SortOutputAccountsCellOpt
+  - SortOutputTransfer
+  - SortOwnerAddressCell
+  - SortOwnerAddressCellOpt
+  - SortPlainInstr
+  - SortPrankCell
+  - SortPrankCellOpt
+  - SortPrevBlockEpochCell
+  - SortPrevBlockEpochCellOpt
+  - SortPrevBlockNonceCell
+  - SortPrevBlockNonceCellOpt
+  - SortPrevBlockRandomSeedCell
+  - SortPrevBlockRandomSeedCellOpt
+  - SortPrevBlockRoundCell
+  - SortPrevBlockRoundCellOpt
+  - SortPrevBlockTimestampCell
+  - SortPrevBlockTimestampCellOpt
+  - SortPreviousBlockInfoCell
+  - SortPreviousBlockInfoCellFragment
+  - SortPreviousBlockInfoCellOpt
+  - SortRefVal
+  - SortRefValType
+  - SortReturnCode
+  - SortSBItem
+  - SortSBItemChunk
+  - SortSet
+  - SortSignedness
+  - SortSparseBytes
+  - SortStartDefn
+  - SortStep
+  - SortSteps
+  - SortStmt
+  - SortStmts
+  - SortStorageCell
+  - SortStorageCellOpt
+  - SortStoreOp
+  - SortStoreOpM
+  - SortStream
+  - SortString
+  - SortTAddrCell
+  - SortTAddrCellOpt
+  - SortTabAddrsCell
+  - SortTabAddrsCellOpt
+  - SortTabIdsCell
+  - SortTabIdsCellOpt
+  - SortTabInstCell
+  - SortTabInstCellFragment
+  - SortTabInstCellMap
+  - SortTableDefn
+  - SortTableElemType
+  - SortTableSpec
+  - SortTableType
+  - SortTableUse
+  - SortTabsCell
+  - SortTabsCellFragment
+  - SortTabsCellOpt
+  - SortTdataCell
+  - SortTdataCellOpt
+  - SortTestOp
+  - SortTextFormatGlobalType
+  - SortTextLimits
+  - SortThrowException
+  - SortTmaxCell
+  - SortTmaxCellOpt
+  - SortTransferTx
+  - SortTransferValue
+  - SortTxCountCell
+  - SortTxCountCellOpt
+  - SortTxHashCell
+  - SortTxHashCellOpt
+  - SortType
+  - SortTypeDecl
+  - SortTypeDecls
+  - SortTypeDefn
+  - SortTypeIdsCell
+  - SortTypeIdsCellOpt
+  - SortTypeKeyWord
+  - SortTypeUse
+  - SortTypesCell
+  - SortTypesCellOpt
+  - SortTypesInfo
+  - SortVMOutput
+  - SortVal
+  - SortValStack
+  - SortValType
+  - SortValTypes
+  - SortValidatorRewardTx
+  - SortValstackCell
+  - SortValstackCellOpt
+  - SortVecType
+  - SortVmInputCell
+  - SortVmInputCellFragment
+  - SortVmInputCellOpt
+  - SortVmOutputCell
+  - SortVmOutputCellOpt
+  - SortWasmCell
+  - SortWasmCellFragment
+  - SortWasmCellOpt
+  - SortWasmInt
+  - SortWasmIntToken
+  - SortWasmStoreCell
+  - SortWasmStoreCellOpt
+  - SortWasmString
+  - SortWasmStringToken
+  - SortWrappedBytes
+  - SortWrappedInt
+- SortLabel: SortLabel
+- SortLimits: SortLimits
+- SortList: SortList
+- SortListAsyncCall: SortListAsyncCall
+- SortListBytes: SortListBytes
+- SortListBytesResult: 3
+  - SortError
+  - SortListBytes
+  - SortListBytesResult
+- SortListInt: SortListInt
+- SortListRef: SortListRef
+- SortListResult: 3
+  - SortError
+  - SortList
+  - SortListResult
+- SortLoadOp: SortLoadOp
+- SortLoadOpM: 2
+  - SortLoadOp
+  - SortLoadOpM
+- SortLocalDecl: SortLocalDecl
+- SortLocalDecls: SortLocalDecls
+- SortLocalIdsCell: SortLocalIdsCell
+- SortLocalIdsCellOpt: 2
+  - SortLocalIdsCell
+  - SortLocalIdsCellOpt
+- SortLocalsCell: SortLocalsCell
+- SortLocalsCellOpt: 2
+  - SortLocalsCell
+  - SortLocalsCellOpt
+- SortLogEntry: SortLogEntry
+- SortLoggingCell: SortLoggingCell
+- SortLoggingCellOpt: 2
+  - SortLoggingCell
+  - SortLoggingCellOpt
+- SortLogsCell: SortLogsCell
+- SortLogsCellOpt: 2
+  - SortLogsCell
+  - SortLogsCellOpt
+- SortMAddrCell: SortMAddrCell
+- SortMAddrCellOpt: 2
+  - SortMAddrCell
+  - SortMAddrCellOpt
+- SortMainStoreCell: SortMainStoreCell
+- SortMainStoreCellFragment: SortMainStoreCellFragment
+- SortMainStoreCellOpt: 2
+  - SortMainStoreCell
+  - SortMainStoreCellOpt
+- SortMandosCell: SortMandosCell
+- SortMandosCellFragment: SortMandosCellFragment
+- SortMandosCellOpt: 2
+  - SortMandosCell
+  - SortMandosCellOpt
+- SortMap: SortMap
+- SortMapBytesToBytes: SortMapBytesToBytes
+- SortMapIntToBytes: SortMapIntToBytes
+- SortMapIntToInt: SortMapIntToInt
+- SortMdataCell: SortMdataCell
+- SortMdataCellOpt: 2
+  - SortMdataCell
+  - SortMdataCellOpt
+- SortMemAddrsCell: SortMemAddrsCell
+- SortMemAddrsCellOpt: 2
+  - SortMemAddrsCell
+  - SortMemAddrsCellOpt
+- SortMemArg: 3
+  - SortAlignArg
+  - SortMemArg
+  - SortOffsetArg
+- SortMemIdsCell: SortMemIdsCell
+- SortMemIdsCellOpt: 2
+  - SortMemIdsCell
+  - SortMemIdsCellOpt
+- SortMemInstCell: SortMemInstCell
+- SortMemInstCellFragment: SortMemInstCellFragment
+- SortMemInstCellMap: 2
+  - SortMemInstCell
+  - SortMemInstCellMap
+- SortMemType: 4
+  - SortInt
+  - SortMemType
+  - SortTextLimits
+  - SortWasmInt
+- SortMemoryDefn: SortMemoryDefn
+- SortMemorySpec: 5
+  - SortInt
+  - SortMemType
+  - SortMemorySpec
+  - SortTextLimits
+  - SortWasmInt
+- SortMemsCell: SortMemsCell
+- SortMemsCellFragment: SortMemsCellFragment
+- SortMemsCellOpt: 2
+  - SortMemsCell
+  - SortMemsCellOpt
+- SortMmaxCell: SortMmaxCell
+- SortMmaxCellOpt: 2
+  - SortMmaxCell
+  - SortMmaxCellOpt
+- SortModIdxCell: SortModIdxCell
+- SortModIdxCellOpt: 2
+  - SortModIdxCell
+  - SortModIdxCellOpt
+- SortModuleDecl: SortModuleDecl
+- SortModuleFileNameCell: SortModuleFileNameCell
+- SortModuleFileNameCellOpt: 2
+  - SortModuleFileNameCell
+  - SortModuleFileNameCellOpt
+- SortModuleIdCell: SortModuleIdCell
+- SortModuleIdCellOpt: 2
+  - SortModuleIdCell
+  - SortModuleIdCellOpt
+- SortModuleIdsCell: SortModuleIdsCell
+- SortModuleIdsCellOpt: 2
+  - SortModuleIdsCell
+  - SortModuleIdsCellOpt
+- SortModuleInstCell: SortModuleInstCell
+- SortModuleInstCellFragment: SortModuleInstCellFragment
+- SortModuleInstCellMap: 2
+  - SortModuleInstCell
+  - SortModuleInstCellMap
+- SortModuleInstancesCell: SortModuleInstancesCell
+- SortModuleInstancesCellFragment: SortModuleInstancesCellFragment
+- SortModuleInstancesCellOpt: 2
+  - SortModuleInstancesCell
+  - SortModuleInstancesCellOpt
+- SortModuleMetadata: SortModuleMetadata
+- SortModuleMetadataCell: SortModuleMetadataCell
+- SortModuleMetadataCellFragment: SortModuleMetadataCellFragment
+- SortModuleMetadataCellOpt: 2
+  - SortModuleMetadataCell
+  - SortModuleMetadataCellOpt
+- SortModuleRegistryCell: SortModuleRegistryCell
+- SortModuleRegistryCellOpt: 2
+  - SortModuleRegistryCell
+  - SortModuleRegistryCellOpt
+- SortMsizeCell: SortMsizeCell
+- SortMsizeCellOpt: 2
+  - SortMsizeCell
+  - SortMsizeCellOpt
+- SortMut: SortMut
+- SortNewAddressesCell: SortNewAddressesCell
+- SortNewAddressesCellOpt: 2
+  - SortNewAddressesCell
+  - SortNewAddressesCellOpt
+- SortNextElemAddrCell: SortNextElemAddrCell
+- SortNextElemAddrCellOpt: 2
+  - SortNextElemAddrCell
+  - SortNextElemAddrCellOpt
+- SortNextElemIdxCell: SortNextElemIdxCell
+- SortNextElemIdxCellOpt: 2
+  - SortNextElemIdxCell
+  - SortNextElemIdxCellOpt
+- SortNextFuncAddrCell: SortNextFuncAddrCell
+- SortNextFuncAddrCellOpt: 2
+  - SortNextFuncAddrCell
+  - SortNextFuncAddrCellOpt
+- SortNextFuncIdxCell: SortNextFuncIdxCell
+- SortNextFuncIdxCellOpt: 2
+  - SortNextFuncIdxCell
+  - SortNextFuncIdxCellOpt
+- SortNextGlobAddrCell: SortNextGlobAddrCell
+- SortNextGlobAddrCellOpt: 2
+  - SortNextGlobAddrCell
+  - SortNextGlobAddrCellOpt
+- SortNextGlobIdxCell: SortNextGlobIdxCell
+- SortNextGlobIdxCellOpt: 2
+  - SortNextGlobIdxCell
+  - SortNextGlobIdxCellOpt
+- SortNextMemAddrCell: SortNextMemAddrCell
+- SortNextMemAddrCellOpt: 2
+  - SortNextMemAddrCell
+  - SortNextMemAddrCellOpt
+- SortNextModuleIdxCell: SortNextModuleIdxCell
+- SortNextModuleIdxCellOpt: 2
+  - SortNextModuleIdxCell
+  - SortNextModuleIdxCellOpt
+- SortNextTabAddrCell: SortNextTabAddrCell
+- SortNextTabAddrCellOpt: 2
+  - SortNextTabAddrCell
+  - SortNextTabAddrCellOpt
+- SortNextTabIdxCell: SortNextTabIdxCell
+- SortNextTabIdxCellOpt: 2
+  - SortNextTabIdxCell
+  - SortNextTabIdxCellOpt
+- SortNextTypeIdxCell: SortNextTypeIdxCell
+- SortNextTypeIdxCellOpt: 2
+  - SortNextTypeIdxCell
+  - SortNextTypeIdxCellOpt
+- SortNodeCell: SortNodeCell
+- SortNodeCellFragment: SortNodeCellFragment
+- SortNodeCellOpt: 2
+  - SortNodeCell
+  - SortNodeCellOpt
+- SortNonceCell: SortNonceCell
+- SortNonceCellOpt: 2
+  - SortNonceCell
+  - SortNonceCellOpt
+- SortNumber: 3
+  - SortFloat
+  - SortInt
+  - SortNumber
+- SortOffset: SortOffset
+- SortOffsetArg: SortOffsetArg
+- SortOptionalId: 3
+  - SortIdentifier
+  - SortIdentifierToken
+  - SortOptionalId
+- SortOptionalInt: 2
+  - SortInt
+  - SortOptionalInt
+- SortOptionalString: 2
+  - SortOptionalString
+  - SortString
+- SortOutCell: SortOutCell
+- SortOutCellOpt: 2
+  - SortOutCell
+  - SortOutCellOpt
+- SortOutputAccount: SortOutputAccount
+- SortOutputAccountsCell: SortOutputAccountsCell
+- SortOutputAccountsCellOpt: 2
+  - SortOutputAccountsCell
+  - SortOutputAccountsCellOpt
+- SortOutputTransfer: SortOutputTransfer
+- SortOwnerAddressCell: SortOwnerAddressCell
+- SortOwnerAddressCellOpt: 2
+  - SortOwnerAddressCell
+  - SortOwnerAddressCellOpt
+- SortPlainInstr: SortPlainInstr
+- SortPrankCell: SortPrankCell
+- SortPrankCellOpt: 2
+  - SortPrankCell
+  - SortPrankCellOpt
+- SortPrevBlockEpochCell: SortPrevBlockEpochCell
+- SortPrevBlockEpochCellOpt: 2
+  - SortPrevBlockEpochCell
+  - SortPrevBlockEpochCellOpt
+- SortPrevBlockNonceCell: SortPrevBlockNonceCell
+- SortPrevBlockNonceCellOpt: 2
+  - SortPrevBlockNonceCell
+  - SortPrevBlockNonceCellOpt
+- SortPrevBlockRandomSeedCell: SortPrevBlockRandomSeedCell
+- SortPrevBlockRandomSeedCellOpt: 2
+  - SortPrevBlockRandomSeedCell
+  - SortPrevBlockRandomSeedCellOpt
+- SortPrevBlockRoundCell: SortPrevBlockRoundCell
+- SortPrevBlockRoundCellOpt: 2
+  - SortPrevBlockRoundCell
+  - SortPrevBlockRoundCellOpt
+- SortPrevBlockTimestampCell: SortPrevBlockTimestampCell
+- SortPrevBlockTimestampCellOpt: 2
+  - SortPrevBlockTimestampCell
+  - SortPrevBlockTimestampCellOpt
+- SortPreviousBlockInfoCell: SortPreviousBlockInfoCell
+- SortPreviousBlockInfoCellFragment: SortPreviousBlockInfoCellFragment
+- SortPreviousBlockInfoCellOpt: 2
+  - SortPreviousBlockInfoCell
+  - SortPreviousBlockInfoCellOpt
+- SortRefVal: SortRefVal
+- SortRefValType: SortRefValType
+- SortReturnCode: 2
+  - SortExceptionCode
+  - SortReturnCode
+- SortSBItem: SortSBItem
+- SortSBItemChunk: SortSBItemChunk
+- SortSet: SortSet
+- SortSignedness: SortSignedness
+- SortSparseBytes: SortSparseBytes
+- SortStartDefn: SortStartDefn
+- SortStep: 2
+  - SortModuleDecl
+  - SortStep
+- SortSteps: SortSteps
+- SortStmt: 18
+  - SortBlockInstr
+  - SortDataDefn
+  - SortDefn
+  - SortElemDefn
+  - SortEmptyStmt
+  - SortExportDefn
+  - SortFoldedInstr
+  - SortFuncDefn
+  - SortGlobalDefn
+  - SortImportDefn
+  - SortInstr
+  - SortMemoryDefn
+  - SortModuleDecl
+  - SortPlainInstr
+  - SortStartDefn
+  - SortStmt
+  - SortTableDefn
+  - SortTypeDefn
+- SortStmts: 4
+  - SortDefns
+  - SortEmptyStmts
+  - SortInstrs
+  - SortStmts
+- SortStorageCell: SortStorageCell
+- SortStorageCellOpt: 2
+  - SortStorageCell
+  - SortStorageCellOpt
+- SortStoreOp: SortStoreOp
+- SortStoreOpM: 2
+  - SortStoreOp
+  - SortStoreOpM
+- SortStream: SortStream
+- SortString: SortString
+- SortTAddrCell: SortTAddrCell
+- SortTAddrCellOpt: 2
+  - SortTAddrCell
+  - SortTAddrCellOpt
+- SortTabAddrsCell: SortTabAddrsCell
+- SortTabAddrsCellOpt: 2
+  - SortTabAddrsCell
+  - SortTabAddrsCellOpt
+- SortTabIdsCell: SortTabIdsCell
+- SortTabIdsCellOpt: 2
+  - SortTabIdsCell
+  - SortTabIdsCellOpt
+- SortTabInstCell: SortTabInstCell
+- SortTabInstCellFragment: SortTabInstCellFragment
+- SortTabInstCellMap: 2
+  - SortTabInstCell
+  - SortTabInstCellMap
+- SortTableDefn: SortTableDefn
+- SortTableElemType: 2
+  - SortRefValType
+  - SortTableElemType
+- SortTableSpec: 2
+  - SortTableSpec
+  - SortTableType
+- SortTableType: SortTableType
+- SortTableUse: SortTableUse
+- SortTabsCell: SortTabsCell
+- SortTabsCellFragment: SortTabsCellFragment
+- SortTabsCellOpt: 2
+  - SortTabsCell
+  - SortTabsCellOpt
+- SortTdataCell: SortTdataCell
+- SortTdataCellOpt: 2
+  - SortTdataCell
+  - SortTdataCellOpt
+- SortTestOp: SortTestOp
+- SortTextFormatGlobalType: 5
+  - SortFValType
+  - SortIValType
+  - SortRefValType
+  - SortTextFormatGlobalType
+  - SortValType
+- SortTextLimits: 3
+  - SortInt
+  - SortTextLimits
+  - SortWasmInt
+- SortThrowException: SortThrowException
+- SortTmaxCell: SortTmaxCell
+- SortTmaxCellOpt: 2
+  - SortTmaxCell
+  - SortTmaxCellOpt
+- SortTransferTx: SortTransferTx
+- SortTransferValue: 3
+  - SortInt
+  - SortList
+  - SortTransferValue
+- SortTxCountCell: SortTxCountCell
+- SortTxCountCellOpt: 2
+  - SortTxCountCell
+  - SortTxCountCellOpt
+- SortTxHashCell: SortTxHashCell
+- SortTxHashCellOpt: 2
+  - SortTxHashCell
+  - SortTxHashCellOpt
+- SortType: 7
+  - SortFValType
+  - SortFuncType
+  - SortIValType
+  - SortRefValType
+  - SortType
+  - SortValType
+  - SortVecType
+- SortTypeDecl: SortTypeDecl
+- SortTypeDecls: SortTypeDecls
+- SortTypeDefn: SortTypeDefn
+- SortTypeIdsCell: SortTypeIdsCell
+- SortTypeIdsCellOpt: 2
+  - SortTypeIdsCell
+  - SortTypeIdsCellOpt
+- SortTypeKeyWord: SortTypeKeyWord
+- SortTypeUse: 2
+  - SortTypeDecls
+  - SortTypeUse
+- SortTypesCell: SortTypesCell
+- SortTypesCellOpt: 2
+  - SortTypesCell
+  - SortTypesCellOpt
+- SortTypesInfo: SortTypesInfo
+- SortVMOutput: SortVMOutput
+- SortVal: 4
+  - SortFVal
+  - SortIVal
+  - SortRefVal
+  - SortVal
+- SortValStack: SortValStack
+- SortValType: 4
+  - SortFValType
+  - SortIValType
+  - SortRefValType
+  - SortValType
+- SortValTypes: SortValTypes
+- SortValidatorRewardTx: SortValidatorRewardTx
+- SortValstackCell: SortValstackCell
+- SortValstackCellOpt: 2
+  - SortValstackCell
+  - SortValstackCellOpt
+- SortVecType: SortVecType
+- SortVmInputCell: SortVmInputCell
+- SortVmInputCellFragment: SortVmInputCellFragment
+- SortVmInputCellOpt: 2
+  - SortVmInputCell
+  - SortVmInputCellOpt
+- SortVmOutputCell: SortVmOutputCell
+- SortVmOutputCellOpt: 2
+  - SortVmOutputCell
+  - SortVmOutputCellOpt
+- SortWasmCell: SortWasmCell
+- SortWasmCellFragment: SortWasmCellFragment
+- SortWasmCellOpt: 2
+  - SortWasmCell
+  - SortWasmCellOpt
+- SortWasmInt: 2
+  - SortInt
+  - SortWasmInt
+- SortWasmIntToken: SortWasmIntToken
+- SortWasmStoreCell: SortWasmStoreCell
+- SortWasmStoreCellOpt: 2
+  - SortWasmStoreCell
+  - SortWasmStoreCellOpt
+- SortWasmString: 2
+  - SortWasmString
+  - SortWasmStringToken
+- SortWasmStringToken: SortWasmStringToken
+- SortWrappedBytes: SortWrappedBytes
+- SortWrappedInt: SortWrappedInt
+Rewrite rules by term index:
+- Anything Lbl#exception(_,_)_ELROND-NODE_InternalCmd_ExceptionCode_Bytes Anything: ELROND-CONFIG.exception-revert
+- Anything Lbl#throwException(_,_)_ELROND-NODE_ThrowException_ExceptionCode_String Anything: ELROND-CONFIG.throwException-cmd
+- Anything Lbl#throwExceptionBs(_,_)_ELROND-NODE_ThrowException_ExceptionCode_Bytes Anything: ELROND-CONFIG.throwExceptionBs-cmd
+- Anything LbladdToESDTBalance(_,_,_,_)_ESDT_InternalCmd_Bytes_Bytes_Int_Bool Anything: 3
+  - ESDT.addToESDTBalance
+  - ESDT.addToESDTBalance-new-esdtData
+  - ESDT.addToESDTBalance-new-err
+- Anything LblcallContractCb(_,_,_)_ASYNC_InternalCmd_Bytes_String_VmInputCell Anything: ASYNC.callContractCb
+- Anything LblesdtNftAddQuantity(_,_,_,_)_ESDT_InternalCmd_Bytes_Bytes_Int_Int Anything: ESDT.esdtNftAddQuantity
+- Anything LblesdtNftAddUri(_,_,_)_ESDT_InternalCmd_Bytes_Bytes_ListBytes Anything: 2
+  - ESDT.esdtNftAddUri
+  - ESDT.esdtNftAddUri-not-found
+- Anything LblmoveNFTToDestination(_,_,_,_)_ESDT_InternalCmd_Bytes_Bytes_Bytes_Int Anything: 3
+  - ESDT.moveNFTToDestination-self
+  - ESDT.moveNFTToDestination-existing
+  - ESDT.moveNFTToDestination-new
+- Anything LblsetAccountOwner(_,_)_ELROND-CONFIG_InternalCmd_Bytes_Bytes Anything: mx-semantics/elrond-config.md :  (512, 10)
+- Anything LbltransferESDT(_,_,_)_ESDT_InternalCmd_Bytes_Bytes_ESDTTransfer Anything: 2
+  - mx-semantics/esdt.md :  (40, 10)
+  - mx-semantics/esdt.md :  (49, 10)
+- Anything LbltransferFunds(_,_,_)_ELROND-CONFIG_InternalCmd_Bytes_Bytes_Int Anything: mx-semantics/elrond-config.md :  (532, 10)
+- Anything LbltransferFundsH(_,_,_)_ELROND-CONFIG_InternalCmd_Bytes_Bytes_Int Anything: 3
+  - ELROND-CONFIG.transferFundsH-self
+  - ELROND-CONFIG.transferFundsH-oofunds
+  - ELROND-CONFIG.transferFundsH
+- Anything Anything Anything: 12
+  - mx-semantics/auto-allocate.md :  (42, 10)
+  - wasm-semantics/wasm.md :  (355, 10)
+  - wasm-semantics/wasm.md :  (510, 10)
+  - wasm-semantics/wasm.md :  (346, 10)
+  - wasm-semantics/wasm.md :  (344, 10)
+  - wasm-semantics/wasm.md :  (345, 10)
+  - wasm-semantics/wasm.md :  (343, 10)
+  - wasm-semantics/wasm.md :  (1208, 10)
+  - wasm-semantics/wasm.md :  (1207, 10)
+  - wasm-semantics/wasm.md :  (353, 10)
+  - mx-semantics/auto-allocate.md :  (53, 10)
+  - ELROND-CONFIG.exception-skip
+- Anything Anything Lbl.List{"mandosSteps"}: MANDOS.steps-empty
+- Anything Anything LblcheckAccountESDTBalanceAux: mx-semantics/mandos.md :  (405, 10)
+- Anything Anything LblcheckAccountNonce: mx-semantics/mandos.md :  (367, 10)
+- Anything Anything LblqueryTx: mx-semantics/mandos.md :  (604, 10)
+- Anything Anything LblsetEsdtBalance: mx-semantics/mandos.md :  (164, 10)
+- Anything Lbl#mergeOutputs_ASYNC_InternalCmd Anything: 2
+  - ASYNC.mergeOutputs
+  - ASYNC.mergeOutputs-err
+- Anything Lbl#setVMOutput Anything: SWITCH.setVMOutput
+- Anything LbladdAsyncCall Anything: ASYNC.addAsyncCall
+- Anything LblappendToOutAccount Anything: 3
+  - ELROND-NODE.appendToOutAccount
+  - ELROND-NODE.appendToOutAccount-new-item
+  - ELROND-NODE.appendToOutAccount-zero
+- Anything LblasyncExecute Anything: ASYNC.asyncExecute
+- Anything LblcallContractString Anything: mx-semantics/elrond-config.md :  (592, 10)
+- Anything LblcallContractWasmString Anything: 5
+  - ELROND-CONFIG.callContract-builtin
+  - ELROND-CONFIG.callContract
+  - ELROND-CONFIG.callContract-err-callback
+  - ELROND-CONFIG.callContract-not-contract
+  - ELROND-CONFIG.callContract-not-found
+- Anything LblcheckAccountExists(_)_ELROND-NODE_InternalCmd_Bytes Anything: 2
+  - ELROND-NODE.checkAccountExists-pass
+  - ELROND-NODE.checkAccountExists-fail
+- Anything LblcheckAllowedToExecute Anything: 3
+  - ESDT.checkAllowedToExecute-system
+  - ESDT.checkAllowedToExecute-pass
+  - ESDT.checkAllowedToExecute-fail
+- Anything LblcheckBool Anything: 2
+  - ELROND-NODE.checkBool-f
+  - ELROND-NODE.checkBool-t
+- Anything LblcheckESDTBalance(_,_,_)_ESDT_InternalCmd_Bytes_Bytes_Int Anything: 2
+  - ESDT.checkESDTBalance
+  - ESDT.checkESDTBalance-oof
+- Anything LblcreateAccount Anything: 2
+  - ELROND-CONFIG.createAccount-existing
+  - ELROND-CONFIG.createAccount-new
+- Anything LbldetermineIsSCCallAfter Anything: 2
+  - ESDT.determineIsSCCallAfter-call
+  - ESDT.determineIsSCCallAfter-nocall
+- Anything LbldropAsyncLocalCall Anything: ASYNC.dropAsyncLocalCall
+- Anything LbldropCallState Anything: ELROND-NODE.dropCallState
+- Anything LbldropWorldState Anything: ELROND-NODE.dropWorldState
+- Anything LblesdtLocalBurn Anything: ESDT.esdtLocalBurn-cmd
+- Anything LblesdtLocalMint Anything: ESDT.esdtLocalMint-cmd
+- Anything LblesdtNftBurn(_,_,_,_)_ESDT_InternalCmd_Bytes_Bytes_Int_Int Anything: ESDT.esdtNftBurn
+- Anything LblesdtNftCreate Anything: ESDT.esdtNftCreate
+- Anything LblexecuteAsyncLocalCall Anything: ASYNC.executeAsyncLocalCall
+- Anything LblexecuteAsyncLocalCallback Anything: 2
+  - ASYNC.executeAsyncLocalCallback-no-callback
+  - ASYNC.executeAsyncLocalCallback
+- Anything LblnewWasmInstance Anything: ELROND-CONFIG.newWasmInstance
+- Anything LblpopCallState Anything: ELROND-NODE.popCallState
+- Anything LblpopWorldState Anything: ELROND-NODE.popWorldState
+- Anything LblprocessBuiltinFunction Anything: 9
+  - ESDT.ESDTNFTCreate
+  - ESDT.ESDTNFTTransfer
+  - ESDT.ESDTTransfer
+  - ESDT.MultiESDTNFTTransfer
+  - ESDT.ESDTLocalBurn
+  - ESDT.ESDTLocalMint
+  - ESDT.ESDTNFTAddQuantity
+  - ESDT.ESDTNFTBurn
+  - ESDT.ESDTNFTAddURI
+- Anything LblpushCallState Anything: ELROND-NODE.pushCallState
+- Anything LblpushWorldState Anything: ELROND-NODE.pushWorldState
+- Anything LblregisterAsyncCall Anything: ASYNC.registerAsyncCall
+- Anything LblremoveEmptyNft(_,_)_ESDT_InternalCmd_Bytes_Bytes Anything: 2
+  - ESDT.removeEmptyNft
+  - ESDT.removeEmptyNft-skip
+- Anything LblresetCallState Anything: ELROND-NODE.resetCallstate
+- Anything LblsaveLatestNonce Anything: ESDT.saveLatestNonce
+- Anything LblsaveNFT Anything: ESDT.saveNFT
+- Anything LblsetAccountCode Anything: ELROND-CONFIG.setAccountCode
+- Anything LblsetAccountFields Anything: ELROND-CONFIG.setAccountFields
+- Anything LblsetContractModIdx_ELROND-CONFIG_InternalCmd Anything: ELROND-CONFIG.setContractModIdx
+- Anything LbltransferESDTs(_,_,_)_ESDT_InternalCmd_Bytes_Bytes_List Anything: mx-semantics/esdt.md :  (27, 10)
+- Anything LbltransferESDTsAux(_,_,_)_ESDT_InternalCmd_Bytes_Bytes_List Anything: 2
+  - mx-semantics/esdt.md :  (34, 10)
+  - mx-semantics/esdt.md :  (33, 10)
+- Anything dotk LblcallTx: MANDOS.callTx
+- Anything dotk LblcallTxAux: MANDOS.callTxAux
+- Anything dotk LblcheckAccountBalance: mx-semantics/mandos.md :  (383, 10)
+- Anything dotk LblcheckAccountBalanceAux: mx-semantics/mandos.md :  (388, 10)
+- Anything dotk LblcheckAccountCode: mx-semantics/mandos.md :  (451, 10)
+- Anything dotk LblcheckAccountCodeAux: 2
+  - MANDOS.checkAccountCodeAux-code
+  - MANDOS.checkAccountCodeAux-no-code
+- Anything dotk LblcheckAccountESDTBalance: mx-semantics/mandos.md :  (400, 10)
+- Anything dotk LblcheckAccountESDTBalanceAux: mx-semantics/mandos.md :  (422, 10)
+- Anything dotk LblcheckAccountNonceAux: mx-semantics/mandos.md :  (371, 10)
+- Anything dotk LblcheckAccountStorage: mx-semantics/mandos.md :  (433, 10)
+- Anything dotk LblcheckAccountStorageAux: mx-semantics/mandos.md :  (438, 10)
+- Anything dotk LblcheckEsdtRoles: MANDOS.checkEsdtRoles
+- Anything dotk LblcheckExpectLogs: 2
+  - mx-semantics/mandos.md :  (585, 10)
+  - mx-semantics/mandos.md :  (590, 10)
+- Anything dotk LblcheckExpectMessage: mx-semantics/mandos.md :  (578, 10)
+- Anything dotk LblcheckExpectOut: mx-semantics/mandos.md :  (564, 10)
+- Anything dotk LblcheckExpectStatus: mx-semantics/mandos.md :  (571, 10)
+- Anything dotk LblcheckNoAdditionalAccounts: mx-semantics/mandos.md :  (498, 10)
+- Anything dotk LblcheckedAccount: mx-semantics/mandos.md :  (486, 10)
+- Anything dotk LblcheckedAccountAux: mx-semantics/mandos.md :  (491, 10)
+- Anything dotk LblclearCheckedAccounts: mx-semantics/mandos.md :  (506, 10)
+- Anything dotk LbldeployTx: mx-semantics/mandos.md :  (634, 10)
+- Anything dotk LbldeployTxAux: MANDOS.deployTxAux
+- Anything dotk LblmandosSteps: MANDOS.steps-seq
+- Anything dotk LblnewAddress: mx-semantics/mandos.md :  (289, 10)
+- Anything dotk LblnewAddressAux: mx-semantics/mandos.md :  (294, 10)
+- Anything dotk LblqueryTxAux: mx-semantics/mandos.md :  (607, 10)
+- Anything dotk Lblregister: mx-semantics/mandos.md :  (87, 10)
+- Anything dotk LblsetAccount: mx-semantics/mandos.md :  (149, 10)
+- Anything dotk LblsetAccountAux: mx-semantics/mandos.md :  (154, 10)
+- Anything dotk LblsetCurBlockInfo: 5
+  - mx-semantics/mandos.md :  (325, 10)
+  - mx-semantics/mandos.md :  (315, 10)
+  - mx-semantics/mandos.md :  (330, 10)
+  - mx-semantics/mandos.md :  (320, 10)
+  - mx-semantics/mandos.md :  (310, 10)
+- Anything dotk LblsetEsdtBalanceAux: 2
+  - MANDOS.setEsdtBalanceAux
+  - MANDOS.setEsdtBalanceAux-new
+- Anything dotk LblsetEsdtLastNonce: 2
+  - MANDOS.setEsdtLastNonce-existing
+  - MANDOS.setEsdtLastNonce-new
+- Anything dotk LblsetEsdtRoles: 2
+  - MANDOS.setEsdtRoles-existing
+  - MANDOS.setEsdtRoles-new
+- Anything dotk LblsetPrevBlockInfo: 5
+  - mx-semantics/mandos.md :  (350, 10)
+  - mx-semantics/mandos.md :  (340, 10)
+  - mx-semantics/mandos.md :  (355, 10)
+  - mx-semantics/mandos.md :  (345, 10)
+  - mx-semantics/mandos.md :  (335, 10)
+- Anything dotk Lbltransfer: mx-semantics/mandos.md :  (679, 10)
+- Anything dotk LbltransferTx: mx-semantics/mandos.md :  (686, 10)
+- Anything dotk LbltransferTxAux: mx-semantics/mandos.md :  (692, 10)
+- Anything dotk LblvalidatorReward: mx-semantics/mandos.md :  (707, 10)
+- Anything dotk LblvalidatorRewardTx: mx-semantics/mandos.md :  (714, 10)
+- Anything dotk LblvalidatorRewardTxAux: mx-semantics/mandos.md :  (718, 10)
+- Lbl#appendBytesToBuffer(_)_MANBUFOPS_InternalInstr_Int Anything Anything: mx-semantics/vmhooks/manBufOps.md :  (59, 10)
+- Lbl#appendBytes_ELROND-NODE_BytesOp Anything Anything: mx-semantics/elrond-node.md :  (225, 10)
+- Lbl#appendToOut(_)_ELROND-NODE_InternalInstr_Bytes Anything Anything: mx-semantics/elrond-node.md :  (250, 10)
+- Lbl#appendToOutFromBytesStack_ELROND-NODE_InternalInstr Anything Anything: mx-semantics/elrond-node.md :  (246, 10)
+- Lbl#bigIntGetESDTExternalBalance(_)_BIGINTOPS_InternalInstr_Int Anything Anything: 2
+  - mx-semantics/vmhooks/bigIntOps.md :  (509, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (525, 10)
+- Lbl#bytesEqual_ELROND-NODE_InternalInstr Anything Anything: mx-semantics/elrond-node.md :  (235, 10)
+- Lbl#callIndirect(_,_)_WASM_Instr_RefVal_FuncType Anything Anything: 3
+  - WASM.callIndirect-null-ref
+  - WASM.callIndirect-invoke
+  - WASM.callIndirect-wrong-type
+- Lbl#checkESDTRole(_)_KASMER_InternalInstr_ESDTLocalRole Anything Anything: 3
+  - KASMER.checkESDTRole-exists
+  - KASMER.checkESDTRole-none
+  - KASMER.checkESDTRole-not-found
+- Lbl#createAsyncCallWithTypedArgs(_,_,_,_,_,_,_)_BASEOPS_InternalInstr_BytesResult_IntResult_BytesResult_ListBytesResult_Int_Int_BytesResult Anything Anything: BASEOPS.createAsyncCallWithTypedArgs
+- Lbl#dropBytes_ELROND-NODE_BytesOp Anything Anything: mx-semantics/elrond-node.md :  (222, 10)
+- Lbl#elemAux(_,_)_WASM_ElemDefn_Int_ElemMode Anything Anything: 3
+  - WASM.elem-active-aux
+  - WASM.elem-declarative-aux
+  - WASM.elem-passive-aux
+- Lbl#elemCheckSizeGTE(_,_)_WASM_Instr_Int_Int Anything Anything: 2
+  - WASM.elemCheckSizeGTE-pass
+  - WASM.elemCheckSizeGTE-fail
+- Lbl#executeOnDestContext(_,_,_,_,_,_)_BASEOPS_InternalInstr_Bytes_Int_List_Int_Bytes_ListBytes Anything Anything: BASEOPS.executeOnDestContext
+- Lbl#executeOnDestContextWithTypedArgs(_,_,_,_,_,_)_BASEOPS_InternalInstr_BytesResult_IntResult_ListResult_Int_BytesResult_ListBytesResult Anything Anything: BASEOPS.executeOnDestContextWithTypedArgs
+- Lbl#getArgsFromMemory(_,_,_)_ELROND-CONFIG_InternalInstr_Int_Int_Int Anything Anything: 2
+  - mx-semantics/elrond-config.md :  (343, 10)
+  - mx-semantics/elrond-config.md :  (349, 10)
+- Lbl#getArgsFromMemoryAux(_,_,_,_,_)_ELROND-CONFIG_InternalInstr_Int_Int_Int_Int_Int Anything Anything: 2
+  - mx-semantics/elrond-config.md :  (360, 10)
+  - mx-semantics/elrond-config.md :  (354, 10)
+- Lbl#getBigInt(_,_)_BIGINT-HELPERS_InternalInstr_Int_Signedness Anything Anything: 2
+  - mx-semantics/vmhooks/bigIntOps.md :  (25, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (35, 10)
+- Lbl#getBigIntOrCreate(_,_)_BIGINT-HELPERS_InternalInstr_Int_Signedness Anything Anything: 2
+  - BIGINT-HELPERS.getBigIntOrCreate-get
+  - BIGINT-HELPERS.getBigIntOrCreate-create
+- Lbl#getBuffer(_)_MANBUFOPS_InternalInstr_Int Anything Anything: 2
+  - MANBUFOPS.getBuffer
+  - MANBUFOPS.getBuffer-not-found
+- Lbl#getESDTTokenData_MANAGEDEI_InternalInstr Anything Anything: 2
+  - MANAGEDEI.getESDTTokenData-nft
+  - MANAGEDEI.getESDTTokenData-ft
+- Lbl#getExternalBalance_BASEOPS_InternalInstr Anything Anything: 2
+  - mx-semantics/vmhooks/baseOps.md :  (76, 10)
+  - mx-semantics/vmhooks/baseOps.md :  (85, 10)
+- Lbl#hashManBuffer(_,_,_)_CRYPTOEI-HELPERS_InternalInstr_Int_Int_HashBytesStackInstr Anything Anything: CRYPTOEI-HELPERS.hashManBuffer
+- Lbl#hashMemory(_,_,_,_)_CRYPTOEI-HELPERS_InternalInstr_Int_Int_Int_HashBytesStackInstr Anything Anything: mx-semantics/vmhooks/cryptoei.md :  (30, 10)
+- Lbl#init_locals___WASM-INTERNAL-SYNTAX_Instr_Int_ValStack Anything Anything: 2
+  - wasm-semantics/wasm.md :  (564, 10)
+  - wasm-semantics/wasm.md :  (563, 10)
+- Lbl#isReservedKey(_)_ELROND-CONFIG_InternalInstr_String Anything Anything: 2
+  - mx-semantics/elrond-config.md :  (200, 10)
+  - mx-semantics/elrond-config.md :  (203, 10)
+- Lbl#keccakFromBytesStack_CRYPTOEI-HELPERS_HashBytesStackInstr Anything Anything: mx-semantics/vmhooks/cryptoei.md :  (25, 10)
+- Lbl#loadArgData(_,_,_,_,_,_)_ELROND-CONFIG_InternalInstr_Int_Int_Int_Int_Int_Int Anything Anything: mx-semantics/elrond-config.md :  (377, 10)
+- Lbl#loadArgDataWithLengthOnStack(_,_,_,_,_)_ELROND-CONFIG_InternalInstr_Int_Int_Int_Int_Int Anything Anything: mx-semantics/elrond-config.md :  (370, 10)
+- Lbl#loadBytesAsSInt64(_)_ELROND-CONFIG_InternalInstr_String Anything Anything: mx-semantics/elrond-config.md :  (313, 10)
+- Lbl#loadBytesAsUInt64(_)_ELROND-CONFIG_InternalInstr_String Anything Anything: mx-semantics/elrond-config.md :  (310, 10)
+- Lbl#mBufferCopyByteSliceH(_,_,_)_MANBUFOPS_InternalInstr_Int_Int_Int Anything Anything: 2
+  - mx-semantics/vmhooks/manBufOps.md :  (303, 10)
+  - mx-semantics/vmhooks/manBufOps.md :  (312, 10)
+- Lbl#mBufferGetByteSliceH(_,_,_)_MANBUFOPS_InternalInstr_Int_Int_Int Anything Anything: 2
+  - mx-semantics/vmhooks/manBufOps.md :  (228, 10)
+  - mx-semantics/vmhooks/manBufOps.md :  (237, 10)
+- Lbl#memLoad(_,_)_ELROND-CONFIG_InternalInstr_Int_Int Anything Anything: 5
+  - ELROND-CONFIG.memLoad-zero-length
+  - ELROND-CONFIG.memLoad-negative-length
+  - ELROND-CONFIG.memLoad
+  - ELROND-CONFIG.memLoad-bad-bounds
+  - ELROND-CONFIG.memLoad-owise
+- Lbl#memStore(_,_)_ELROND-CONFIG_InternalInstr_Int_Bytes Anything Anything: 4
+  - mx-semantics/elrond-config.md :  (58, 10)
+  - mx-semantics/elrond-config.md :  (80, 10)
+  - mx-semantics/elrond-config.md :  (63, 10)
+  - ELROND-CONFIG.memStore-owise
+- Lbl#memStoreFromBytesStack(_)_ELROND-CONFIG_InternalInstr_Int Anything Anything: mx-semantics/elrond-config.md :  (55, 10)
+- Lbl#pushBytes(_)_ELROND-NODE_BytesOp_Bytes Anything Anything: mx-semantics/elrond-node.md :  (219, 10)
+- Lbl#returnData(_,_)_BASEOPS_InternalInstr_Int_Int Anything Anything: mx-semantics/vmhooks/baseOps.md :  (328, 10)
+- Lbl#returnIfSInt64(_,_)_ELROND-CONFIG_InternalInstr_Int_String Anything Anything: 2
+  - mx-semantics/elrond-config.md :  (302, 10)
+  - mx-semantics/elrond-config.md :  (299, 10)
+- Lbl#returnIfUInt64(_,_)_ELROND-CONFIG_InternalInstr_Int_String Anything Anything: 2
+  - mx-semantics/elrond-config.md :  (294, 10)
+  - mx-semantics/elrond-config.md :  (291, 10)
+- Lbl#returnLength_ELROND-NODE_InternalInstr Anything Anything: mx-semantics/elrond-node.md :  (230, 10)
+- Lbl#setBalance(_,_)_KASMER_InternalInstr_BytesResult_IntResult Anything Anything: 5
+  - KASMER.setBalance-invalid-big-int
+  - KASMER.setBalance-neg
+  - KASMER.setBalance-invalid-buffer
+  - KASMER.setBalance
+  - KASMER.setBalance-acct-not-found
+- Lbl#setBigInt(_,_,_)_BIGINT-HELPERS_InternalInstr_Int_Bytes_Signedness Anything Anything: mx-semantics/vmhooks/bigIntOps.md :  (65, 10)
+- Lbl#setBigIntFromBytesStack(_,_)_BIGINT-HELPERS_InternalInstr_Int_Signedness Anything Anything: mx-semantics/vmhooks/bigIntOps.md :  (62, 10)
+- Lbl#setBigIntValue(_,_)_BIGINT-HELPERS_InternalInstr_Int_Int Anything Anything: mx-semantics/vmhooks/bigIntOps.md :  (68, 10)
+- Lbl#setBuffer(_,_)_MANBUFOPS_InternalInstr_Int_Bytes Anything Anything: mx-semantics/vmhooks/manBufOps.md :  (54, 10)
+- Lbl#setBufferFromBytesStack(_)_MANBUFOPS_InternalInstr_Int Anything Anything: mx-semantics/vmhooks/manBufOps.md :  (51, 10)
+- Lbl#setESDTBalance(_)_KASMER_InternalInstr_IntResult Anything Anything: 5
+  - KASMER.setESDTBalance-invalid-big-int
+  - KASMER.setESDTBalance-neg
+  - KASMER.setESDTBalance
+  - KASMER.setESDTBalance-new-token
+  - KASMER.setESDTBalance-acct-not-found
+- Lbl#setESDTRole(_,_)_KASMER_InternalInstr_ESDTLocalRole_Bool Anything Anything: 4
+  - KASMER.setESDTRole-set-existing
+  - KASMER.setESDTRole-add-new
+  - KASMER.setESDTRole-remove-skip
+  - KASMER.setESDTRole-not-found
+- Lbl#setReturnDataIfExists(_,_)_MANAGEDEI_InternalInstr_Int_Int Anything Anything: 2
+  - MANAGEDEI.setReturnDataIfExists-noData
+  - MANAGEDEI.setReturnDataIfExists
+- Lbl#setStorage(_,_)_ELROND-CONFIG_InternalInstr_Bytes_Bytes Anything Anything: mx-semantics/elrond-config.md :  (167, 10)
+- Lbl#sha256FromBytesStack_CRYPTOEI-HELPERS_HashBytesStackInstr Anything Anything: mx-semantics/vmhooks/cryptoei.md :  (20, 10)
+- Lbl#signalError_BASEOPS_InternalInstr Anything Anything: mx-semantics/vmhooks/baseOps.md :  (347, 10)
+- Lbl#sliceBytes(_,_)_MANBUFOPS_InternalInstr_Int_Int Anything Anything: mx-semantics/vmhooks/manBufOps.md :  (68, 10)
+- Lbl#startPrank(_)_KASMER_InternalInstr_BytesResult Anything Anything: 3
+  - KASMER.startPrank
+  - KASMER.startPrank-not-allowed
+  - KASMER.startPrank-err
+- Lbl#storageLoadFromAddress_ELROND-CONFIG_InternalInstr Anything Anything: 2
+  - ELROND-CONFIG.storageLoadFromAddress
+  - ELROND-CONFIG.storageLoadFromAddress-unknown-addr
+- Lbl#storageLoad_ELROND-CONFIG_InternalInstr Anything Anything: mx-semantics/elrond-config.md :  (211, 10)
+- Lbl#storageStore_ELROND-CONFIG_InternalInstr Anything Anything: mx-semantics/elrond-config.md :  (162, 10)
+- Lbl#tableCheckSizeGTE(_,_)_WASM_Instr_Int_Int Anything Anything: 2
+  - WASM.tableCheckSizeGTE-pass
+  - WASM.tableCheckSizeGTE-fail
+- Lbl#tableCopy(_,_,_,_,_)_WASM_Instr_Int_Int_Int_Int_Int Anything Anything: 3
+  - WASM.tableCopy-LR
+  - WASM.tableCopy-RL
+  - WASM.tableCopy-zero
+- Lbl#tableFill(_,_,_,_)_WASM_Instr_Int_Int_RefVal_Int Anything Anything: 2
+  - WASM.tableFill-loop
+  - WASM.tableFill-zero
+- Lbl#tableGet(_,_)_WASM_Instr_Int_Int Anything Anything: 2
+  - WASM.tableGet-trap
+  - WASM.tableGet
+- Lbl#tableInit(_,_,_,_)_WASM_Instr_Int_Int_Int_ListRef Anything Anything: 2
+  - WASM.tableInit
+  - WASM.tableInit-done
+- Lbl#tableSet(_,_,_)_WASM_Instr_Int_RefVal_Int Anything Anything: 2
+  - WASM.tableSet
+  - WASM.tableSet-oob
+- Lbl#throwException(_,_)_ELROND-NODE_ThrowException_ExceptionCode_String Anything Anything: ELROND-CONFIG.throwException
+- Lbl#throwExceptionBs(_,_)_ELROND-NODE_ThrowException_ExceptionCode_Bytes Anything Anything: ELROND-CONFIG.throwExceptionBs
+- Lbl#transferESDTNFTExecuteWithTypedArgs(_,_,_,_,_)_BASEOPS_InternalInstr_BytesResult_ListResult_Int_BytesResult_ListBytesResult Anything Anything: 2
+  - mx-semantics/vmhooks/baseOps.md :  (417, 10)
+  - BASEOPS.transfer-esdt-and-execute
+- Lbl#transferValueExecuteWithTypedArgs(_,_,_,_,_)_BASEOPS_InternalInstr_BytesResult_IntResult_Int_BytesResult_ListBytesResult Anything Anything: 2
+  - mx-semantics/vmhooks/baseOps.md :  (435, 10)
+  - BASEOPS.transfer-and-execute
+- Lbl#transferValue_BASEOPS_InternalInstr Anything Anything: mx-semantics/vmhooks/baseOps.md :  (106, 10)
+- Lbl#waitCommands Lbl#endWasm Anything: SWITCH.waitCommands
+- Lbl#writeBytesToBuffer(_)_MANAGEDCONVERSIONS_InternalInstr_Bytes Anything Anything: MANAGEDCONVERSIONS.writeBytesToBuffer
+- Lbl#writeEsdtToBytes(_)_MANAGEDCONVERSIONS_InternalInstr_ESDTTransfer Anything Anything: mx-semantics/vmhooks/managedConversions.md :  (33, 10)
+- Lbl#writeEsdtsToBytes(_)_MANAGEDCONVERSIONS_InternalInstr_List Anything Anything: mx-semantics/vmhooks/managedConversions.md :  (20, 10)
+- Lbl#writeEsdtsToBytesH(_)_MANAGEDCONVERSIONS_InternalInstr_List Anything Anything: 2
+  - mx-semantics/vmhooks/managedConversions.md :  (25, 10)
+  - mx-semantics/vmhooks/managedConversions.md :  (27, 10)
+- Lbl#writeListBytesToBuffers(_)_MANAGEDCONVERSIONS_InternalInstr_ListBytes Anything Anything: MANAGEDCONVERSIONS.writeListBytesToBuffers
+- Lbl#writeListBytesToBuffersH(_)_MANAGEDCONVERSIONS_InternalInstr_ListBytes Anything Anything: 2
+  - MANAGEDCONVERSIONS.writeListBytesToBuffersH-nil
+  - MANAGEDCONVERSIONS.writeListBytesToBuffersH-cons
+- Lbl#writeLogAux(_,_,_)_ELROND-CONFIG_InternalInstr_Int_ListBytes_Bytes Anything Anything: 2
+  - mx-semantics/elrond-config.md :  (390, 10)
+  - mx-semantics/elrond-config.md :  (395, 10)
+- Lbl#writeLog_ELROND-CONFIG_InternalInstr Anything Anything: mx-semantics/elrond-config.md :  (386, 10)
+- Lbl#writeManagedVecOfManagedBuffers(_,_)_MANAGEDCONVERSIONS_InternalInstr_ListBytes_Int Anything Anything: MANAGEDCONVERSIONS.writeManagedVecOfManagedBuffers
+- Lbl#writeToStorage(_,_)_ELROND-CONFIG_InternalInstr_Bytes_Bytes Anything Anything: 3
+  - mx-semantics/elrond-config.md :  (175, 10)
+  - mx-semantics/elrond-config.md :  (184, 10)
+  - ELROND-CONFIG.writeToStorage-unknown-addr
+- Lbl(invoke_)_WASM_Instr_Int Anything Anything: wasm-semantics/wasm.md :  (1189, 10)
+- Lbl_.___WASM_Instr_IValType_LoadOp_Int Anything Anything: 7
+  - wasm-semantics/wasm.md :  (1452, 10)
+  - wasm-semantics/wasm.md :  (1449, 10)
+  - wasm-semantics/wasm.md :  (1446, 10)
+  - wasm-semantics/wasm.md :  (1451, 10)
+  - wasm-semantics/wasm.md :  (1448, 10)
+  - wasm-semantics/wasm.md :  (1450, 10)
+  - wasm-semantics/wasm.md :  (1447, 10)
+- Lbl_.____WASM_Instr_IValType_StoreOp_Int_Int Anything Anything: 4
+  - wasm-semantics/wasm.md :  (1425, 10)
+  - wasm-semantics/wasm.md :  (1428, 10)
+  - wasm-semantics/wasm.md :  (1427, 10)
+  - wasm-semantics/wasm.md :  (1426, 10)
+- LblaBlock Anything Anything: wasm-semantics/wasm.md :  (498, 10)
+- LblaBr Anything Anything: 2
+  - wasm-semantics/wasm.md :  (511, 10)
+  - wasm-semantics/wasm.md :  (513, 10)
+- LblaBr_if Anything Anything: 2
+  - wasm-semantics/wasm.md :  (518, 10)
+  - wasm-semantics/wasm.md :  (521, 10)
+- LblaBr_table Anything Anything: wasm-semantics/wasm.md :  (527, 10)
+- LblaCall Anything Anything: wasm-semantics/wasm.md :  (1219, 10)
+- LblaCall_indirect Anything Anything: WASM.call-indirect-getRef
+- LblaCvtOp Anything Anything: 4
+  - wasm-semantics/wasm.md :  (435, 10)
+  - wasm-semantics/wasm.md :  (438, 10)
+  - wasm-semantics/wasm.md :  (429, 10)
+  - wasm-semantics/wasm.md :  (432, 10)
+- LblaDataDefn Anything Anything: wasm-semantics/wasm.md :  (1643, 10)
+- LblaDrop Anything Anything: wasm-semantics/wasm.md :  (449, 10)
+- LblaElem.drop Anything Anything: WASM.elem.drop
+- LblaElemDefn Anything Anything: WASM.elem-active
+- LblaExportDefn Anything Anything: wasm-semantics/wasm.md :  (1692, 10)
+- LblaExtendS Anything Anything: wasm-semantics/wasm.md :  (389, 10)
+- LblaFBinOp Anything Anything: wasm-semantics/wasm.md :  (400, 10)
+- LblaFConst Anything Anything: wasm-semantics/wasm.md :  (373, 10)
+- LblaFRelOp Anything Anything: wasm-semantics/wasm.md :  (420, 10)
+- LblaFUnOp Anything Anything: wasm-semantics/wasm.md :  (387, 10)
+- LblaFuncDefn Anything Anything: wasm-semantics/wasm.md :  (1132, 10)
+- LblaGlobal.get Anything Anything: wasm-semantics/wasm.md :  (641, 10)
+- LblaGlobal.set Anything Anything: wasm-semantics/wasm.md :  (655, 10)
+- LblaGlobalDefn Anything Anything: wasm-semantics/wasm.md :  (608, 10)
+- LblaGrow Anything Anything: wasm-semantics/wasm.md :  (1510, 10)
+- LblaIBinOp Anything Anything: wasm-semantics/wasm.md :  (398, 10)
+- LblaIConst Anything Anything: wasm-semantics/wasm.md :  (372, 10)
+- LblaIRelOp Anything Anything: wasm-semantics/wasm.md :  (418, 10)
+- LblaIUnOp Anything Anything: wasm-semantics/wasm.md :  (385, 10)
+- LblaIf Anything Anything: 2
+  - wasm-semantics/wasm.md :  (536, 10)
+  - wasm-semantics/wasm.md :  (540, 10)
+- LblaImportDefn Anything Anything: 4
+  - wasm-semantics/wasm.md :  (1717, 10)
+  - wasm-semantics/wasm.md :  (1791, 10)
+  - wasm-semantics/wasm.md :  (1767, 10)
+  - wasm-semantics/wasm.md :  (1743, 10)
+- LblaImportDefnHelper Anything Anything: wasm-semantics/wasm.md :  (1727, 10)
+- LblaLoad Anything Anything: wasm-semantics/wasm.md :  (1443, 10)
+- LblaLocal.get Anything Anything: wasm-semantics/wasm.md :  (578, 10)
+- LblaLocal.set Anything Anything: wasm-semantics/wasm.md :  (582, 10)
+- LblaLocal.tee Anything Anything: wasm-semantics/wasm.md :  (587, 10)
+- LblaLoop Anything Anything: wasm-semantics/wasm.md :  (546, 10)
+- LblaMemoryDefn Anything Anything: 2
+  - wasm-semantics/wasm.md :  (1353, 10)
+  - wasm-semantics/wasm.md :  (1355, 10)
+- LblaModuleDecl Anything Anything: WASM.newModule
+- LblaNop Anything Anything: wasm-semantics/wasm.md :  (471, 10)
+- LblaRef.func Anything Anything: WASM.ref.func
+- LblaRef.is_null Anything Anything: 2
+  - WASM.ref.isNull-true
+  - WASM.ref.isNull-false
+- LblaRef.null Anything Anything: 4
+  - WASM.ref.null.extern
+  - wasm-semantics/wasm.md :  (375, 10)
+  - WASM.ref.null.func
+  - wasm-semantics/wasm.md :  (376, 10)
+- LblaReturn Anything Anything: wasm-semantics/wasm.md :  (1209, 10)
+- LblaSelect Anything Anything: 2
+  - wasm-semantics/wasm.md :  (458, 10)
+  - wasm-semantics/wasm.md :  (452, 10)
+- LblaSize Anything Anything: wasm-semantics/wasm.md :  (1487, 10)
+- LblaStartDefn Anything Anything: wasm-semantics/wasm.md :  (1673, 10)
+- LblaStore Anything Anything: wasm-semantics/wasm.md :  (1392, 10)
+- LblaTable.copy Anything Anything: 2
+  - WASM.table.copy-self
+  - WASM.table.copy
+- LblaTable.fill Anything Anything: WASM.table.fill
+- LblaTable.get Anything Anything: WASM.table.get
+- LblaTable.grow Anything Anything: 2
+  - WASM.table.grow-fail
+  - WASM.table.grow
+- LblaTable.init Anything Anything: WASM.table.init
+- LblaTable.set Anything Anything: WASM.table.set
+- LblaTable.size Anything Anything: WASM.table.size
+- LblaTableDefn Anything Anything: 2
+  - wasm-semantics/wasm.md :  (1308, 10)
+  - wasm-semantics/wasm.md :  (1310, 10)
+- LblaTestOp Anything Anything: wasm-semantics/wasm.md :  (409, 10)
+- LblaTypeDefn Anything Anything: wasm-semantics/wasm.md :  (1103, 10)
+- LblaUnreachable Anything Anything: wasm-semantics/wasm.md :  (477, 10)
+- Lblallocelem(_,_,_)_WASM_Alloc_RefValType_ListRef_OptionalId Anything Anything: WASM.allocelem
+- Lblallocfunc(_,_,_,_,_,_)_WASM_Alloc_Int_Int_FuncType_VecType_Instrs_FuncMetadata Anything Anything: wasm-semantics/wasm.md :  (1143, 10)
+- Lblallocglobal(_,_)_WASM_Alloc_OptionalId_GlobalType Anything Anything: wasm-semantics/wasm.md :  (610, 10)
+- Lblallocmemory(_,_,_)_WASM_Alloc_OptionalId_Int_OptionalInt Anything Anything: wasm-semantics/wasm.md :  (1359, 10)
+- Lblalloctable(_,_,_,_)_WASM_Alloc_OptionalId_Int_OptionalInt_RefValType Anything Anything: wasm-semantics/wasm.md :  (1314, 10)
+- Lblalloctype(_,_)_WASM_Alloc_OptionalId_FuncType Anything Anything: wasm-semantics/wasm.md :  (1105, 10)
+- LblcheckIsSmartContract Anything Anything: 2
+  - BASEOPS.checkIsSmartContract-no-code
+  - BASEOPS.checkIsSmartContract-code
+- Lbldata{__}_WASM_DataDefn_Int_Bytes Anything Anything: wasm-semantics/wasm.md :  (1646, 10)
+- LblendFoundryImmediately Anything Anything: KASMER.endFoundryImmediately
+- LblfinishExecuteOnDestContext Anything Anything: 2
+  - BASEOPS.finishExecuteOnDestContext-ok
+  - BASEOPS.finishExecuteOnDestContext-exception
+- LblfoundryAssert Anything Anything: 2
+  - KASMER.foundryAssert-true
+  - KASMER.foundryAssert-false
+- LblfoundryAssume Anything Anything: 2
+  - KASMER.foundryAssume-true
+  - KASMER.foundryAssume-false
+- LblfoundryCreateAccount(_,_,_)_KASMER_InternalInstr_BytesResult_Int_IntResult Anything Anything: 2
+  - KASMER.foundryCreateAccount
+  - KASMER.foundryCreateAccount-err
+- LblfoundryDeployContract(_,_,_,_,_,_)_KASMER_InternalInstr_BytesResult_Int_IntResult_BytesResult_ListBytesResult_Int Anything Anything: 2
+  - KASMER.foundryDeployContract
+  - KASMER.foundryDeployContract-err
+- LblfoundryRegisterNewAddress(_,_,_)_KASMER_InternalInstr_BytesResult_Int_BytesResult Anything Anything: 2
+  - KASMER.foundryRegisterNewAddress
+  - KASMER.foundryRegisterNewAddress-err
+- LblfoundryWriteToStorage_KASMER_InternalInstr Anything Anything: 2
+  - KASMER.foundryWriteToStorage-empty
+  - KASMER.foundryWriteToStorage
+- Lblframe_____WASM_Frame_Int_ValTypes_ValStack_Map Anything Anything: wasm-semantics/wasm.md :  (1175, 10)
+- LblgetCurrentESDTNFTNonce Anything Anything: 2
+  - BASEOPS.getCurrentESDTNFTNonce
+  - BASEOPS.getCurrentESDTNFTNonce-none
+- LblgetESDTLocalRoles Anything Anything: 2
+  - MANAGEDEI.getESDTLocalRoles-aux
+  - MANAGEDEI.getESDTLocalRoles-aux-nil
+- Lblgrow__WASM_Instr_Int Anything Anything: 2
+  - wasm-semantics/wasm.md :  (1528, 10)
+  - wasm-semantics/wasm.md :  (1513, 10)
+- LblhostCall(_,_,_)_WASM-AUTO-ALLOCATE_Instr_String_String_FuncType Anything Anything: 147
+  - KASMER.testapi-createAccount
+  - KASMER.testapi-deployContract
+  - KASMER.testapi-registerNewAddress
+  - KASMER.testapi-setESDTExternalBalance
+  - KASMER.testapi-setExternalBalance
+  - KASMER.testapi-startPrank
+  - MANAGEDEI.managedExecuteOnDestContext
+  - MANAGEDEI.managedCreateAsyncCall
+  - MANAGEDEI.managedMultiTransferESDTNFTExecute
+  - mx-semantics/vmhooks/managedei.md :  (90, 10)
+  - MANAGEDEI.managedAsyncCall
+  - mx-semantics/vmhooks/baseOps.md :  (21, 10)
+  - mx-semantics/vmhooks/managedei.md :  (82, 10)
+  - KASMER.testapi-getStorage
+  - KASMER.testapi-setStorage
+  - BIGINTOPS.bigIntAbs-invalid-handle
+  - BIGINTOPS.bigIntAbs
+  - mx-semantics/vmhooks/bigIntOps.md :  (240, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (256, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (364, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (379, 10)
+  - BIGINTOPS.bigIntGetInt64-invalid-handle
+  - BIGINTOPS.bigIntGetInt64
+  - BIGINTOPS.bigIntGetInt64-not-int64
+  - BIGINTOPS.bigIntIsInt64
+  - BIGINTOPS.bigIntIsInt64-invalid-handle
+  - mx-semantics/vmhooks/bigIntOps.md :  (288, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (302, 10)
+  - BIGINTOPS.bigIntNeg-invalid-handle
+  - BIGINTOPS.bigIntNeg
+  - mx-semantics/vmhooks/bigIntOps.md :  (128, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (343, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (355, 10)
+  - BIGINTOPS.bigIntSqrt-invalid-handle
+  - BIGINTOPS.bigIntSqrt
+  - BIGINTOPS.bigIntSqrt-neg
+  - mx-semantics/vmhooks/bigIntOps.md :  (265, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (279, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (311, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (333, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (325, 10)
+  - mx-semantics/vmhooks/manBufOps.md :  (252, 10)
+  - mx-semantics/vmhooks/baseOps.md :  (406, 9)
+  - KASMER.testapi-assertBool
+  - KASMER.testapi-assumeBool
+  - mx-semantics/vmhooks/bigIntOps.md :  (397, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (389, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (489, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (476, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (200, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (190, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (228, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (219, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (210, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (151, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (418, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (405, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (142, 10)
+  - KASMER.testapi-checkESDTRole
+  - mx-semantics/vmhooks/baseOps.md :  (317, 10)
+  - mx-semantics/vmhooks/baseOps.md :  (268, 10)
+  - MANAGEDEI.getESDTLocalRoles
+  - mx-semantics/vmhooks/baseOps.md :  (62, 10)
+  - mx-semantics/vmhooks/baseOps.md :  (32, 10)
+  - mx-semantics/vmhooks/cryptoei.md :  (81, 10)
+  - mx-semantics/vmhooks/manBufOps.md :  (174, 10)
+  - mx-semantics/vmhooks/manBufOps.md :  (198, 10)
+  - mx-semantics/vmhooks/manBufOps.md :  (293, 10)
+  - mx-semantics/vmhooks/manBufOps.md :  (185, 10)
+  - mx-semantics/vmhooks/manBufOps.md :  (284, 10)
+  - mx-semantics/vmhooks/manBufOps.md :  (114, 10)
+  - mx-semantics/vmhooks/manBufOps.md :  (104, 10)
+  - mx-semantics/vmhooks/manBufOps.md :  (217, 10)
+  - mx-semantics/vmhooks/manBufOps.md :  (94, 10)
+  - mx-semantics/vmhooks/manBufOps.md :  (208, 10)
+  - mx-semantics/vmhooks/manBufOps.md :  (84, 10)
+  - mx-semantics/vmhooks/manBufOps.md :  (133, 10)
+  - mx-semantics/vmhooks/manBufOps.md :  (271, 10)
+  - mx-semantics/vmhooks/manBufOps.md :  (124, 10)
+  - mx-semantics/vmhooks/manBufOps.md :  (154, 10)
+  - mx-semantics/vmhooks/manBufOps.md :  (144, 10)
+  - MANAGEDEI.managedGetESDTTokenData
+  - CRYPTOEI.managedKeccak256
+  - CRYPTOEI.managedSha256
+  - mx-semantics/vmhooks/managedei.md :  (44, 10)
+  - KASMER.testapi-setESDTRole
+  - mx-semantics/vmhooks/cryptoei.md :  (61, 10)
+  - mx-semantics/vmhooks/baseOps.md :  (335, 10)
+  - mx-semantics/vmhooks/smallIntOps.md :  (62, 10)
+  - mx-semantics/vmhooks/smallIntOps.md :  (55, 10)
+  - mx-semantics/vmhooks/smallIntOps.md :  (107, 10)
+  - mx-semantics/vmhooks/smallIntOps.md :  (95, 10)
+  - mx-semantics/vmhooks/smallIntOps.md :  (82, 10)
+  - mx-semantics/vmhooks/smallIntOps.md :  (69, 10)
+  - mx-semantics/vmhooks/baseOps.md :  (188, 10)
+  - mx-semantics/vmhooks/baseOps.md :  (175, 10)
+  - mx-semantics/vmhooks/baseOps.md :  (161, 10)
+  - mx-semantics/vmhooks/baseOps.md :  (90, 10)
+  - mx-semantics/vmhooks/baseOps.md :  (302, 10)
+  - mx-semantics/vmhooks/manBufOps.md :  (245, 10)
+  - KASMER.testapi-stopPrank
+  - mx-semantics/vmhooks/managedei.md :  (31, 10)
+  - BASEOPS.cleanReturnData
+  - mx-semantics/vmhooks/managedei.md :  (17, 10)
+  - KASMER.testapi-setBlockTimestamp
+  - mx-semantics/vmhooks/baseOps.md :  (374, 10)
+  - mx-semantics/vmhooks/baseOps.md :  (398, 10)
+  - mx-semantics/vmhooks/managedei.md :  (240, 10)
+  - MANAGEDEI.managedGetPrevBlockRandomSeed
+  - mx-semantics/vmhooks/baseOps.md :  (370, 10)
+  - mx-semantics/vmhooks/baseOps.md :  (362, 10)
+  - mx-semantics/vmhooks/baseOps.md :  (366, 10)
+  - mx-semantics/vmhooks/baseOps.md :  (358, 10)
+  - mx-semantics/vmhooks/baseOps.md :  (394, 10)
+  - mx-semantics/vmhooks/baseOps.md :  (386, 10)
+  - mx-semantics/vmhooks/baseOps.md :  (390, 10)
+  - mx-semantics/vmhooks/baseOps.md :  (382, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (470, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (453, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (433, 10)
+  - mx-semantics/vmhooks/managedei.md :  (37, 10)
+  - mx-semantics/vmhooks/managedei.md :  (52, 10)
+  - BASEOPS.getESDTTokenName
+  - BASEOPS.checkNoPayment-pass
+  - BASEOPS.checkNoPayment-fail-esdt
+  - mx-semantics/vmhooks/bigIntOps.md :  (464, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (447, 10)
+  - mx-semantics/vmhooks/baseOps.md :  (134, 10)
+  - mx-semantics/vmhooks/baseOps.md :  (146, 10)
+  - mx-semantics/vmhooks/baseOps.md :  (119, 10)
+  - mx-semantics/vmhooks/baseOps.md :  (126, 10)
+  - mx-semantics/vmhooks/manBufOps.md :  (164, 10)
+  - SMALLINTOPS.smallIntGetSignedArgument
+  - SMALLINTOPS.smallIntGetSignedArgument-ioor
+  - SMALLINTOPS.smallIntGetUnsignedArgument
+  - SMALLINTOPS.smallIntGetUnsignedArgument-ioor
+  - mx-semantics/vmhooks/baseOps.md :  (203, 10)
+  - mx-semantics/vmhooks/manBufOps.md :  (263, 10)
+  - BASEOPS.getGasLeft
+  - mx-semantics/vmhooks/baseOps.md :  (261, 10)
+  - BASEOPS.checkNoPayment-fail-egld
+  - mx-semantics/vmhooks/baseOps.md :  (157, 10)
+  - BASEOPS.getESDTTokenName-too-many
+  - BASEOPS.getESDTTokenName-none
+  - MANAGEDEI.managedGetCallbackClosure
+  - MANAGEDEI.managedGetCallbackClosure-err
+  - KASMER.testapi-stopPrank-err
+- Lblinit_local___WASM-INTERNAL-SYNTAX_Instr_Int_Val Anything Anything: wasm-semantics/wasm.md :  (558, 10)
+- Lblinit_locals__WASM-INTERNAL-SYNTAX_Instr_ValStack Anything Anything: wasm-semantics/wasm.md :  (561, 10)
+- Lbllabel_{_}__WASM_Label_VecType_Instrs_ValStack Anything Anything: wasm-semantics/wasm.md :  (490, 10)
+- Lblload{_____}_WASM_Instr_IValType_Int_Int_Signedness_Int Anything Anything: 2
+  - wasm-semantics/wasm.md :  (1463, 10)
+  - wasm-semantics/wasm.md :  (1472, 10)
+- Lblload{_____}_WASM_Instr_IValType_Int_Int_Signedness_SparseBytes Anything Anything: 2
+  - wasm-semantics/wasm.md :  (1480, 10)
+  - wasm-semantics/wasm.md :  (1481, 10)
+- Lblload{____}_WASM_Instr_IValType_Int_Int_Signedness Anything Anything: wasm-semantics/wasm.md :  (1454, 10)
+- LblnewEmptyModule__WASM-AUTO-ALLOCATE_Stmt_WasmString Anything Anything: mx-semantics/auto-allocate.md :  (21, 10)
+- Lblstore{____}_WASM_Instr_Int_Int_Number_Int Anything Anything: 2
+  - wasm-semantics/wasm.md :  (1404, 10)
+  - wasm-semantics/wasm.md :  (1417, 10)
+- Lblstore{___}_WASM_Instr_Int_Int_Number Anything Anything: wasm-semantics/wasm.md :  (1395, 10)
+- dotk LblmkCall(_,_,_)_ELROND-NODE_InternalCmd_Bytes_WasmString_VmInputCell Anything: 2
+  - ELROND-CONFIG.mkCall
+  - ELROND-CONFIG.mkCall-func-not-found
+- dotk Anything Anything: ASYNC.executeAsyncLocalCalls
+- dotk Lbl#endWasm Anything: SWITCH.endWasm
+- dotk Lbl#waitWasm Anything: SWITCH.waitWasm
+- dotk LblexecuteAsyncLocalCalls Anything: ASYNC.executeAsyncLocalCalls-empty
+- dotk dotk Anything: 2
+  - mx-semantics/mandos.md :  (76, 10)
+  - mx-semantics/mandos.md :  (80, 10)
+- dotk dotk Lbl#wait_MANDOS_Step: mx-semantics/mandos.md :  (50, 10)
+- dotk dotk LblsetExitCode: mx-semantics/mandos.md :  (68, 10)
+Function equations by term index:
+- Lbl#ContextLookup(_,_)_WASM-DATA-COMMON_Int_Map_Index: 2
+  - wasm-semantics/wasm-text.md :  (413, 10)
+  - wasm-semantics/data.md :  (293, 10)
+- Lbl#DS2Bytes(_)_WASM-DATA-COMMON_Bytes_DataString: wasm-semantics/data.md :  (627, 10)
+- Lbl#StorageAdded()_ELROND-CONFIG_Int: mx-semantics/elrond-config.md :  (250, 10)
+- Lbl#StorageDeleted()_ELROND-CONFIG_Int: mx-semantics/elrond-config.md :  (251, 10)
+- Lbl#StorageModified()_ELROND-CONFIG_Int: mx-semantics/elrond-config.md :  (249, 10)
+- Lbl#StorageUnmodified()_ELROND-CONFIG_Int: mx-semantics/elrond-config.md :  (248, 10)
+- Lbl#address2Bytes(_)_ELROND-NODE_Bytes_Address: 2
+  - mx-semantics/elrond-node.md :  (190, 10)
+  - mx-semantics/elrond-node.md :  (189, 10)
+- Lbl#alignHexString(_)_ELROND-CONFIG_String_String: 2
+  - mx-semantics/elrond-config.md :  (322, 10)
+  - mx-semantics/elrond-config.md :  (323, 10)
+- Lbl#allReadable(_,_)_EEI-HELPERS_Bool_Bytes_Int: 3
+  - mx-semantics/vmhooks/eei-helpers.md :  (61, 8)
+  - mx-semantics/vmhooks/eei-helpers.md :  (63, 8)
+  - mx-semantics/vmhooks/eei-helpers.md :  (64, 8)
+- Lbl#allValidRandom(_,_)_EEI-HELPERS_Bool_Bytes_Int: 3
+  - mx-semantics/vmhooks/eei-helpers.md :  (78, 8)
+  - mx-semantics/vmhooks/eei-helpers.md :  (80, 8)
+  - mx-semantics/vmhooks/eei-helpers.md :  (81, 8)
+- Lbl#appendInstrs(_,_)_WASM-TEXT_Instrs_Instrs_Instrs: 2
+  - wasm-semantics/wasm-text.md :  (645, 10)
+  - wasm-semantics/wasm-text.md :  (644, 10)
+- Lbl#autoAllocModules(_,_)_WASM-AUTO-ALLOCATE_Stmts_Defns_Map: 3
+  - mx-semantics/auto-allocate.md :  (36, 10)
+  - mx-semantics/auto-allocate.md :  (37, 10)
+  - mx-semantics/auto-allocate.md :  (38, 10)
+- Lbl#bigIntSign(_)_ELROND-CONFIG_Int_Int: 3
+  - mx-semantics/elrond-config.md :  (268, 10)
+  - mx-semantics/elrond-config.md :  (266, 10)
+  - mx-semantics/elrond-config.md :  (267, 10)
+- Lbl#canGrow(_,_,_)_WASM_Bool_Int_Int_OptionalInt: 2
+  - wasm-semantics/wasm.md :  (825, 10)
+  - wasm-semantics/wasm.md :  (823, 10)
+- Lbl#canSaveId(_,_)_WASM-DATA-COMMON_Bool_Map_OptionalId: 2
+  - wasm-semantics/data.md :  (280, 10)
+  - wasm-semantics/data.md :  (279, 10)
+- Lbl#chop(_)_WASM-DATA-COMMON_IVal_IVal: wasm-semantics/data.md :  (406, 10)
+- Lbl#concatDS(_)_WASM-DATA-COMMON_String_DataString: wasm-semantics/data.md :  (617, 10)
+- Lbl#concatDS(_,_)_WASM-DATA-COMMON_String_DataString_String: 2
+  - wasm-semantics/data.md :  (618, 10)
+  - wasm-semantics/data.md :  (619, 10)
+- Lbl#ctz(_)_WASM-NUMERIC_Int_Int: 2
+  - wasm-semantics/numeric.md :  (146, 10)
+  - wasm-semantics/numeric.md :  (147, 10)
+- Lbl#drop(_,_)_WASM-DATA-COMMON_ValStack_Int_ValStack: 3
+  - wasm-semantics/data.md :  (522, 10)
+  - wasm-semantics/data.md :  (521, 10)
+  - wasm-semantics/data.md :  (523, 10)
+- Lbl#emptyModule(_)_WASM_ModuleDecl_OptionalId: wasm-semantics/wasm.md :  (1851, 10)
+- Lbl#encodeUTF8(_)_WASM-DATA-COMMON_Bytes_Int: 4
+  - wasm-semantics/data.md :  (596, 10)
+  - wasm-semantics/data.md :  (601, 10)
+  - wasm-semantics/data.md :  (599, 10)
+  - wasm-semantics/data.md :  (597, 10)
+- Lbl#freshCtx()_WASM-TEXT_Context: wasm-semantics/wasm-text.md :  (785, 10)
+- Lbl#gatherTypes(_,_,_)_WASM_VecType_TypeKeyWord_TypeDecls_ValTypes: 5
+  - wasm-semantics/wasm.md :  (1073, 10)
+  - wasm-semantics/wasm.md :  (1072, 10)
+  - wasm-semantics/wasm.md :  (1070, 10)
+  - wasm-semantics/wasm.md :  (1069, 10)
+  - wasm-semantics/wasm.md :  (1068, 10)
+- Lbl#get(_)_WASM-DATA-COMMON_Int_IVal: wasm-semantics/data.md :  (414, 10)
+- Lbl#getBytesRange(_,_,_)_WASM-DATA-COMMON_Bytes_SparseBytes_Int_Int: wasm-semantics/data.md :  (655, 10)
+- Lbl#getElemSegment(_,_)_WASM-DATA-COMMON_Index_ElemSegment_Int: 2
+  - wasm-semantics/data.md :  (310, 10)
+  - wasm-semantics/data.md :  (311, 10)
+- Lbl#getInts(_,_)_WASM-DATA-COMMON_Int_Ints_Int: 2
+  - wasm-semantics/data.md :  (316, 10)
+  - wasm-semantics/data.md :  (317, 10)
+- Lbl#getModuleCodePath(_)_MANDOS_OptionalString_ModuleDecl: 3
+  - mx-semantics/mandos.md :  (459, 10)
+  - mx-semantics/mandos.md :  (458, 10)
+  - mx-semantics/mandos.md :  (460, 10)
+- Lbl#getOffset(_)_WASM-TEXT_Int_MemArg: 3
+  - wasm-semantics/wasm-text.md :  (1137, 10)
+  - wasm-semantics/wasm-text.md :  (1135, 10)
+  - wasm-semantics/wasm-text.md :  (1136, 10)
+- Lbl#getRandomChars(_)_EEI-HELPERS_Bytes_Bytes: 2
+  - mx-semantics/vmhooks/eei-helpers.md :  (45, 8)
+  - mx-semantics/vmhooks/eei-helpers.md :  (40, 8)
+- Lbl#getRange(_,_,_)_WASM-DATA-COMMON_Int_SparseBytes_Int_Int: wasm-semantics/data.md :  (660, 10)
+- Lbl#getTicker(_)_EEI-HELPERS_Bytes_Bytes: 2
+  - mx-semantics/vmhooks/eei-helpers.md :  (43, 8)
+  - mx-semantics/vmhooks/eei-helpers.md :  (38, 8)
+- Lbl#growthAllowed(_,_)_WASM_Bool_Int_OptionalInt: 2
+  - wasm-semantics/wasm.md :  (1547, 10)
+  - wasm-semantics/wasm.md :  (1548, 10)
+- Lbl#hasPrefix(_,_)_ELROND-CONFIG_Bool_String_String: 2
+  - mx-semantics/elrond-config.md :  (44, 10)
+  - mx-semantics/elrond-config.md :  (40, 10)
+- Lbl#idcElems(_)_WASM-TEXT_Map_Defns: wasm-semantics/wasm-text.md :  (1256, 10)
+- Lbl#idcElemsAux(_,_,_)_WASM-TEXT_Map_Defns_Int_Map: 4
+  - wasm-semantics/wasm-text.md :  (1258, 10)
+  - wasm-semantics/wasm-text.md :  (1264, 10)
+  - wasm-semantics/wasm-text.md :  (1260, 10)
+  - wasm-semantics/wasm-text.md :  (1268, 10)
+- Lbl#idcFuncs(_,_)_WASM-TEXT_Map_Defns_Defns: wasm-semantics/wasm-text.md :  (1218, 10)
+- Lbl#idcFuncsAux(_,_,_,_)_WASM-TEXT_Map_Defns_Defns_Int_Map: 6
+  - wasm-semantics/wasm-text.md :  (1225, 10)
+  - wasm-semantics/wasm-text.md :  (1224, 10)
+  - wasm-semantics/wasm-text.md :  (1226, 10)
+  - wasm-semantics/wasm-text.md :  (1221, 10)
+  - wasm-semantics/wasm-text.md :  (1220, 10)
+  - wasm-semantics/wasm-text.md :  (1222, 10)
+- Lbl#idcGlobals(_,_)_WASM-TEXT_Map_Defns_Defns: wasm-semantics/wasm-text.md :  (1299, 10)
+- Lbl#idcGlobalsAux(_,_,_,_)_WASM-TEXT_Map_Defns_Defns_Int_Map: 6
+  - wasm-semantics/wasm-text.md :  (1305, 10)
+  - wasm-semantics/wasm-text.md :  (1307, 10)
+  - wasm-semantics/wasm-text.md :  (1302, 10)
+  - wasm-semantics/wasm-text.md :  (1301, 10)
+  - wasm-semantics/wasm-text.md :  (1306, 10)
+  - wasm-semantics/wasm-text.md :  (1303, 10)
+- Lbl#idcMems(_,_)_WASM-TEXT_Map_Defns_Defns: wasm-semantics/wasm-text.md :  (1275, 10)
+- Lbl#idcMemsAux(_,_,_,_)_WASM-TEXT_Map_Defns_Defns_Int_Map: 5
+  - wasm-semantics/wasm-text.md :  (1288, 10)
+  - wasm-semantics/wasm-text.md :  (1276, 10)
+  - wasm-semantics/wasm-text.md :  (1279, 10)
+  - wasm-semantics/wasm-text.md :  (1292, 10)
+  - wasm-semantics/wasm-text.md :  (1283, 10)
+- Lbl#idcTables(_,_)_WASM-TEXT_Map_Defns_Defns: wasm-semantics/wasm-text.md :  (1231, 10)
+- Lbl#idcTablesAux(_,_,_,_)_WASM-TEXT_Map_Defns_Defns_Int_Map: 5
+  - wasm-semantics/wasm-text.md :  (1244, 10)
+  - wasm-semantics/wasm-text.md :  (1232, 10)
+  - wasm-semantics/wasm-text.md :  (1235, 10)
+  - wasm-semantics/wasm-text.md :  (1248, 10)
+  - wasm-semantics/wasm-text.md :  (1239, 10)
+- Lbl#idcTypes(_)_WASM-TEXT_Map_Defns: wasm-semantics/wasm-text.md :  (1209, 10)
+- Lbl#idcTypesAux(_,_,_)_WASM-TEXT_Map_Defns_Int_Map: 3
+  - wasm-semantics/wasm-text.md :  (1213, 10)
+  - wasm-semantics/wasm-text.md :  (1212, 10)
+  - wasm-semantics/wasm-text.md :  (1211, 10)
+- Lbl#ids2Idxs(_,_)_WASM-TEXT_Map_TypeUse_LocalDecls: wasm-semantics/wasm-text.md :  (1312, 10)
+- Lbl#ids2Idxs(_,_,_)_WASM-TEXT_Map_Int_TypeUse_LocalDecls: 8
+  - wasm-semantics/wasm-text.md :  (1323, 10)
+  - wasm-semantics/wasm-text.md :  (1316, 10)
+  - wasm-semantics/wasm-text.md :  (1315, 10)
+  - wasm-semantics/wasm-text.md :  (1320, 10)
+  - wasm-semantics/wasm-text.md :  (1318, 10)
+  - wasm-semantics/wasm-text.md :  (1314, 10)
+  - wasm-semantics/wasm-text.md :  (1325, 10)
+  - wasm-semantics/wasm-text.md :  (1321, 10)
+- Lbl#idxCloseBracket(_,_)_WASM-DATA-COMMON_Int_String_Int: 2
+  - wasm-semantics/data.md :  (591, 10)
+  - wasm-semantics/data.md :  (592, 10)
+- Lbl#incBytes(_,_)_MANDOS_Bytes_Bytes_Int: mx-semantics/mandos.md :  (733, 10)
+- Lbl#isInfinityOrNaN(_)_WASM-NUMERIC_Bool_Float: wasm-semantics/numeric.md :  (160, 10)
+- Lbl#isSmartContract(_)_ELROND-CONFIG_Bool_Bytes: 2
+  - mx-semantics/elrond-config.md :  (451, 10)
+  - mx-semantics/elrond-config.md :  (458, 10)
+- Lbl#isTickerValid(_)_EEI-HELPERS_Bool_Bytes: 2
+  - mx-semantics/vmhooks/eei-helpers.md :  (54, 8)
+  - mx-semantics/vmhooks/eei-helpers.md :  (51, 8)
+- Lbl#lambda__: wasm-semantics/data/sparse-bytes.k :  (63, 8)
+- Lbl#lambda__2: mx-semantics/vmhooks/bigIntOps.md :  (96, 24)
+- Lbl#lenElemExprs(_)_WASM-TEXT_Int_ElemExprs: 2
+  - wasm-semantics/wasm-text.md :  (532, 10)
+  - wasm-semantics/wasm-text.md :  (533, 10)
+- Lbl#lenElemSegment(_)_WASM-DATA-COMMON_Int_ElemSegment: 2
+  - wasm-semantics/data.md :  (307, 10)
+  - wasm-semantics/data.md :  (308, 10)
+- Lbl#lenInts(_)_WASM-DATA-COMMON_Int_Ints: 2
+  - wasm-semantics/data.md :  (313, 10)
+  - wasm-semantics/data.md :  (314, 10)
+- Lbl#lengthDataPages(_)_WASM-TEXT_Int_DataString: wasm-semantics/wasm-text.md :  (567, 10)
+- Lbl#limitsMatchImport(_,_,_)_WASM_Bool_Int_OptionalInt_Limits: 3
+  - wasm-semantics/wasm.md :  (1823, 10)
+  - wasm-semantics/wasm.md :  (1825, 10)
+  - wasm-semantics/wasm.md :  (1824, 10)
+- Lbl#locals2vectype(_,_)_WASM-TEXT_VecType_LocalDecls_ValTypes: 3
+  - wasm-semantics/wasm-text.md :  (902, 10)
+  - wasm-semantics/wasm-text.md :  (903, 10)
+  - wasm-semantics/wasm-text.md :  (904, 10)
+- Lbl#lookupStorage(_,_)_ELROND-CONFIG_Bytes_MapBytesToBytes_Bytes: mx-semantics/elrond-config.md :  (234, 10)
+- Lbl#maxMemorySize()_WASM-INTERNAL-SYNTAX_Int: wasm-semantics/wasm.md :  (1557, 10)
+- Lbl#maxTableSize()_WASM-INTERNAL-SYNTAX_Int: wasm-semantics/wasm.md :  (1558, 10)
+- Lbl#minWidth(_)_WASM-NUMERIC_Int_Int: 2
+  - wasm-semantics/numeric.md :  (143, 10)
+  - wasm-semantics/numeric.md :  (144, 10)
+- Lbl#newKey(_)_BIGINT-HELPERS_Int_Map: mx-semantics/vmhooks/bigIntOps.md :  (78, 10)
+- Lbl#newKey(_)_BIGINT-HELPERS_Int_MapIntToBytes: mx-semantics/vmhooks/bigIntOps.md :  (82, 10)
+- Lbl#newKey(_)_BIGINT-HELPERS_Int_MapIntToInt: mx-semantics/vmhooks/bigIntOps.md :  (86, 10)
+- Lbl#newKeyAux(_,_)_BIGINT-HELPERS_Int_Int_Map: 2
+  - mx-semantics/vmhooks/bigIntOps.md :  (79, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (80, 10)
+- Lbl#newKeyAux(_,_)_BIGINT-HELPERS_Int_Int_MapIntToBytes: 2
+  - mx-semantics/vmhooks/bigIntOps.md :  (83, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (84, 10)
+- Lbl#newKeyAux(_,_)_BIGINT-HELPERS_Int_Int_MapIntToInt: 2
+  - mx-semantics/vmhooks/bigIntOps.md :  (87, 10)
+  - mx-semantics/vmhooks/bigIntOps.md :  (88, 10)
+- Lbl#numBytes(_)_WASM-DATA-COMMON_Int_IValType: wasm-semantics/data.md :  (378, 10)
+- Lbl#open(_)_K-IO_IOInt_String: /nix/store/kczin6jrjj1d1s40xbwpmfhanlsp1df0-k-7.0.40-be1acaf3f66f7d296024e9e7aaee8a24d9481475/include/kframework/builtin/domains.md :  (2487, 8)
+- Lbl#pageSize()_WASM-INTERNAL-SYNTAX_Int: wasm-semantics/wasm.md :  (1556, 10)
+- Lbl#parseHexBytes(_)_ELROND-CONFIG_Bytes_String: mx-semantics/elrond-config.md :  (328, 10)
+- Lbl#parseHexBytesAux(_)_ELROND-CONFIG_Bytes_String: 2
+  - mx-semantics/elrond-config.md :  (330, 10)
+  - mx-semantics/elrond-config.md :  (329, 10)
+- Lbl#popcnt(_)_WASM-NUMERIC_Int_Int: 2
+  - wasm-semantics/numeric.md :  (149, 10)
+  - wasm-semantics/numeric.md :  (150, 10)
+- Lbl#pow(_)_WASM-DATA-INTERNAL-SYNTAX_Int_IValType: 2
+  - wasm-semantics/data.md :  (385, 10)
+  - wasm-semantics/data.md :  (387, 10)
+- Lbl#pow1(_)_WASM-DATA-INTERNAL-SYNTAX_Int_IValType: 2
+  - wasm-semantics/data.md :  (384, 10)
+  - wasm-semantics/data.md :  (386, 10)
+- Lbl#quoteUnparseWasmString(_)_ELROND-NODE_WasmStringToken_String: mx-semantics/elrond-node.md :  (185, 10)
+- Lbl#randomCharsAreValid(_)_EEI-HELPERS_Bool_Bytes: 2
+  - mx-semantics/vmhooks/eei-helpers.md :  (73, 8)
+  - mx-semantics/vmhooks/eei-helpers.md :  (72, 8)
+- Lbl#readableChar(_)_EEI-HELPERS_Bool_Int: mx-semantics/vmhooks/eei-helpers.md :  (66, 8)
+- Lbl#removeEmptyBytes(_)_MANDOS_MapBytesToBytes_MapBytesToBytes: 2
+  - mx-semantics/mandos.md :  (102, 10)
+  - mx-semantics/mandos.md :  (104, 10)
+- Lbl#removeReservedKeys(_)_MANDOS_MapBytesToBytes_MapBytesToBytes: 2
+  - mx-semantics/mandos.md :  (120, 10)
+  - mx-semantics/mandos.md :  (122, 10)
+- Lbl#reverseDefns(_,_)_WASM-TEXT_Defns_Defns_Defns: 2
+  - wasm-semantics/wasm-text.md :  (749, 10)
+  - wasm-semantics/wasm-text.md :  (750, 10)
+- Lbl#reverseInstrs(_,_)_WASM-TEXT_Instrs_Instrs_Instrs: 2
+  - wasm-semantics/wasm-text.md :  (647, 10)
+  - wasm-semantics/wasm-text.md :  (648, 10)
+- Lbl#revs(_)_WASM-DATA-COMMON_ValStack_ValStack: wasm-semantics/data.md :  (525, 10)
+- Lbl#revs(_,_)_WASM-DATA-COMMON_ValStack_ValStack_ValStack: 2
+  - wasm-semantics/data.md :  (527, 10)
+  - wasm-semantics/data.md :  (528, 10)
+- Lbl#revt(_)_WASM-DATA-COMMON_ValTypes_ValTypes: wasm-semantics/data.md :  (361, 10)
+- Lbl#revt(_,_)_WASM-DATA-COMMON_ValTypes_ValTypes_ValTypes: 2
+  - wasm-semantics/data.md :  (363, 10)
+  - wasm-semantics/data.md :  (364, 10)
+- Lbl#round(_,_)_WASM-DATA-COMMON_FVal_FValType_Number: 4
+  - wasm-semantics/data.md :  (426, 10)
+  - wasm-semantics/data.md :  (428, 10)
+  - wasm-semantics/data.md :  (425, 10)
+  - wasm-semantics/data.md :  (427, 10)
+- Lbl#sameType(_,_)_WASM-DATA-INTERNAL-SYNTAX_Bool_Val_Val: 5
+  - wasm-semantics/data.md :  (188, 10)
+  - wasm-semantics/data.md :  (187, 10)
+  - wasm-semantics/data.md :  (189, 10)
+  - wasm-semantics/data.md :  (190, 10)
+  - wasm-semantics/data.md :  (191, 10)
+- Lbl#saveId(_,_,_)_WASM-DATA-COMMON_Map_Map_OptionalId_Int: 2
+  - wasm-semantics/data.md :  (276, 10)
+  - wasm-semantics/data.md :  (277, 10)
+- Lbl#setBytesRange(_,_,_)_WASM-DATA-COMMON_SparseBytes_SparseBytes_Int_Bytes: wasm-semantics/data.md :  (640, 10)
+- Lbl#setRange(_,_,_,_)_WASM-DATA-COMMON_SparseBytes_SparseBytes_Int_Int_Int: wasm-semantics/data.md :  (644, 10)
+- Lbl#signed(_,_)_WASM-DATA-INTERNAL-SYNTAX_Int_IValType_Int: 2
+  - wasm-semantics/data.md :  (442, 10)
+  - wasm-semantics/data.md :  (443, 10)
+- Lbl#signedWidth(_,_)_WASM-DATA-INTERNAL-SYNTAX_Int_Int_Int: 5
+  - wasm-semantics/data.md :  (448, 10)
+  - wasm-semantics/data.md :  (449, 10)
+  - wasm-semantics/data.md :  (450, 10)
+  - wasm-semantics/data.md :  (451, 10)
+  - wasm-semantics/data.md :  (452, 10)
+- Lbl#sliceBytesInBounds(_,_,_)_MANBUFOPS_Bool_Bytes_Int_Int: mx-semantics/vmhooks/manBufOps.md :  (74, 10)
+- Lbl#stderr_K-IO_Int: /nix/store/kczin6jrjj1d1s40xbwpmfhanlsp1df0-k-7.0.40-be1acaf3f66f7d296024e9e7aaee8a24d9481475/include/kframework/builtin/domains.md :  (2584, 8)
+- Lbl#stdin_K-IO_Int: /nix/store/kczin6jrjj1d1s40xbwpmfhanlsp1df0-k-7.0.40-be1acaf3f66f7d296024e9e7aaee8a24d9481475/include/kframework/builtin/domains.md :  (2582, 8)
+- Lbl#stdout_K-IO_Int: /nix/store/kczin6jrjj1d1s40xbwpmfhanlsp1df0-k-7.0.40-be1acaf3f66f7d296024e9e7aaee8a24d9481475/include/kframework/builtin/domains.md :  (2583, 8)
+- Lbl#storageStatus(_,_,_)_ELROND-CONFIG_Int_MapBytesToBytes_Bytes_Bytes: 5
+  - mx-semantics/elrond-config.md :  (245, 10)
+  - mx-semantics/elrond-config.md :  (246, 10)
+  - mx-semantics/elrond-config.md :  (244, 10)
+  - mx-semantics/elrond-config.md :  (242, 10)
+  - mx-semantics/elrond-config.md :  (243, 10)
+- Lbl#stripQuotes(_)_WASM-AUTO-ALLOCATE_String_String: mx-semantics/auto-allocate.md :  (81, 10)
+- Lbl#structureModule(_,_)_WASM-TEXT_ModuleDecl_Defns_ModuleDecl: 11
+  - wasm-semantics/wasm-text.md :  (734, 10)
+  - wasm-semantics/wasm-text.md :  (743, 10)
+  - wasm-semantics/wasm-text.md :  (744, 10)
+  - wasm-semantics/wasm-text.md :  (742, 10)
+  - wasm-semantics/wasm-text.md :  (738, 10)
+  - wasm-semantics/wasm-text.md :  (739, 10)
+  - wasm-semantics/wasm-text.md :  (737, 10)
+  - wasm-semantics/wasm-text.md :  (741, 10)
+  - wasm-semantics/wasm-text.md :  (745, 10)
+  - wasm-semantics/wasm-text.md :  (740, 10)
+  - wasm-semantics/wasm-text.md :  (736, 10)
+- Lbl#t2aDefn<_>(_)_WASM-TEXT_Defn_Context_Defn: 25
+  - wasm-semantics/wasm-text.md :  (883, 10)
+  - wasm-semantics/wasm-text.md :  (940, 10)
+  - wasm-semantics/wasm-text.md :  (989, 10)
+  - wasm-semantics/wasm-text.md :  (944, 10)
+  - wasm-semantics/wasm-text.md :  (947, 10)
+  - wasm-semantics/wasm-text.md :  (875, 10)
+  - wasm-semantics/wasm-text.md :  (997, 10)
+  - wasm-semantics/wasm-text.md :  (998, 10)
+  - wasm-semantics/wasm-text.md :  (1001, 10)
+  - wasm-semantics/wasm-text.md :  (1000, 10)
+  - wasm-semantics/wasm-text.md :  (864, 10)
+  - wasm-semantics/wasm-text.md :  (863, 10)
+  - wasm-semantics/wasm-text.md :  (866, 10)
+  - wasm-semantics/wasm-text.md :  (869, 10)
+  - wasm-semantics/wasm-text.md :  (868, 10)
+  - wasm-semantics/wasm-text.md :  (917, 10)
+  - wasm-semantics/wasm-text.md :  (932, 10)
+  - wasm-semantics/wasm-text.md :  (910, 10)
+  - wasm-semantics/wasm-text.md :  (855, 10)
+  - wasm-semantics/wasm-text.md :  (996, 10)
+  - wasm-semantics/wasm-text.md :  (930, 10)
+  - wasm-semantics/wasm-text.md :  (995, 10)
+  - wasm-semantics/wasm-text.md :  (862, 10)
+  - wasm-semantics/wasm-text.md :  (861, 10)
+  - wasm-semantics/wasm-text.md :  (1007, 10)
+- Lbl#t2aDefns<_>(_)_WASM-TEXT_Defns_Context_Defns: 2
+  - wasm-semantics/wasm-text.md :  (1194, 10)
+  - wasm-semantics/wasm-text.md :  (1195, 10)
+- Lbl#t2aElemExpr<_>(_)_WASM-TEXT_RefVal_Context_ElemExpr: 3
+  - wasm-semantics/wasm-text.md :  (979, 10)
+  - wasm-semantics/wasm-text.md :  (978, 10)
+  - wasm-semantics/wasm-text.md :  (974, 10)
+- Lbl#t2aElemExprs<_>(_)_WASM-TEXT_ListRef_Context_ElemExprs: 2
+  - wasm-semantics/wasm-text.md :  (970, 10)
+  - wasm-semantics/wasm-text.md :  (972, 10)
+- Lbl#t2aElemList<_>(_)_WASM-TEXT_ListRef_Context_ElemList: 3
+  - wasm-semantics/wasm-text.md :  (963, 10)
+  - wasm-semantics/wasm-text.md :  (961, 10)
+  - wasm-semantics/wasm-text.md :  (962, 10)
+- Lbl#t2aElemSegment<_>(_)_WASM-TEXT_ListRef_Context_ElemSegment: 2
+  - wasm-semantics/wasm-text.md :  (966, 10)
+  - wasm-semantics/wasm-text.md :  (965, 10)
+- Lbl#t2aInstr<_>(_)_WASM-TEXT_Instr_Context_Instr: 63
+  - wasm-semantics/wasm-text.md :  (1175, 10)
+  - wasm-semantics/wasm-text.md :  (1162, 10)
+  - wasm-semantics/wasm-text.md :  (1164, 10)
+  - wasm-semantics/wasm-text.md :  (1163, 10)
+  - wasm-semantics/wasm-text.md :  (1016, 10)
+  - wasm-semantics/wasm-text.md :  (1015, 10)
+  - wasm-semantics/wasm-text.md :  (1173, 10)
+  - wasm-semantics/wasm-text.md :  (1177, 10)
+  - wasm-semantics/wasm-text.md :  (1178, 10)
+  - wasm-semantics/wasm-text.md :  (1153, 10)
+  - wasm-semantics/wasm-text.md :  (1042, 10)
+  - wasm-semantics/wasm-text.md :  (1147, 10)
+  - wasm-semantics/wasm-text.md :  (1149, 10)
+  - wasm-semantics/wasm-text.md :  (1144, 10)
+  - wasm-semantics/wasm-text.md :  (1152, 10)
+  - wasm-semantics/wasm-text.md :  (1146, 10)
+  - wasm-semantics/wasm-text.md :  (1131, 10)
+  - wasm-semantics/wasm-text.md :  (1148, 10)
+  - wasm-semantics/wasm-text.md :  (1143, 10)
+  - wasm-semantics/wasm-text.md :  (1151, 10)
+  - wasm-semantics/wasm-text.md :  (1145, 10)
+  - wasm-semantics/wasm-text.md :  (1023, 10)
+  - wasm-semantics/wasm-text.md :  (1110, 10)
+  - wasm-semantics/wasm-text.md :  (1027, 10)
+  - wasm-semantics/wasm-text.md :  (1043, 10)
+  - wasm-semantics/wasm-text.md :  (1130, 10)
+  - wasm-semantics/wasm-text.md :  (1150, 10)
+  - wasm-semantics/wasm-text.md :  (1022, 10)
+  - wasm-semantics/wasm-text.md :  (1129, 10)
+  - wasm-semantics/wasm-text.md :  (1128, 10)
+  - wasm-semantics/wasm-text.md :  (1125, 10)
+  - wasm-semantics/wasm-text.md :  (1124, 10)
+  - wasm-semantics/wasm-text.md :  (1127, 10)
+  - wasm-semantics/wasm-text.md :  (1126, 10)
+  - wasm-semantics/wasm-text.md :  (1123, 10)
+  - wasm-semantics/wasm-text.md :  (1122, 10)
+  - wasm-semantics/wasm-text.md :  (1024, 10)
+  - wasm-semantics/wasm-text.md :  (1025, 10)
+  - wasm-semantics/wasm-text.md :  (1026, 10)
+  - wasm-semantics/wasm-text.md :  (1031, 10)
+  - wasm-semantics/wasm-text.md :  (1033, 10)
+  - wasm-semantics/wasm-text.md :  (1065, 10)
+  - wasm-semantics/wasm-text.md :  (1066, 10)
+  - wasm-semantics/wasm-text.md :  (1056, 10)
+  - wasm-semantics/wasm-text.md :  (1057, 10)
+  - wasm-semantics/wasm-text.md :  (1058, 10)
+  - wasm-semantics/wasm-text.md :  (1111, 10)
+  - wasm-semantics/wasm-text.md :  (1049, 10)
+  - wasm-semantics/wasm-text.md :  (1051, 10)
+  - wasm-semantics/wasm-text.md :  (1053, 10)
+  - wasm-semantics/wasm-text.md :  (1060, 10)
+  - wasm-semantics/wasm-text.md :  (1062, 10)
+  - wasm-semantics/wasm-text.md :  (1029, 10)
+  - wasm-semantics/wasm-text.md :  (1112, 10)
+  - wasm-semantics/wasm-text.md :  (1096, 10)
+  - wasm-semantics/wasm-text.md :  (1034, 10)
+  - wasm-semantics/wasm-text.md :  (1101, 10)
+  - wasm-semantics/wasm-text.md :  (1092, 10)
+  - wasm-semantics/wasm-text.md :  (1072, 10)
+  - wasm-semantics/wasm-text.md :  (1088, 10)
+  - wasm-semantics/wasm-text.md :  (1076, 10)
+  - wasm-semantics/wasm-text.md :  (1084, 10)
+  - wasm-semantics/wasm-text.md :  (1080, 10)
+- Lbl#t2aInstrs<_>(_)_WASM-TEXT_Instrs_Context_Instrs: 2
+  - wasm-semantics/wasm-text.md :  (1197, 10)
+  - wasm-semantics/wasm-text.md :  (1198, 10)
+- Lbl#t2aModule<_>(_)_WASM-TEXT_ModuleDecl_Context_ModuleDecl: wasm-semantics/wasm-text.md :  (837, 10)
+- Lbl#t2aModuleDecl<_>(_)_WASM-TEXT_ModuleDecl_Context_ModuleDecl: wasm-semantics/wasm-text.md :  (829, 10)
+- Lbl#t2aStmt<_>(_)_WASM-TEXT_Stmt_Context_Stmt: 4
+  - wasm-semantics/wasm-text.md :  (825, 10)
+  - wasm-semantics/wasm-text.md :  (826, 10)
+  - wasm-semantics/wasm-text.md :  (824, 10)
+  - wasm-semantics/wasm-text.md :  (827, 10)
+- Lbl#t2aStmts<_>(_)_WASM-TEXT_Stmts_Context_Stmts: 2
+  - wasm-semantics/wasm-text.md :  (1191, 10)
+  - wasm-semantics/wasm-text.md :  (1192, 10)
+- Lbl#take(_,_)_WASM-DATA-COMMON_ValStack_Int_ValStack: 3
+  - wasm-semantics/data.md :  (518, 10)
+  - wasm-semantics/data.md :  (517, 10)
+  - wasm-semantics/data.md :  (519, 10)
+- Lbl#typeMatches(_,_)_WASM-DATA-INTERNAL-SYNTAX_Bool_ValType_Val: 5
+  - wasm-semantics/data.md :  (180, 10)
+  - wasm-semantics/data.md :  (179, 10)
+  - wasm-semantics/data.md :  (181, 10)
+  - wasm-semantics/data.md :  (182, 10)
+  - wasm-semantics/data.md :  (183, 10)
+- Lbl#types2indices(_,_)_WASM-TEXT_TypesInfo_Defns_TypesInfo: 3
+  - wasm-semantics/wasm-text.md :  (488, 10)
+  - wasm-semantics/wasm-text.md :  (490, 10)
+  - wasm-semantics/wasm-text.md :  (493, 10)
+- Lbl#unfoldDefns(_,_,_)_WASM-TEXT_Defns_Defns_Int_TypesInfo: 31
+  - wasm-semantics/wasm-text.md :  (439, 10)
+  - wasm-semantics/wasm-text.md :  (623, 10)
+  - wasm-semantics/wasm-text.md :  (625, 10)
+  - wasm-semantics/wasm-text.md :  (600, 10)
+  - wasm-semantics/wasm-text.md :  (596, 10)
+  - wasm-semantics/wasm-text.md :  (604, 10)
+  - wasm-semantics/wasm-text.md :  (505, 10)
+  - wasm-semantics/wasm-text.md :  (499, 10)
+  - wasm-semantics/wasm-text.md :  (467, 10)
+  - wasm-semantics/wasm-text.md :  (462, 10)
+  - wasm-semantics/wasm-text.md :  (457, 10)
+  - wasm-semantics/wasm-text.md :  (502, 10)
+  - wasm-semantics/wasm-text.md :  (586, 10)
+  - wasm-semantics/wasm-text.md :  (580, 10)
+  - wasm-semantics/wasm-text.md :  (578, 10)
+  - wasm-semantics/wasm-text.md :  (583, 10)
+  - wasm-semantics/wasm-text.md :  (472, 10)
+  - wasm-semantics/wasm-text.md :  (477, 10)
+  - wasm-semantics/wasm-text.md :  (551, 10)
+  - wasm-semantics/wasm-text.md :  (562, 10)
+  - wasm-semantics/wasm-text.md :  (556, 10)
+  - wasm-semantics/wasm-text.md :  (548, 10)
+  - wasm-semantics/wasm-text.md :  (559, 10)
+  - wasm-semantics/wasm-text.md :  (525, 10)
+  - wasm-semantics/wasm-text.md :  (520, 10)
+  - wasm-semantics/wasm-text.md :  (541, 10)
+  - wasm-semantics/wasm-text.md :  (535, 10)
+  - wasm-semantics/wasm-text.md :  (517, 10)
+  - wasm-semantics/wasm-text.md :  (514, 10)
+  - wasm-semantics/wasm-text.md :  (538, 10)
+  - wasm-semantics/wasm-text.md :  (440, 10)
+- Lbl#unfoldElemExpr(_)_WASM-TEXT_ElemExpr_ElemExpr: wasm-semantics/wasm-text.md :  (616, 10)
+- Lbl#unfoldElemExprs(_)_WASM-TEXT_ElemExprs_ElemExprs: 2
+  - wasm-semantics/wasm-text.md :  (613, 10)
+  - wasm-semantics/wasm-text.md :  (614, 10)
+- Lbl#unfoldElemList(_)_WASM-TEXT_ElemList_ElemList: 2
+  - wasm-semantics/wasm-text.md :  (608, 10)
+  - wasm-semantics/wasm-text.md :  (609, 10)
+- Lbl#unfoldInstrs(_,_,_)_WASM-TEXT_Instrs_Instrs_Int_Map: 22
+  - wasm-semantics/wasm-text.md :  (635, 10)
+  - wasm-semantics/wasm-text.md :  (677, 10)
+  - wasm-semantics/wasm-text.md :  (676, 10)
+  - wasm-semantics/wasm-text.md :  (686, 10)
+  - wasm-semantics/wasm-text.md :  (685, 10)
+  - wasm-semantics/wasm-text.md :  (684, 10)
+  - wasm-semantics/wasm-text.md :  (683, 10)
+  - wasm-semantics/wasm-text.md :  (680, 10)
+  - wasm-semantics/wasm-text.md :  (679, 10)
+  - wasm-semantics/wasm-text.md :  (696, 10)
+  - wasm-semantics/wasm-text.md :  (692, 10)
+  - wasm-semantics/wasm-text.md :  (705, 10)
+  - wasm-semantics/wasm-text.md :  (704, 10)
+  - wasm-semantics/wasm-text.md :  (712, 10)
+  - wasm-semantics/wasm-text.md :  (711, 10)
+  - wasm-semantics/wasm-text.md :  (710, 10)
+  - wasm-semantics/wasm-text.md :  (708, 10)
+  - wasm-semantics/wasm-text.md :  (707, 10)
+  - wasm-semantics/wasm-text.md :  (660, 10)
+  - wasm-semantics/wasm-text.md :  (661, 10)
+  - wasm-semantics/wasm-text.md :  (662, 10)
+  - wasm-semantics/wasm-text.md :  (636, 10)
+- Lbl#unsigned(_,_)_WASM-DATA-INTERNAL-SYNTAX_Int_IValType_Int: 2
+  - wasm-semantics/data.md :  (445, 10)
+  - wasm-semantics/data.md :  (446, 10)
+- Lbl#updateFuncIds(_,_)_WASM-TEXT_Context_Context_Map: wasm-semantics/wasm-text.md :  (792, 10)
+- Lbl#updateFuncIdsAux(_,_,_)_WASM-TEXT_Context_Context_Map_Bool: 2
+  - wasm-semantics/wasm-text.md :  (794, 10)
+  - wasm-semantics/wasm-text.md :  (793, 10)
+- Lbl#updateLocalIds(_,_)_WASM-TEXT_Context_Context_Map: wasm-semantics/wasm-text.md :  (788, 10)
+- Lbl#updateLocalIdsAux(_,_,_)_WASM-TEXT_Context_Context_Map_Bool: 2
+  - wasm-semantics/wasm-text.md :  (790, 10)
+  - wasm-semantics/wasm-text.md :  (789, 10)
+- Lbl#validArgIdx(_,_)_BASEOPS_Bool_Int_ListBytes: mx-semantics/vmhooks/baseOps.md :  (113, 10)
+- Lbl#validBufferId(_,_)_MANBUFOPS_Bool_Int_MapIntToBytes: mx-semantics/vmhooks/manBufOps.md :  (23, 10)
+- Lbl#validRandom(_)_EEI-HELPERS_Bool_Int: mx-semantics/vmhooks/eei-helpers.md :  (83, 8)
+- Lbl#validateToken(_)_EEI-HELPERS_Bool_Bytes: 2
+  - mx-semantics/vmhooks/eei-helpers.md :  (29, 8)
+  - mx-semantics/vmhooks/eei-helpers.md :  (27, 8)
+- Lbl#width(_)_WASM-DATA-COMMON_Int_IValType: 2
+  - wasm-semantics/data.md :  (375, 10)
+  - wasm-semantics/data.md :  (376, 10)
+- Lbl#wrap(_,_)_WASM-DATA-COMMON_Int_Int_Int: wasm-semantics/data.md :  (410, 10)
+- Lbl#zero(_)_WASM-DATA-COMMON_ValStack_ValTypes: 4
+  - wasm-semantics/data.md :  (512, 10)
+  - wasm-semantics/data.md :  (514, 10)
+  - wasm-semantics/data.md :  (513, 10)
+  - wasm-semantics/data.md :  (515, 10)
+- append: 2
+  - UNKNOWN
+  - UNKNOWN
+Simplifications by term index:
+Ceils:

--- a/booster/test/llvm-integration/LLVM.hs
+++ b/booster/test/llvm-integration/LLVM.hs
@@ -301,7 +301,7 @@ a `equal` b = SymbolApplication eqInt [] [intTerm a, intTerm b]
 testDef :: KoreDefinition
 testDef =
     KoreDefinition
-        DefinitionAttributes
+        (DefinitionAttributes Nothing)
         Map.empty -- no modules (HACK)
         defSorts
         defSymbols

--- a/booster/test/llvm-integration/LLVM.hs
+++ b/booster/test/llvm-integration/LLVM.hs
@@ -301,7 +301,7 @@ a `equal` b = SymbolApplication eqInt [] [intTerm a, intTerm b]
 testDef :: KoreDefinition
 testDef =
     KoreDefinition
-        (DefinitionAttributes Nothing)
+        (defaultDefAttributes)
         Map.empty -- no modules (HACK)
         defSorts
         defSymbols

--- a/booster/tools/booster/Server.hs
+++ b/booster/tools/booster/Server.hs
@@ -135,10 +135,11 @@ main = do
                     , logFormat
                     , logTimeStamps
                     , logContexts
+                    , logFile
                     , smtOptions
                     , equationOptions
+                    , indexCells
                     , eventlogEnabledUserEvents
-                    , logFile
                     }
             , proxyOptions =
                 ProxyOptions
@@ -244,7 +245,7 @@ main = do
                     mLlvmLibrary <- maybe (pure Nothing) (fmap Just . mkAPI) mdl
                     definitionsWithCeilSummaries <-
                         liftIO $
-                            loadDefinition definitionFile
+                            loadDefinition indexCells definitionFile
                                 >>= mapM (mapM (runNoLoggingT . computeCeilsDefinition mLlvmLibrary))
                                 >>= evaluate . force . either (error . show) id
                     unless (isJust $ Map.lookup mainModuleName definitionsWithCeilSummaries) $ do

--- a/booster/unit-tests/Test/Booster/Fixture.hs
+++ b/booster/unit-tests/Test/Booster/Fixture.hs
@@ -32,7 +32,7 @@ boolSort = SortApp "SortBool" []
 testDefinition :: KoreDefinition
 testDefinition =
     KoreDefinition
-        { attributes = DefinitionAttributes
+        { attributes = DefinitionAttributes Nothing
         , modules = Map.singleton "AMODULE" ModuleAttributes
         , sorts =
             Map.fromList

--- a/booster/unit-tests/Test/Booster/Fixture.hs
+++ b/booster/unit-tests/Test/Booster/Fixture.hs
@@ -32,7 +32,7 @@ boolSort = SortApp "SortBool" []
 testDefinition :: KoreDefinition
 testDefinition =
     KoreDefinition
-        { attributes = DefinitionAttributes Nothing
+        { attributes = defaultDefAttributes
         , modules = Map.singleton "AMODULE" ModuleAttributes
         , sorts =
             Map.fromList

--- a/booster/unit-tests/Test/Booster/Pattern/ApplyEquations.hs
+++ b/booster/unit-tests/Test/Booster/Pattern/ApplyEquations.hs
@@ -28,7 +28,7 @@ import Booster.Definition.Base
 import Booster.Pattern.ApplyEquations
 import Booster.Pattern.Base
 import Booster.Pattern.Bool
-import Booster.Pattern.Index (TermIndex (..), CellIndex (..))
+import Booster.Pattern.Index (CellIndex (..), TermIndex (..))
 import Booster.Pattern.Util (sortOfTerm)
 import Booster.Syntax.Json.Internalise (trm)
 import Booster.Util (Flag (..))
@@ -252,7 +252,7 @@ test_errors =
 ----------------------------------------
 
 index :: SymbolName -> TermIndex
-index = TermIndex . (:[]) . TopSymbol
+index = TermIndex . (: []) . TopSymbol
 
 funDef, simplDef, loopDef :: KoreDefinition
 funDef =

--- a/booster/unit-tests/Test/Booster/Pattern/ApplyEquations.hs
+++ b/booster/unit-tests/Test/Booster/Pattern/ApplyEquations.hs
@@ -28,7 +28,7 @@ import Booster.Definition.Base
 import Booster.Pattern.ApplyEquations
 import Booster.Pattern.Base
 import Booster.Pattern.Bool
-import Booster.Pattern.Index (TermIndex (..))
+import Booster.Pattern.Index (TermIndex (..), CellIndex (..))
 import Booster.Pattern.Util (sortOfTerm)
 import Booster.Syntax.Json.Internalise (trm)
 import Booster.Util (Flag (..))
@@ -251,13 +251,16 @@ test_errors =
 
 ----------------------------------------
 
+index :: SymbolName -> TermIndex
+index = TermIndex . (:[]) . TopSymbol
+
 funDef, simplDef, loopDef :: KoreDefinition
 funDef =
     testDefinition
         { functionEquations =
             mkTheory
-                [ (TopSymbol "f1", f1Equations)
-                , (TopSymbol "f2", f2Equations) -- should not be applied (f2 partial)
+                [ (index "f1", f1Equations)
+                , (index "f2", f2Equations) -- should not be applied (f2 partial)
                 ]
         }
 simplDef =
@@ -265,7 +268,7 @@ simplDef =
         { simplifications =
             mkTheory
                 [
-                    ( TopSymbol "con1"
+                    ( index "con1"
                     ,
                         [ equation -- con1(con2(f2(X))) => con1(X) , but f2 partial => not applied
                             Nothing
@@ -286,7 +289,7 @@ simplDef =
                         ]
                     )
                 ,
-                    ( TopSymbol "con3"
+                    ( index "con3"
                     ,
                         [ equation -- con3(X, X) => inj{sub,some}(con4(X, X))
                             Nothing
@@ -303,7 +306,7 @@ loopDef =
         { simplifications =
             mkTheory
                 [
-                    ( TopSymbol "f1"
+                    ( index "f1"
                     ,
                         [ equation
                             Nothing

--- a/booster/unit-tests/Test/Booster/Pattern/Index.hs
+++ b/booster/unit-tests/Test/Booster/Pattern/Index.hs
@@ -15,7 +15,7 @@ import Test.Tasty.HUnit
 import Booster.Definition.Attributes.Base
 import Booster.Definition.Base
 import Booster.Pattern.Base
-import Booster.Pattern.Index (TermIndex (..), CellIndex (..))
+import Booster.Pattern.Index (CellIndex (..), TermIndex (..))
 import Booster.Pattern.Index qualified as Idx
 import Booster.Syntax.Json.Internalise (trm)
 import Booster.Syntax.ParsedKore.Internalise (symb)
@@ -99,15 +99,16 @@ testIndexCover =
                     , [Anything, TopSymbol "blu"]
                     , [Anything, Anything]
                     ]
-            cells ==> [ cells
-                      , [TopSymbol "bla", TopSymbol "blu", Anything]
-                      , [TopSymbol "bla", Anything, TopSymbol "bli"]
-                      , [TopSymbol "bla", Anything, Anything]
-                      , [Anything, TopSymbol "blu", TopSymbol "bli"]
-                      , [Anything, TopSymbol "blu", Anything]
-                      , [Anything, Anything, TopSymbol "bli"]
-                      , [Anything, Anything, Anything]
-                     ]
+            cells
+                ==> [ cells
+                    , [TopSymbol "bla", TopSymbol "blu", Anything]
+                    , [TopSymbol "bla", Anything, TopSymbol "bli"]
+                    , [TopSymbol "bla", Anything, Anything]
+                    , [Anything, TopSymbol "blu", TopSymbol "bli"]
+                    , [Anything, TopSymbol "blu", Anything]
+                    , [Anything, Anything, TopSymbol "bli"]
+                    , [Anything, Anything, Anything]
+                    ]
         ]
   where
     (==>) :: [CellIndex] -> [[CellIndex]] -> Assertion

--- a/booster/unit-tests/Test/Booster/Pattern/Index.hs
+++ b/booster/unit-tests/Test/Booster/Pattern/Index.hs
@@ -12,8 +12,6 @@ import Data.Set qualified as Set
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import Booster.Definition.Attributes.Base
-import Booster.Definition.Base
 import Booster.Pattern.Base
 import Booster.Pattern.Index (CellIndex (..), TermIndex (..))
 import Booster.Pattern.Index qualified as Idx

--- a/booster/unit-tests/Test/Booster/Pattern/Index.hs
+++ b/booster/unit-tests/Test/Booster/Pattern/Index.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+{- |
+Copyright   : (c) Runtime Verification, 2022
+License     : BSD-3-Clause
+-}
+module Test.Booster.Pattern.Index (
+    test_indexing,
+) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Booster.Definition.Attributes.Base
+import Booster.Definition.Base
+import Booster.Pattern.Base
+import Booster.Pattern.Index (TermIndex (..), CellIndex (..))
+import Booster.Pattern.Index qualified as Idx
+import Booster.Syntax.Json.Internalise (trm)
+import Booster.Syntax.ParsedKore.Internalise (symb)
+import Test.Booster.Fixture hiding (inj)
+
+test_indexing :: TestTree
+test_indexing =
+    testGroup
+        "Term Indexing"
+        [ testKCellIndexing
+        , testCompositeIndexing
+        , testTopTermIndexing
+        ]
+
+testKCellIndexing :: TestTree
+testKCellIndexing =
+    testGroup
+        "Indexing the K cell"
+        [ testCase "An empty K cell is indexed as dotk" $
+            [trm| kCell{}(dotk{}()) |] ==> TopSymbol "dotk"
+        , testCase "A non-empty K cell is indexed as its head element without injections" $ do
+            KSeq someSort [trm| X:SomeSort{} |]
+                ==> Anything
+            [trm| kCell{}(kseq{}(inj{SomeSort{},SortKItem{}}(\dv{SomeSort{}}("X")), dotk{}())) |]
+                ==> Anything
+            [trm| kCell{}(kseq{}(inj{SomeSort{},SortKItem{}}(f1{}(X:SomeSort{})), dotk{}())) |]
+                ==> TopSymbol "f1"
+        ]
+  where
+    kCell :: Symbol
+    kCell =
+        [symb| symbol Lbl'-LT-'k'-GT-'{}(SortK{}) : SortKCell{} [constructor{}()] |]
+
+    (==>) :: Term -> CellIndex -> Assertion
+    t ==> result = Idx.kCellTermIndex t @=? TermIndex [result]
+
+inj :: Symbol
+inj = [symb| symbol inj{From, To}( From ) : To [sortInjection{}()] |]
+
+testCompositeIndexing :: TestTree
+testCompositeIndexing =
+    testGroup
+        "Indexing with custom cells"
+        [ testCase "No cells for indexing results in empty index" $
+            Idx.compositeTermIndex [] undefined @=? TermIndex []
+        ]
+
+testTopTermIndexing :: TestTree
+testTopTermIndexing =
+    testGroup
+        "Indexing the top term"
+        [ testCase "Only symbol applications get an index" $ do
+            [trm| VAR:SomeSort{} |] ==> Anything
+            [trm| \dv{SomeSort{}}("") |] ==> Anything
+            [trm| f1{}(VAR:SomeSort{}) |] ==> TopSymbol "f1"
+        , testCase "And-terms are indexed by combining the argument indexes" $ do
+            AndTerm [trm| f1{}( X:SomeSort{} ) |] [trm| Y:SomeSort{} |] ==> TopSymbol "f1"
+            AndTerm [trm| X:SomeSort{} |] [trm| f1{}( Y:SomeSort{} ) |] ==> TopSymbol "f1"
+            AndTerm [trm| f1{}( X:SomeSort{} ) |] [trm| f1{}( Y:SomeSort{} ) |] ==> TopSymbol "f1"
+            AndTerm [trm| f1{}( X:SomeSort{} ) |] [trm| f2{}( Y:SomeSort{} ) |] ==> None
+            AndTerm [trm| X:SomeSort{} |] [trm| Y:SomeSort{} |] ==> Anything
+        ]
+  where
+    (==>) :: Term -> CellIndex -> Assertion
+    t ==> result = Idx.termTopIndex t @=? TermIndex [result]

--- a/booster/unit-tests/Test/Booster/Pattern/Rewrite.hs
+++ b/booster/unit-tests/Test/Booster/Pattern/Rewrite.hs
@@ -23,7 +23,7 @@ import Test.Tasty.HUnit
 import Booster.Definition.Attributes.Base
 import Booster.Definition.Base
 import Booster.Pattern.Base
-import Booster.Pattern.Index (TermIndex (..))
+import Booster.Pattern.Index (TermIndex (..), CellIndex (..))
 import Booster.Pattern.Rewrite
 import Booster.Syntax.Json.Internalise (trm)
 import Booster.Syntax.ParsedKore.Internalise (symb)
@@ -58,14 +58,17 @@ test_performRewrite =
 
 ----------------------------------------
 
+index :: SymbolName -> TermIndex
+index = TermIndex . (:[]) . TopSymbol
+
 def :: KoreDefinition
 def =
     testDefinition
         { rewriteTheory =
             mkTheory
-                [ (TopSymbol "con1", [rule1, rule2, rule1'])
-                , (TopSymbol "con3", [rule3])
-                , (TopSymbol "con4", [rule4])
+                [ (index "con1", [rule1, rule2, rule1'])
+                , (index "con3", [rule3])
+                , (index "con4", [rule4])
                 ]
         }
 

--- a/booster/unit-tests/Test/Booster/Pattern/Rewrite.hs
+++ b/booster/unit-tests/Test/Booster/Pattern/Rewrite.hs
@@ -23,7 +23,7 @@ import Test.Tasty.HUnit
 import Booster.Definition.Attributes.Base
 import Booster.Definition.Base
 import Booster.Pattern.Base
-import Booster.Pattern.Index (TermIndex (..), CellIndex (..))
+import Booster.Pattern.Index (CellIndex (..), TermIndex (..))
 import Booster.Pattern.Rewrite
 import Booster.Syntax.Json.Internalise (trm)
 import Booster.Syntax.ParsedKore.Internalise (symb)
@@ -59,7 +59,7 @@ test_performRewrite =
 ----------------------------------------
 
 index :: SymbolName -> TermIndex
-index = TermIndex . (:[]) . TopSymbol
+index = TermIndex . (: []) . TopSymbol
 
 def :: KoreDefinition
 def =

--- a/dev-tools/booster-dev/Server.hs
+++ b/dev-tools/booster-dev/Server.hs
@@ -51,6 +51,7 @@ main = do
             , llvmLibraryFile
             , smtOptions
             , equationOptions
+            , indexCells
             , eventlogEnabledUserEvents
             , logFile
             } = options
@@ -66,7 +67,7 @@ main = do
 
     withLlvmLib llvmLibraryFile $ \mLlvmLibrary -> do
         definitionMap <-
-            loadDefinition definitionFile
+            loadDefinition indexCells definitionFile
                 >>= mapM (mapM ((fst <$>) . runNoLoggingT . computeCeilsDefinition mLlvmLibrary))
                 >>= evaluate . force . either (error . show) id
         -- ensure the (default) main module is present in the definition

--- a/dev-tools/parsetest-binary/ParsetestBinary.hs
+++ b/dev-tools/parsetest-binary/ParsetestBinary.hs
@@ -28,7 +28,7 @@ test :: Maybe (FilePath, Text.Text) -> FilePath -> IO Term
 test (Just (definitionFile, mainModuleName)) f = do
     definitionMap <-
         either (error . show) id
-            <$> loadDefinition definitionFile
+            <$> loadDefinition [] definitionFile
     let internalModule =
             fromMaybe (error $ Text.unpack mainModuleName <> ": No such module") $
                 Map.lookup mainModuleName definitionMap

--- a/flake.nix
+++ b/flake.nix
@@ -274,6 +274,7 @@
               pkgs.nix
               pkgs.z3
               pkgs.lsof
+              pkgs.libffi
           ];
           shellHook = ''
             hpack booster && hpack dev-tools

--- a/flake.nix
+++ b/flake.nix
@@ -274,7 +274,6 @@
               pkgs.nix
               pkgs.z3
               pkgs.lsof
-              pkgs.libffi
           ];
           shellHook = ''
             hpack booster && hpack dev-tools


### PR DESCRIPTION
* The index on the `k` cell is generalised to an index on one or more arbitrary cells containing K sequences (default stays the same, the `k` cell only). 
* The cell(s) to index are read from a definition attribute named `indexCells`. This attribute is expected to contain an argument list of names _quoted as all symbols in kore_  (e.g., `Lbl'-LT-'k'-GT-'` for the `k` cell).
* Alternatively, the cell(s) to index can be overridden by a command line option `--index-cells CELL1,CELL2,...` to `booster-dev` and `kore-rpc-booster`.  This option takes plain names (like `k` for the `k` cell), which are quoted and prefixed before overriding the definition attribute of the loaded definition.

Fixes #3874

