### PR TITLE
`MAP.updateAll` implementation on concrete arguments

### DIFF
--- a/kore/test/Test/Kore/Builtin/Definition.hs
+++ b/kore/test/Test/Kore/Builtin/Definition.hs
@@ -460,6 +460,10 @@ updateMapSymbol :: Internal.Symbol
 updateMapSymbol =
     builtinSymbol "updateMap" mapSort [mapSort, intSort, intSort]
         & hook "MAP.update"
+updateAllMapSymbol :: Internal.Symbol
+updateAllMapSymbol =
+    builtinSymbol "updateAllMap" mapSort [mapSort, mapSort]
+        & hook "MAP.updateAll"
 lookupMapSymbol :: Internal.Symbol
 lookupMapSymbol =
     builtinSymbol "lookupMap" intSort [mapSort, intSort]
@@ -510,6 +514,11 @@ updateMap ::
     TermLike RewritingVariableName ->
     TermLike RewritingVariableName
 updateMap map' key value = mkApplySymbol updateMapSymbol [map', key, value]
+updateAllMap ::
+    TermLike RewritingVariableName ->
+    TermLike RewritingVariableName ->
+    TermLike RewritingVariableName
+updateAllMap map' updates = mkApplySymbol updateAllMapSymbol [map', updates]
 lookupMap ::
     TermLike RewritingVariableName ->
     TermLike RewritingVariableName ->
@@ -1553,6 +1562,7 @@ mapModule =
             , hookedSymbolDecl lookupMapSymbol
             , hookedSymbolDecl lookupOrDefaultMapSymbol
             , hookedSymbolDecl updateMapSymbol
+            , hookedSymbolDecl updateAllMapSymbol
             , hookedSymbolDecl inKeysMapSymbol
             , hookedSymbolDecl keysMapSymbol
             , hookedSymbolDecl keysListMapSymbol

--- a/kore/test/Test/Kore/Builtin/Map.hs
+++ b/kore/test/Test/Kore/Builtin/Map.hs
@@ -205,11 +205,11 @@ test_updateAll =
             expect = OrPattern.fromTermLike aMap
         (===) expect =<< evaluateTermT update1
         (===) expect =<< evaluateTermT update2
-    -- , testCaseWithoutSMT "Empty maps should yield a result" $ do
-    --     let update1 = updateAllMap unitMap unitMap
-    --         expect = OrPattern.fromTermLike unitMap
-    --     result <- evaluateTermT update1
-    --     assertEqual "duh" expect result
+        -- , testCaseWithoutSMT "Empty maps should yield a result" $ do
+        --     let update1 = updateAllMap unitMap unitMap
+        --         expect = OrPattern.fromTermLike unitMap
+        --     result <- evaluateTermT update1
+        --     assertEqual "duh" expect result
     ]
 
 test_removeUnit :: TestTree

--- a/kore/test/Test/Kore/Builtin/Map.hs
+++ b/kore/test/Test/Kore/Builtin/Map.hs
@@ -1,6 +1,7 @@
 module Test.Kore.Builtin.Map (
     test_lookupUnit,
     test_lookupUpdate,
+    test_updateAll,
     test_removeUnit,
     test_sizeUnit,
     test_removeKeyNotIn,
@@ -193,6 +194,22 @@ test_lookupUpdate =
             expect = OrPattern.fromTermLike patVal
         (===) expect =<< evaluateTermT patLookup
         (===) (OrPattern.topOf kSort) =<< evaluatePredicateT predicate
+    ]
+
+test_updateAll :: [TestTree]
+test_updateAll =
+    [ testPropertyWithoutSolver "Empty maps are neutral elements for MAP.updateAll" $ do
+        aMap <- forAll genMapPattern
+        let update1 = updateAllMap aMap unitMap
+            update2 = updateAllMap unitMap aMap
+            expect = OrPattern.fromTermLike aMap
+        (===) expect =<< evaluateTermT update1
+        (===) expect =<< evaluateTermT update2
+    -- , testCaseWithoutSMT "Empty maps should yield a result" $ do
+    --     let update1 = updateAllMap unitMap unitMap
+    --         expect = OrPattern.fromTermLike unitMap
+    --     result <- evaluateTermT update1
+    --     assertEqual "duh" expect result
     ]
 
 test_removeUnit :: TestTree


### PR DESCRIPTION
Fixes #3898 

`MAP.updateAll` was previously returning `notImplemented` (always returning `NotApplicable`) but this causes an error when its arguments are fully-concrete.
This change implements the hook for fully-concrete maps, by doing the obvious update of the underlying hash map and special-casing empty maps.