### PR TITLE
Revert "Do not retry SMT query when WarnDecidePredicateUnknown"

### DIFF
--- a/kore/src/Kore/Rewrite/SMT/Evaluator.hs
+++ b/kore/src/Kore/Rewrite/SMT/Evaluator.hs
@@ -169,11 +169,7 @@ decidePredicate ::
 decidePredicate onUnknown sideCondition predicates =
     whileDebugEvaluateCondition predicates $
         do
-            result <- case onUnknown of
-                -- do not retry the query on Unknown if the use-case is "soft", i.e. applying simplifications
-                WarnDecidePredicateUnknown _ _ -> query
-                -- if Unknown leads to a hard error, retry the query with scaled timeouts
-                ErrorDecidePredicateUnknown _ _ -> query >>= whenUnknown retry
+            result <- query >>= whenUnknown retry
             debugEvaluateConditionResult result
             case result of
                 Unsat -> return False


### PR DESCRIPTION
Some `kasmer` proof rely heavily on simplifications and start failing when we stop applying them.

This reverts commit 40c912bf769b3bf7cfae8552e0faf698ac727920.
