### PR TITLE
Recover from `TooManyIterations` when simplifying during rewriting

### DIFF
--- a/booster/library/Booster/Pattern/ApplyEquations.hs
+++ b/booster/library/Booster/Pattern/ApplyEquations.hs
@@ -331,18 +331,14 @@ iterateEquations direction preference startTerm = do
             config <- getConfig
             currentCount <- countSteps
             when (coerce currentCount > config.maxIterations) $ do
-                -- FIXME if this exception is caught in evaluatePattern',
-                --       then CtxAbort is a wrong context for it.
-                --       We should emit this log  entry somewhere else.
-                withContext CtxAbort $ do
-                    logWarn $
-                        renderOneLineText $
-                            "Unable to finish evaluation in" <+> pretty currentCount <+> "iterations."
-                    withContext CtxDetail $
-                        getPrettyModifiers >>= \case
-                            ModifiersRep (_ :: FromModifiersT mods => Proxy mods) ->
-                                logMessage . renderOneLineText $
-                                    "Final term:" <+> pretty' @mods currentTerm
+                logWarn $
+                    renderOneLineText $
+                        "Unable to finish evaluation in" <+> pretty currentCount <+> "iterations."
+                withContext CtxDetail $
+                    getPrettyModifiers >>= \case
+                        ModifiersRep (_ :: FromModifiersT mods => Proxy mods) ->
+                            logMessage . renderOneLineText $
+                                "Final term:" <+> pretty' @mods currentTerm
                 throw $
                     TooManyIterations currentCount startTerm currentTerm
             pushTerm currentTerm

--- a/booster/library/Booster/Pattern/ApplyEquations.hs
+++ b/booster/library/Booster/Pattern/ApplyEquations.hs
@@ -408,8 +408,7 @@ evaluateTerm' ::
     Direction ->
     Term ->
     EquationT io Term
-evaluateTerm' direction =
-    iterateEquations direction PreferFunctions
+evaluateTerm' direction = iterateEquations direction PreferFunctions
 
 {- | Simplify a Pattern, processing its constraints independently.
      Returns either the first failure or the new pattern if no failure was encountered

--- a/booster/library/Booster/Pattern/Rewrite.hs
+++ b/booster/library/Booster/Pattern/Rewrite.hs
@@ -761,6 +761,9 @@ performRewrite doTracing def mLlvmLibrary mSolver mbMaxDepth cutLabels terminalL
                 Left r@UndefinedTerm{} -> do
                     emitRewriteTrace $ RewriteSimplified (Just r)
                     pure Nothing
+                Left r@(TooManyIterations _ _ end) -> do
+                    emitRewriteTrace $ RewriteSimplified (Just r)
+                    pure $ Just p{term = end}
                 Left other -> do
                     emitRewriteTrace $ RewriteSimplified (Just other)
                     pure $ Just p

--- a/booster/library/Booster/Pattern/Rewrite.hs
+++ b/booster/library/Booster/Pattern/Rewrite.hs
@@ -761,9 +761,6 @@ performRewrite doTracing def mLlvmLibrary mSolver mbMaxDepth cutLabels terminalL
                 Left r@UndefinedTerm{} -> do
                     emitRewriteTrace $ RewriteSimplified (Just r)
                     pure Nothing
-                Left r@(TooManyIterations _ _ end) -> do
-                    emitRewriteTrace $ RewriteSimplified (Just r)
-                    pure $ Just p{term = end}
                 Left other -> do
                     emitRewriteTrace $ RewriteSimplified (Just other)
                     pure $ Just p


### PR DESCRIPTION
Booster's rewriting algorithm, upon getting stuck (or aborting due to `RuleApplicationUnclear`), will try so simplify the configuration once and retry applying rules. When we cannot not finish simplifying the term due to a `TooManyIterations`, we throw the partial result away and fail.

This PR handles the `TooManyIterations` exception and attempts applying rewrite rules to the partially simplified term.