### PR TITLE
EXPERIMENTS: shorten cache lookup chains, invalidate cache on new ensures

### DIFF
--- a/booster/library/Booster/Pattern/ApplyEquations.hs
+++ b/booster/library/Booster/Pattern/ApplyEquations.hs
@@ -243,16 +243,16 @@ toCache Equations orig result = eqState $ do
     -- Check before inserting a new result to avoid creating a
     -- lookup chain e -> result -> olderResult.
     newEqCache <- case Map.lookup result s.cache.equations of
-            Nothing ->
-                pure $ Map.insert orig result s.cache.equations
-            Just furtherResult -> do
-                when (result /= furtherResult) $ do
-                    withContextFor Equations . logMessage $
-                        "toCache shortening a chain "
-                            <> showHashHex (getAttributes orig).hash
-                            <> "->"
-                            <> showHashHex (getAttributes furtherResult).hash
-                pure $ Map.insert orig furtherResult s.cache.equations
+        Nothing ->
+            pure $ Map.insert orig result s.cache.equations
+        Just furtherResult -> do
+            when (result /= furtherResult) $ do
+                withContextFor Equations . logMessage $
+                    "toCache shortening a chain "
+                        <> showHashHex (getAttributes orig).hash
+                        <> "->"
+                        <> showHashHex (getAttributes furtherResult).hash
+            pure $ Map.insert orig furtherResult s.cache.equations
     put s{cache = s.cache{equations = newEqCache}}
 
 fromCache :: LoggerMIO io => CacheTag -> Term -> EquationT io (Maybe Term)

--- a/booster/library/Booster/Pattern/Rewrite.hs
+++ b/booster/library/Booster/Pattern/Rewrite.hs
@@ -50,9 +50,9 @@ import Booster.Definition.Base
 import Booster.LLVM as LLVM (API)
 import Booster.Log
 import Booster.Pattern.ApplyEquations (
+    CacheTag (Equations),
     EquationFailure (..),
     SimplifierCache (..),
-    CacheTag (Equations),
     evaluatePattern,
     simplifyConstraint,
  )
@@ -407,7 +407,6 @@ applyRule pat@Pattern{ceilConditions} rule =
                         withContextFor Equations . logMessage $
                             ("New path condition ensured, invalidating cache" :: Text)
                         lift . RewriteT . lift . modify $ \s -> s{equations = mempty}
-
 
                     -- existential variables may be present in rule.rhs and rule.ensures,
                     -- need to strip prefixes and freshen their names with respect to variables already

--- a/booster/library/Booster/Pattern/Rewrite.hs
+++ b/booster/library/Booster/Pattern/Rewrite.hs
@@ -51,7 +51,8 @@ import Booster.LLVM as LLVM (API)
 import Booster.Log
 import Booster.Pattern.ApplyEquations (
     EquationFailure (..),
-    SimplifierCache,
+    SimplifierCache (..),
+    CacheTag (Equations),
     evaluatePattern,
     simplifyConstraint,
  )
@@ -400,6 +401,13 @@ applyRule pat@Pattern{ceilConditions} rule =
                             pure ()
                         Left other ->
                             liftIO $ Exception.throw other
+
+                    -- if a new constraint is going to be added, the equation cache is invalid
+                    unless (null newConstraints) $ do
+                        withContextFor Equations . logMessage $
+                            ("New path condition ensured, invalidating cache" :: Text)
+                        lift . RewriteT . lift . modify $ \s -> s{equations = mempty}
+
 
                     -- existential variables may be present in rule.rhs and rule.ensures,
                     -- need to strip prefixes and freshen their names with respect to variables already


### PR DESCRIPTION
### Fixes #3982

To avoid situations where the cache contains successive mappings `e -> e1 -> e2 -> e3 ... -> e_n` (a "lookup chain"), the following modifications are made:

1. When inserting `e -> e1`, first check whether `e1 -> e2` is in the cache, and insert `e -> e2` instead in this case.
2. When looking up `e` and a binding `e -> e1` is found, check whether a binding `e1 -> e2` is also in the cache.
   In this case, update the binding for `e` to `e -> e2` and return `e2`.

This will eventually lead to removing all lookup chains that may exist in a cache (for "interesting" cached values that are being looked up), without the risk of a loop.

Assume the following:
* the cache was initially empty;
* insertions and lookups are performed as described above;
* the cache contains a lookup chain `e -> e1 -> e2`.

If `e1 -> e2` was inserted first, insertion of `e -> e1` would have resulted in storing `e -> e2`. Therefore, `e -> e1` must have been inserted first.

A subsequent lookup of `e` will update the cache to contain `e -> e2`.

Insertion of `e -> e1`, then `e1 -> e2`, then `e2 -> e3`, will create the lookup chain `e -> e1 -> e2 -> e3`.

- A lookup of `e` would leave the cache containing two shorter chains `e -> e2 -> e3` and `e1 -> e2 -> e3`.
- A lookup of `e1` would also leave the cache containing one shorter chain `e -> e1 -> e3`, and `e2 -> e3`.

Every lookup potentially shortens a lookup chain, possibly to several chains.

### Fixes #3993 

When a new path condition is added (from an `ensures` clause), the `Equations` cache is purged. While some entries may still be valid, 
* all entries `t -> t` (no simplification possible) may be invalid because new equations might be applicable with the new path condition
* even entries `t -> t'` with `t /= t'` may be invalid because while they already memoise some applicable simplifications, they may store sub-terms that could now be evaluated or simplified  further (new equations may apply)