### PR TITLE
HOTFIX store version in step output and read back to publish release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,13 @@ jobs:
   draft-release:
     name: 'Draft Release'
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps make-release.outputs.version }}
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4
       - name: 'Make release'
+        id: 'make-release'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -66,9 +69,9 @@ jobs:
       - name: 'Finalise release'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.draft-release.outputs.version }}
         run: |
           set -x
-          VERSION=${{ steps.draft-release.outputs.version }}
           gh release edit ${VERSION}                    \
             --repo runtimeverification/haskell-backend  \
             --draft=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
             --draft                                     \
             --title ${VERSION}                          \
             --target ${{ github.sha }}
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
   release:
     name: 'Release'
@@ -67,7 +68,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -x
-          VERSION=v$(cat package/version)
+          VERSION=${{ steps.draft-release.outputs.version }}
           gh release edit ${VERSION}                    \
             --repo runtimeverification/haskell-backend  \
             --draft=false


### PR DESCRIPTION
Follows the example from https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs#example-defining-outputs-for-a-job to store the version number in a job output.