### PR TITLE
HOTFIX master.yml: Push version tag to `origin`

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -79,5 +79,5 @@ jobs:
           if git add --update && git commit --no-edit --allow-empty --message "Set Version: $(cat package/version)"; then
             git push origin release
             git tag "v$(cat package/version)" origin/master
-            git push "v$(cat package/version)"
+            git push origin "v$(cat package/version)"
           fi


### PR DESCRIPTION
The previous PR #3983 had an error in the line that pushes the tag (missing `origin`) see https://github.com/runtimeverification/haskell-backend/actions/runs/9972668145/job/27556861219