### PR TITLE
HOTFIX change condition to constraint in context options

### DIFF
--- a/booster/library/Booster/CLOptions.hs
+++ b/booster/library/Booster/CLOptions.hs
@@ -258,7 +258,7 @@ levelToContext =
             ( "Rewrite"
             ,
                 [ [ctxt| booster|kore>rewrite*,success|failure|abort|detail |]
-                , [ctxt| booster|kore>rewrite*,match|definedness|condition,failure|abort |]
+                , [ctxt| booster|kore>rewrite*,match|definedness|constraint,failure|abort |]
                 ]
             )
         ,
@@ -277,7 +277,7 @@ levelToContext =
             ( "Aborts"
             ,
                 [ [ctxt| booster>rewrite*,detail. |]
-                , [ctxt| booster>rewrite*,match|definedness|condition,abort. |]
+                , [ctxt| booster>rewrite*,match|definedness|constraint,abort. |]
                 , [ctxt| proxy. |]
                 , [ctxt| proxy,abort. |]
                 , [ctxt| booster>failure,abort |]


### PR DESCRIPTION
The context string was changed in prior PR #3919  but the configuration options were not, leading to incomplete data for abort analysis..