### PR TITLE
Add `-l EquationWarnings` and `warning` context in Booster

### DIFF
--- a/booster/library/Booster/CLOptions.hs
+++ b/booster/library/Booster/CLOptions.hs
@@ -232,6 +232,10 @@ allowedLogLevels =
     , ("Depth", "Log the current depth of the state")
     , ("SMT", "Log the SMT-solver interactions")
     , ("ErrorDetails", "Log error conditions with extensive details")
+    ,
+        ( "EquationWarnings"
+        , "Log warnings indicating soft-violations of conditions, i.e. exceeding the equation recursion/iteration limit "
+        )
     ]
 
 levelToContext :: Map Text [ContextFilter]
@@ -277,6 +281,12 @@ levelToContext =
                 , [ctxt| proxy. |]
                 , [ctxt| proxy,abort. |]
                 , [ctxt| booster>failure,abort |]
+                ]
+            )
+        ,
+            ( "EquationWarnings"
+            ,
+                [ [ctxt| booster>(simplification *|function *)>warning |]
                 ]
             )
         ]

--- a/booster/library/Booster/Pattern/ApplyEquations.hs
+++ b/booster/library/Booster/Pattern/ApplyEquations.hs
@@ -232,9 +232,8 @@ fromCache tag t = eqState $ Map.lookup t <$> gets (select tag . (.cache))
 
 logWarn :: LoggerMIO m => Text -> m ()
 logWarn msg =
-    withContext "warning" $ do
-        logMessage $
-            msg <> " For more details, enable full context logging '--log-context \"*\"'"
+    withContext "warning" $
+        logMessage msg
 
 checkForLoop :: LoggerMIO io => Term -> EquationT io ()
 checkForLoop t = do

--- a/booster/library/Booster/Pattern/ApplyEquations.hs
+++ b/booster/library/Booster/Pattern/ApplyEquations.hs
@@ -232,8 +232,9 @@ fromCache tag t = eqState $ Map.lookup t <$> gets (select tag . (.cache))
 
 logWarn :: LoggerMIO m => Text -> m ()
 logWarn msg =
-    logMessage' $
-        msg <> " For more details, enable full context logging '--log-context \"*\"'"
+    withContext "warning" $ do
+        logMessage $
+            msg <> " For more details, enable full context logging '--log-context \"*\"'"
 
 checkForLoop :: LoggerMIO io => Term -> EquationT io ()
 checkForLoop t = do


### PR DESCRIPTION
Fixes #3927

This PR disables the display of the three equation-related warning in Booster by default. They can be re-enabled by the flag `-l EquationWarnings`, which is a shorthand to the context expression `--log-context booster>(simplification *|function *)>warning`.