### PR TITLE
Order requests from a tarball based on the sequence folder

### DIFF
--- a/booster/package.yaml
+++ b/booster/package.yaml
@@ -119,6 +119,7 @@ executables:
       - bz2
       - casing
       - clock
+      - containers
       - directory
       - extra
       - filepath


### PR DESCRIPTION
Fixes #3978 

This change is backwards compatible and works on the old style tarballs which do not contain the `sequence` folder.