### PR TITLE
Simplify the remainder predicate before checking its satisfiability

### DIFF
--- a/kore/src/Kore/Rewrite/RewriteStep.hs
+++ b/kore/src/Kore/Rewrite/RewriteStep.hs
@@ -304,12 +304,14 @@ finalizeRulesParallel
                     unifiedRules
                     & fmap fold
             let unifications = MultiOr.make (Conditional.withoutTerm <$> unifiedRules)
+                -- TODO here we lose the connection between the rules and the remainders.
+                -- Perhaps it would make sense to log the remainder of every rule.
                 remainderPredicate = Remainder.remainder' unifications
             -- evaluate the remainder predicate to make sure it is actually satisfiable
             SMT.evalPredicate
                 (ErrorDecidePredicateUnknown $srcLoc Nothing)
                 remainderPredicate
-                Nothing
+                (Just (SideCondition.addAssumption (predicate initial) sideCondition))
                 >>= \case
                     -- remainder condition is UNSAT: we prune the remainder branch early to avoid
                     -- jumping into the pit of function evaluation in the configuration under the

--- a/kore/src/Kore/Rewrite/RewriteStep.hs
+++ b/kore/src/Kore/Rewrite/RewriteStep.hs
@@ -323,7 +323,7 @@ finalizeRulesParallel
             SMT.evalPredicate
                 (ErrorDecidePredicateUnknown $srcLoc Nothing)
                 simplifiedRemainderPredicate
-                (Just (SideCondition.addAssumption (predicate initial) sideCondition))
+                (Just sideCondition)
                 >>= \case
                     -- remainder condition is UNSAT: we prune the remainder branch early to avoid
                     -- jumping into the pit of function evaluation in the configuration under the

--- a/kore/src/Kore/Rewrite/RewriteStep.hs
+++ b/kore/src/Kore/Rewrite/RewriteStep.hs
@@ -312,10 +312,7 @@ finalizeRulesParallel
             simplifiedRemainderConditional <-
                 Logic.observeAllT $
                     Simplifier.simplifyCondition
-                        ( sideCondition
-                            & SideCondition.addConditionWithReplacements
-                                (Pattern.withoutTerm initial)
-                        )
+                        SideCondition.top
                         (Condition.fromPredicate remainderPredicate)
             let simplifiedRemainderPredicate = Remainder.remainder' $ MultiOr.make simplifiedRemainderConditional
 
@@ -323,7 +320,7 @@ finalizeRulesParallel
             SMT.evalPredicate
                 (ErrorDecidePredicateUnknown $srcLoc Nothing)
                 simplifiedRemainderPredicate
-                (Just sideCondition)
+                Nothing
                 >>= \case
                     -- remainder condition is UNSAT: we prune the remainder branch early to avoid
                     -- jumping into the pit of function evaluation in the configuration under the

--- a/kore/src/Kore/Rewrite/Step.hs
+++ b/kore/src/Kore/Rewrite/Step.hs
@@ -324,20 +324,8 @@ applyRemainder ::
     Condition RewritingVariableName ->
     LogicT Simplifier (Pattern RewritingVariableName)
 applyRemainder sideCondition initial remainder = inContext "apply-remainder" $ do
-    -- Simplify the remainder predicate under the initial conditions. We must
-    -- ensure that functions in the remainder are evaluated using the top-level
-    -- side conditions because we will not re-evaluate them after they are added
-    -- to the top level.
-    partial <-
-        Simplifier.simplifyCondition
-            ( sideCondition
-                & SideCondition.addConditionWithReplacements
-                    (Pattern.withoutTerm initial)
-            )
-            remainder
-    -- Add the simplified remainder to the initial conditions. We must preserve
-    -- the initial conditions here!
+    -- Add the remainder to the initial conditions.
     Simplifier.simplifyCondition
         sideCondition
-        (Pattern.andCondition initial partial)
+        (Pattern.andCondition initial remainder)
         <&> Pattern.mapVariables resetConfigVariable


### PR DESCRIPTION
Needs https://github.com/runtimeverification/haskell-backend/pull/3943

This is a more radical variant of https://github.com/runtimeverification/haskell-backend/pull/3943 that simplifies the remainder before checking it for satisfiability. If the remainder is satisfiable, we do not simplify it again in `applyRemainder`.