### PR TITLE
Actually use the solver when starting rewriting

### DIFF
--- a/booster/library/Booster/Pattern/Rewrite.hs
+++ b/booster/library/Booster/Pattern/Rewrite.hs
@@ -725,7 +725,7 @@ performRewrite ::
     io (Natural, Seq (RewriteTrace ()), RewriteResult Pattern)
 performRewrite doTracing def mLlvmLibrary mSolver mbMaxDepth cutLabels terminalLabels pat = do
     (rr, RewriteStepsState{counter, traces}) <-
-        flip runStateT rewriteStart $ doSteps False pat
+        flip runStateT (rewriteStart mSolver) $ doSteps False pat
     pure (counter, traces, rr)
   where
     logDepth = withContext CtxDepth . logMessage
@@ -925,11 +925,11 @@ data RewriteStepsState = RewriteStepsState
     , smtSolver :: Maybe SMT.SMTContext
     }
 
-rewriteStart :: RewriteStepsState
-rewriteStart =
+rewriteStart :: Maybe SMT.SMTContext -> RewriteStepsState
+rewriteStart mSolver =
     RewriteStepsState
         { counter = 0
         , traces = mempty
         , simplifierCache = mempty
-        , smtSolver = Nothing
+        , smtSolver = mSolver
         }


### PR DESCRIPTION
When processing an execute request, we start z3 in `JsonRpc.hs` and pass it to `performRewrite`. However, we then actually start rewriting without a solver. This PR makes sire the initial state in `performRewrite` actually is initialized with a solver.