### PR TITLE
Abort on "Unknown" side conditions, don't crash

### DIFF
--- a/booster/library/Booster/SMT/Interface.hs
+++ b/booster/library/Booster/SMT/Interface.hs
@@ -327,11 +327,11 @@ checkPredicates ctxt givenPs givenSubst psToCheck
             (Unsat, Sat) -> pure False
             (Unknown, _) -> do
                 smtRun GetReasonUnknown >>= \case
-                    ReasonUnknown reason -> throwE $ SMTSolverUnknown reason mempty mempty
+                    ReasonUnknown reason -> throwE $ SMTSolverUnknown reason givenPs psToCheck
                     other -> throwSMT' $ "Unexpected result while calling ':reason-unknown': " <> show other
             (_, Unknown) -> do
                 smtRun GetReasonUnknown >>= \case
-                    ReasonUnknown reason -> throwE $ SMTSolverUnknown reason mempty mempty
+                    ReasonUnknown reason -> throwE $ SMTSolverUnknown reason givenPs psToCheck
                     other -> throwSMT' $ "Unexpected result while calling ':reason-unknown': " <> show other
             other -> throwSMT' $ "Unexpected result while checking a condition: " <> show other
   where


### PR DESCRIPTION
This PR makes sure we do not immediately hard-stop with an RPC error when receiving `Unknown` from Z3 in Booster.

- use pure exceptions in SMT functions, check results at call sites to `checkPredicates`
- threat Z3-`Unknown` predicates as any other unclear conditions: abort rewriting