### PR TITLE
Make booster-analysis script work for *tar again

### DIFF
--- a/scripts/booster-analysis.sh
+++ b/scripts/booster-analysis.sh
@@ -48,7 +48,7 @@ run_tarball(){
 export -f run_tarball
 export SCRIPT_DIR
 
-find $BUG_REPORT_DIR -name \*.tar -or -name \*.tar.gz -print0 | xargs -0 -t -I {} -P $PARALLEL bash -c 'run_tarball "$@"' $(basename {}) {}
+find $BUG_REPORT_DIR -name \*.tar -print0 -or -name \*.tar.gz -print0 | xargs -0 -t -I {} -P $PARALLEL bash -c 'run_tarball "$@"' $(basename {}) {}
 
 cd $LOG_DIR
 


### PR DESCRIPTION
The previous change introduced an `-or` which requires repeating the `-print0`.