### PR TITLE
Remove directory name assumption in `kore-rpc-client`

### DIFF
--- a/booster/tools/rpc-client/RpcClient.hs
+++ b/booster/tools/rpc-client/RpcClient.hs
@@ -483,7 +483,7 @@ parseMode =
         maybeReader $ \s -> case split (== '=') s of [k, v] -> Just (k, v); _ -> Nothing
 
 ----------------------------------------
--- Running all requests contained in the `rpc_*` directory of a tarball
+-- Running all requests contained in the subdirectories of the tarball
 
 runTarball ::
     CommonOptions ->
@@ -548,15 +548,13 @@ runTarball common (Just sock) tarFile keepGoing runOnly compareDetails = do
         case splitFileName (Tar.entryPath entry) of
             -- unpack all directories "rpc_<something>" containing "*.json" files
             (dir, "") -- directory
-                | Tar.Directory <- Tar.entryContent entry
-                , "rpc_" `isPrefixOf` dir -> do
+                | Tar.Directory <- Tar.entryContent entry -> do
                     createDirectoryIfMissing False dir -- create rpc dir so we can unpack files there
                     acc -- no additional file to return
                 | otherwise ->
                     acc -- skip other directories and top-level files
             (dir, file)
-                | "rpc_" `isPrefixOf` dir
-                , ".json" `isSuffixOf` file
+                | ".json" `isSuffixOf` file
                 , not ("." `isPrefixOf` file)
                 , Tar.NormalFile bs _size <- Tar.entryContent entry -> do
                     -- unpack json files into tmp directory

--- a/booster/tools/rpc-client/RpcClient.hs
+++ b/booster/tools/rpc-client/RpcClient.hs
@@ -549,7 +549,7 @@ runTarball common (Just sock) tarFile keepGoing runOnly compareDetails = do
             -- unpack all directories "rpc_<something>" containing "*.json" files
             (dir, "") -- directory
                 | Tar.Directory <- Tar.entryContent entry -> do
-                    createDirectoryIfMissing False dir -- create rpc dir so we can unpack files there
+                    createDirectoryIfMissing True dir -- create rpc dir so we can unpack files there
                     acc -- no additional file to return
                 | otherwise ->
                     acc -- skip other directories and top-level files
@@ -560,7 +560,7 @@ runTarball common (Just sock) tarFile keepGoing runOnly compareDetails = do
                     -- unpack json files into tmp directory
                     let newPath = dir </> file
                     -- current tarballs do not have dir entries, create dir here
-                    createDirectoryIfMissing False $ tmpDir </> dir
+                    createDirectoryIfMissing True $ tmpDir </> dir
                     BS.writeFile (tmpDir </> newPath) bs
                     (newPath :) <$> acc
                 | otherwise ->

--- a/booster/tools/rpc-client/RpcClient.hs
+++ b/booster/tools/rpc-client/RpcClient.hs
@@ -542,11 +542,11 @@ runTarball common (Just sock) tarFile keepGoing runOnly compareDetails = do
     throwAnyError :: Either Tar.FormatError Tar.FileNameError -> IO a
     throwAnyError = either throwIO throwIO
 
-    -- unpack all rpc_*/*.json files into dir and return their names
+    -- unpack all */*.json files into dir and return their names
     unpackIfRpc :: FilePath -> Tar.Entry -> IO [FilePath] -> IO [FilePath]
     unpackIfRpc tmpDir entry acc = do
         case splitFileName (Tar.entryPath entry) of
-            -- unpack all directories "rpc_<something>" containing "*.json" files
+            -- unpack all directories "<something>" containing "*.json" files
             (dir, "") -- directory
                 | Tar.Directory <- Tar.entryContent entry -> do
                     createDirectoryIfMissing True dir -- create rpc dir so we can unpack files there


### PR DESCRIPTION
- when running a tarball, consider the requests from all directories, not just the one prefixed with `rpc_`
- allow creating parent directories when unpacking a tarball