### PR TITLE
Install missing prerequisites for Ubuntu package on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,10 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install prerequisites
+        run: |
+          sudo apt install --yes debhelper z3 libsecp256k1-dev
+
       - name: Cache Stack root
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
This is a simple oversight on my part; I forgot to replicate this stanza from the test to the release job when making #3955.