### PR TITLE
Remove cross-workflow dependency from master:cache-stack job

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -66,7 +66,6 @@ jobs:
   cache-stack:
     name: 'Cache Stack'
     runs-on: ubuntu-22.04
-    needs: draft-release
     steps:
       - name: Install prerequisites
         run: |


### PR DESCRIPTION
Fixes an oversight in the job dependency changes of #3924 
I also pushed a branch named `release` to github to make the `version-bump` job work.
