### PR TITLE
Remove references to my contact details from repo

### DIFF
--- a/package/debian/changelog
+++ b/package/debian/changelog
@@ -2,4 +2,4 @@ k-haskell-backend (0.1.0) unstable; urgency=medium
 
   * Initial release
 
- -- Bruce Collie <bruce.collie@runtimeverification.com>  Fri, 26 Apr 2024 15:43:00 +0100
+ -- Georgy Lukyanov <georgy.lukyanov@runtimeverification.com>  Fri, 26 Apr 2024 15:43:00 +0100

--- a/package/debian/control.jammy
+++ b/package/debian/control.jammy
@@ -1,7 +1,7 @@
 Source: k-haskell-backend
 Section: devel
 Priority: optional
-Maintainer: Bruce Collie <bruce.collie@runtimeverification.com>
+Maintainer: Georgy Lukyanov <georgy.lukyanov@runtimeverification.com>
 Build-Depends: debhelper (>=10)
 Standards-Version: 3.9.6
 Homepage: https://github.com/runtimeverification/haskell-backend

--- a/package/debian/copyright
+++ b/package/debian/copyright
@@ -1,6 +1,6 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: k-haskell-backend
-Upstream-Contact: Bruce Collie <bruce.collie@runtimeverification.com>
+Upstream-Contact: Georgy Lukyanov <georgy.lukyanov@runtimeverification.com>
 Source: https://github.com/runtimeverification/haskell-backend
 
 Files: *


### PR DESCRIPTION
This PR removes any final references to my contact details from the LLVM backend repo, and assigns them to @geo2a  instead.