### PR TITLE
Booster: Avoid var. names from input substitution when creating new ones

### DIFF
--- a/booster/library/Booster/JsonRpc.hs
+++ b/booster/library/Booster/JsonRpc.hs
@@ -60,6 +60,7 @@ import Booster.Pattern.Rewrite (
     performRewrite,
  )
 import Booster.Pattern.Util (
+    freeVariables,
     sortOfPattern,
     substituteInPredicate,
     substituteInTerm,
@@ -144,8 +145,11 @@ respond stateVar request =
                                     , constraints = Set.map (substituteInPredicate substitution) pat.constraints
                                     , ceilConditions = pat.ceilConditions
                                     }
-                            -- remember the variables used in the substitution
-                            substVars = Map.keysSet substitution
+                            -- remember all variables used in the substitutions
+                            substVars =
+                                Set.unions
+                                    [ Set.singleton v <> freeVariables e
+                                    | (v, e) <- Map.assocs substitution]
 
                         solver <- traverse (SMT.initSolver def) mSMTOptions
                         result <-

--- a/booster/library/Booster/JsonRpc.hs
+++ b/booster/library/Booster/JsonRpc.hs
@@ -144,10 +144,12 @@ respond stateVar request =
                                     , constraints = Set.map (substituteInPredicate substitution) pat.constraints
                                     , ceilConditions = pat.ceilConditions
                                     }
+                            -- remember the variables used in the substitution
+                            substVars = Map.keysSet substitution
 
                         solver <- traverse (SMT.initSolver def) mSMTOptions
                         result <-
-                            performRewrite doTracing def mLlvmLibrary solver mbDepth cutPoints terminals substPat
+                            performRewrite doTracing def mLlvmLibrary solver substVars mbDepth cutPoints terminals substPat
                         whenJust solver SMT.finaliseSolver
                         stop <- liftIO $ getTime Monotonic
                         let duration =

--- a/booster/test/rpc-integration/resources/questionmark-vars.k
+++ b/booster/test/rpc-integration/resources/questionmark-vars.k
@@ -1,6 +1,4 @@
 module QUESTIONMARK-VARS
-  imports K-EQUAL
-
   syntax State ::= "a"
                  | "b"
                  | ".State"

--- a/booster/test/rpc-integration/resources/questionmark-vars.k
+++ b/booster/test/rpc-integration/resources/questionmark-vars.k
@@ -1,4 +1,6 @@
 module QUESTIONMARK-VARS
+  imports K-EQUAL
+
   syntax State ::= "a"
                  | "b"
                  | ".State"

--- a/booster/test/rpc-integration/test-questionmark-vars/README.md
+++ b/booster/test/rpc-integration/test-questionmark-vars/README.md
@@ -92,3 +92,31 @@ transition rules that unconditionally introduce a fresh variable in the configur
    <a-state> ?X2          </a-state>
    <b-state> ?X1          </b-state>
 ```
+
+5) _ques-and-substitution_
+
+   If a substitution `X ==K b` is supplied, it will be applied before rewriting.
+   However, the variable `X` can still not be used because the substitution will also be returned in the result (for information).
+   Therefore, the newly created variable cannot be `X0`.
+
+   _Input:_
+
+```
+   <k> #setAStateSymbolic </k>
+   <a-state> ?X0      </a-state>
+   <b-state> ?X       </b-state>
+    #And
+   ?X ==K b #And ?X0 ==K ?X1 #And ?X2 ==K ?X3 // substitutions
+```
+
+   _Expected:_
+
+```
+   <k> .K                 </k>
+   <a-state> ?X0          </a-state>
+   <b-state> b            </b-state>
+    #And
+   ?X ==K b #And ?X0 ==K ?X1 #And ?X2 ==K ?X3 // substitutions
+    #And 
+   condition(?X3)
+```

--- a/booster/test/rpc-integration/test-questionmark-vars/README.md
+++ b/booster/test/rpc-integration/test-questionmark-vars/README.md
@@ -118,5 +118,5 @@ transition rules that unconditionally introduce a fresh variable in the configur
     #And
    ?X ==K b #And ?X0 ==K ?X1 #And ?X2 ==K ?X3 // substitutions
     #And 
-   condition(?X3)
+   condition(?X4)
 ```

--- a/booster/test/rpc-integration/test-questionmark-vars/README.md
+++ b/booster/test/rpc-integration/test-questionmark-vars/README.md
@@ -106,7 +106,7 @@ transition rules that unconditionally introduce a fresh variable in the configur
    <a-state> ?X0      </a-state>
    <b-state> ?X       </b-state>
     #And
-   ?X ==K b #And ?X0 ==K ?X1 #And ?X2 ==K ?X3 // substitutions
+   ?X #Equals b #And ?X0 #Equals ?X1 #And ?X2 #Equals ?X3 // substitutions
 ```
 
    _Expected:_
@@ -116,7 +116,7 @@ transition rules that unconditionally introduce a fresh variable in the configur
    <a-state> ?X0          </a-state>
    <b-state> b            </b-state>
     #And
-   ?X ==K b #And ?X0 ==K ?X1 #And ?X2 ==K ?X3 // substitutions
-    #And 
+   ?X #Equals b #And ?X0 #Equals ?X1 #And ?X2 #Equals ?X3 // substitutions
+    #And
    condition(?X4)
 ```

--- a/booster/test/rpc-integration/test-questionmark-vars/response-one-ques-substitution.booster-dev
+++ b/booster/test/rpc-integration/test-questionmark-vars/response-one-ques-substitution.booster-dev
@@ -1,0 +1,225 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "reason": "stuck",
+        "depth": 1,
+        "state": {
+            "term": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "App",
+                    "name": "Lbl'-LT-'generatedTop'-GT-'",
+                    "sorts": [],
+                    "args": [
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'k'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "App",
+                                    "name": "dotk",
+                                    "sorts": [],
+                                    "args": []
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'a-state'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "EVar",
+                                    "name": "Var'Ques'X4",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortState",
+                                        "args": []
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'b-state'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "App",
+                                    "name": "Lblb'Unds'QUESTIONMARK-VARS'Unds'State",
+                                    "sorts": [],
+                                    "args": []
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'generatedCounter'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "DV",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    },
+                                    "value": "0"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "substitution": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "And",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortGeneratedTopCell",
+                        "args": []
+                    },
+                    "patterns": [
+                        {
+                            "tag": "Equals",
+                            "argSort": {
+                                "tag": "SortApp",
+                                "name": "SortState",
+                                "args": []
+                            },
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortGeneratedTopCell",
+                                "args": []
+                            },
+                            "first": {
+                                "tag": "EVar",
+                                "name": "Var'Ques'X",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortState",
+                                    "args": []
+                                }
+                            },
+                            "second": {
+                                "tag": "App",
+                                "name": "Lblb'Unds'QUESTIONMARK-VARS'Unds'State",
+                                "sorts": [],
+                                "args": []
+                            }
+                        },
+                        {
+                            "tag": "Equals",
+                            "argSort": {
+                                "tag": "SortApp",
+                                "name": "SortState",
+                                "args": []
+                            },
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortGeneratedTopCell",
+                                "args": []
+                            },
+                            "first": {
+                                "tag": "EVar",
+                                "name": "Var'Ques'X0",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortState",
+                                    "args": []
+                                }
+                            },
+                            "second": {
+                                "tag": "EVar",
+                                "name": "Var'Ques'X1",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortState",
+                                    "args": []
+                                }
+                            }
+                        },
+                        {
+                            "tag": "Equals",
+                            "argSort": {
+                                "tag": "SortApp",
+                                "name": "SortState",
+                                "args": []
+                            },
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortGeneratedTopCell",
+                                "args": []
+                            },
+                            "first": {
+                                "tag": "EVar",
+                                "name": "Var'Ques'X2",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortState",
+                                    "args": []
+                                }
+                            },
+                            "second": {
+                                "tag": "EVar",
+                                "name": "Var'Ques'X3",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortState",
+                                    "args": []
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "predicate": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "Equals",
+                    "argSort": {
+                        "tag": "SortApp",
+                        "name": "SortBool",
+                        "args": []
+                    },
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortGeneratedTopCell",
+                        "args": []
+                    },
+                    "first": {
+                        "tag": "DV",
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortBool",
+                            "args": []
+                        },
+                        "value": "true"
+                    },
+                    "second": {
+                        "tag": "App",
+                        "name": "Lblcondition'LParUndsRParUnds'QUESTIONMARK-VARS'Unds'Bool'Unds'State",
+                        "sorts": [],
+                        "args": [
+                            {
+                                "tag": "EVar",
+                                "name": "Var'Ques'X4",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortState",
+                                    "args": []
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/booster/test/rpc-integration/test-questionmark-vars/response-one-ques-substitution.json
+++ b/booster/test/rpc-integration/test-questionmark-vars/response-one-ques-substitution.json
@@ -1,0 +1,235 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "reason": "stuck",
+        "depth": 1,
+        "state": {
+            "term": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "App",
+                    "name": "Lbl'-LT-'generatedTop'-GT-'",
+                    "sorts": [],
+                    "args": [
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'k'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "App",
+                                    "name": "dotk",
+                                    "sorts": [],
+                                    "args": []
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'a-state'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "EVar",
+                                    "name": "Var'Ques'X4",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortState",
+                                        "args": []
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'b-state'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "App",
+                                    "name": "Lblb'Unds'QUESTIONMARK-VARS'Unds'State",
+                                    "sorts": [],
+                                    "args": []
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'generatedCounter'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "DV",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    },
+                                    "value": "0"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "substitution": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "And",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortGeneratedTopCell",
+                        "args": []
+                    },
+                    "patterns": [
+                        {
+                            "tag": "And",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortGeneratedTopCell",
+                                "args": []
+                            },
+                            "patterns": [
+                                {
+                                    "tag": "Equals",
+                                    "argSort": {
+                                        "tag": "SortApp",
+                                        "name": "SortState",
+                                        "args": []
+                                    },
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortGeneratedTopCell",
+                                        "args": []
+                                    },
+                                    "first": {
+                                        "tag": "EVar",
+                                        "name": "Var'Ques'X",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortState",
+                                            "args": []
+                                        }
+                                    },
+                                    "second": {
+                                        "tag": "App",
+                                        "name": "Lblb'Unds'QUESTIONMARK-VARS'Unds'State",
+                                        "sorts": [],
+                                        "args": []
+                                    }
+                                },
+                                {
+                                    "tag": "Equals",
+                                    "argSort": {
+                                        "tag": "SortApp",
+                                        "name": "SortState",
+                                        "args": []
+                                    },
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortGeneratedTopCell",
+                                        "args": []
+                                    },
+                                    "first": {
+                                        "tag": "EVar",
+                                        "name": "Var'Ques'X0",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortState",
+                                            "args": []
+                                        }
+                                    },
+                                    "second": {
+                                        "tag": "EVar",
+                                        "name": "Var'Ques'X1",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortState",
+                                            "args": []
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "Equals",
+                            "argSort": {
+                                "tag": "SortApp",
+                                "name": "SortState",
+                                "args": []
+                            },
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortGeneratedTopCell",
+                                "args": []
+                            },
+                            "first": {
+                                "tag": "EVar",
+                                "name": "Var'Ques'X2",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortState",
+                                    "args": []
+                                }
+                            },
+                            "second": {
+                                "tag": "EVar",
+                                "name": "Var'Ques'X3",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortState",
+                                    "args": []
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "predicate": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "Equals",
+                    "argSort": {
+                        "tag": "SortApp",
+                        "name": "SortBool",
+                        "args": []
+                    },
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortGeneratedTopCell",
+                        "args": []
+                    },
+                    "first": {
+                        "tag": "DV",
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortBool",
+                            "args": []
+                        },
+                        "value": "true"
+                    },
+                    "second": {
+                        "tag": "App",
+                        "name": "Lblcondition'LParUndsRParUnds'QUESTIONMARK-VARS'Unds'Bool'Unds'State",
+                        "sorts": [],
+                        "args": [
+                            {
+                                "tag": "EVar",
+                                "name": "Var'Ques'X4",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortState",
+                                    "args": []
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/booster/test/rpc-integration/test-questionmark-vars/state-one-ques-substitution.execute
+++ b/booster/test/rpc-integration/test-questionmark-vars/state-one-ques-substitution.execute
@@ -1,0 +1,185 @@
+{
+    "format": "KORE",
+    "version": 1,
+    "term": {
+        "tag": "And",
+        "sort": {
+            "tag": "SortApp",
+            "name": "SortGeneratedTopCell",
+            "args": []
+        },
+        "patterns": [
+            {
+                "tag": "App",
+                "name": "Lbl'-LT-'generatedTop'-GT-'",
+                "sorts": [],
+                "args": [
+                    {
+                        "tag": "App",
+                        "name": "Lbl'-LT-'k'-GT-'",
+                        "sorts": [],
+                        "args": [
+                            {
+                                "tag": "App",
+                                "name": "kseq",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "args": [],
+                                        "name": "Lbl'Hash'setAStateSymbolic'Unds'QUESTIONMARK-VARS'Unds'KItem",
+                                        "sorts": [],
+                                        "tag": "App"
+                                    },
+                                    {
+                                        "args": [],
+                                        "name": "dotk",
+                                        "sorts": [],
+                                        "tag": "App"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "tag": "App",
+                        "name": "Lbl'-LT-'a-state'-GT-'",
+                        "sorts": [],
+                        "args": [
+                            {
+                                "tag": "EVar",
+                                "name": "Var'Ques'X0",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortState",
+                                    "args": []
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "tag": "App",
+                        "name": "Lbl'-LT-'b-state'-GT-'",
+                        "sorts": [],
+                        "args": [
+                            {
+                                "tag": "EVar",
+                                "name": "Var'Ques'X",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortState",
+                                    "args": []
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "tag": "App",
+                        "name": "Lbl'-LT-'generatedCounter'-GT-'",
+                        "sorts": [],
+                        "args": [
+                            {
+                                "tag": "DV",
+                                "sort": {
+                                    "args": [],
+                                    "name": "SortInt",
+                                    "tag": "SortApp"
+                                },
+                                "value": "0"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "tag": "Equals",
+                "sort": {
+                    "tag": "SortApp",
+                    "name": "SortGeneratedTopCell",
+                    "args": []
+                },
+                "argSort": {
+                    "tag": "SortApp",
+                    "name": "SortState",
+                    "args": []
+                },
+                "first": {
+                    "tag": "EVar",
+                    "name": "Var'Ques'X",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortState",
+                        "args": []
+                    }
+                },
+                "second": {
+                    "tag": "App",
+                    "name": "Lblb'Unds'QUESTIONMARK-VARS'Unds'State",
+                    "sorts": [],
+                    "args": []
+                }
+            },
+            {
+                "tag": "Equals",
+                "sort": {
+                    "tag": "SortApp",
+                    "name": "SortGeneratedTopCell",
+                    "args": []
+                },
+                "argSort": {
+                    "tag": "SortApp",
+                    "name": "SortState",
+                    "args": []
+                },
+                "first": {
+                    "tag": "EVar",
+                    "name": "Var'Ques'X0",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortState",
+                        "args": []
+                    }
+                },
+                "second": {
+                    "tag": "EVar",
+                    "name": "Var'Ques'X1",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortState",
+                        "args": []
+                    }
+                }
+            },
+            {
+                "tag": "Equals",
+                "sort": {
+                    "tag": "SortApp",
+                    "name": "SortGeneratedTopCell",
+                    "args": []
+                },
+                "argSort": {
+                    "tag": "SortApp",
+                    "name": "SortState",
+                    "args": []
+                },
+                "first": {
+                    "tag": "EVar",
+                    "name": "Var'Ques'X2",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortState",
+                        "args": []
+                    }
+                },
+                "second": {
+                    "tag": "EVar",
+                    "name": "Var'Ques'X3",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortState",
+                        "args": []
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/booster/unit-tests/Test/Booster/Pattern/Rewrite.hs
+++ b/booster/unit-tests/Test/Booster/Pattern/Rewrite.hs
@@ -245,7 +245,7 @@ runWith t =
     second fst $
         unsafePerformIO
             ( runNoLoggingT $
-                runRewriteT NoCollectRewriteTraces def Nothing Nothing mempty (rewriteStep [] [] $ Pattern_ t)
+                runRewriteT NoCollectRewriteTraces def Nothing Nothing mempty mempty (rewriteStep [] [] $ Pattern_ t)
             )
 
 rewritesTo :: Term -> (Text, Term) -> IO ()
@@ -272,7 +272,7 @@ failsWith t err =
 runRewrite :: Term -> IO (Natural, RewriteResult Term)
 runRewrite t = do
     (counter, _, res) <-
-        runNoLoggingT $ performRewrite NoCollectRewriteTraces def Nothing Nothing Nothing [] [] $ Pattern_ t
+        runNoLoggingT $ performRewrite NoCollectRewriteTraces def Nothing Nothing mempty Nothing [] [] $ Pattern_ t
     pure (counter, fmap (.term) res)
 
 aborts :: RewriteFailed "Rewrite" -> Term -> IO ()
@@ -415,7 +415,7 @@ supportsDepthControl =
     rewritesToDepth (MaxDepth depth) (Steps n) t t' f = do
         (counter, _, res) <-
             runNoLoggingT $
-                performRewrite NoCollectRewriteTraces def Nothing Nothing (Just depth) [] [] $
+                performRewrite NoCollectRewriteTraces def Nothing Nothing mempty (Just depth) [] [] $
                     Pattern_ t
         (counter, fmap (.term) res) @?= (n, f t')
 
@@ -469,7 +469,7 @@ supportsCutPoints =
     rewritesToCutPoint lbl (Steps n) t t' f = do
         (counter, _, res) <-
             runNoLoggingT $
-                performRewrite NoCollectRewriteTraces def Nothing Nothing Nothing [lbl] [] $
+                performRewrite NoCollectRewriteTraces def Nothing Nothing mempty Nothing [lbl] [] $
                     Pattern_ t
         (counter, fmap (.term) res) @?= (n, f t')
 
@@ -501,5 +501,5 @@ supportsTerminalRules =
     rewritesToTerminal lbl (Steps n) t t' f = do
         (counter, _, res) <-
             runNoLoggingT $ do
-                performRewrite NoCollectRewriteTraces def Nothing Nothing Nothing [] [lbl] $ Pattern_ t
+                performRewrite NoCollectRewriteTraces def Nothing Nothing mempty Nothing [] [lbl] $ Pattern_ t
         (counter, fmap (.term) res) @?= (n, f t')


### PR DESCRIPTION
When rewriting with rules that have existentials on the RHS, booster needs to rename these existential variables to avoid collisions.

However, the input is pre-processed to recognise predicates of the form `X ==K expr` and apply them (after checking/vetting) as a _substitution_ to the configuration and (other) path conditions.

As a result, the variable names in the substitution are not present in the pattern any more when rewriting. The substitution is added back (as additional information) in the output, so subsequent simplification steps will apply it again, falsely, if variable names from the substitution are reused during rewriting.

As a solution, we supply the "forbidden variable names" to the rewriter. Alternatively, we could stop including the applied substitution in the output, but this would create a disparity between `booster` and `kore-rpc`.

Fixes #4006
