### PR TITLE
Allow matching functions when rewriting

### DIFF
--- a/booster/library/Booster/Pattern/Match.hs
+++ b/booster/library/Booster/Pattern/Match.hs
@@ -294,6 +294,7 @@ match1 _       t1@FunctionApplication{}                   t2@KSet{}             
 match1 Eval    (FunctionApplication symbol1 sorts1 args1) (ConsApplication symbol2 sorts2 args2)     = matchSymbolAplications Eval symbol1 sorts1 args1 symbol2 sorts2 args2
 match1 _       t1@FunctionApplication{}                   t2@ConsApplication{}                       = addIndeterminate t1 t2
 match1 Eval    (FunctionApplication symbol1 sorts1 args1) (FunctionApplication symbol2 sorts2 args2) = matchSymbolAplications Eval symbol1 sorts1 args1 symbol2 sorts2 args2
+match1 Rewrite (FunctionApplication symbol1 sorts1 args1) (FunctionApplication symbol2 sorts2 args2) = matchSymbolAplications Rewrite symbol1 sorts1 args1 symbol2 sorts2 args2
 match1 _       t1@FunctionApplication{}                   t2@FunctionApplication{}                   = addIndeterminate t1 t2
 match1 Rewrite t1@FunctionApplication{}                   (Var t2)                                   = failWith $ SubjectVariableMatch t1 t2
 match1 _       t1@FunctionApplication{}                   t2@Var{}                                   = addIndeterminate t1 t2


### PR DESCRIPTION
This is an experiment to support CSE rules that, when matched on `master`, leave matching remainders as follows:

```
_+Bytes__BYTES-HOOKED_Bytes_Bytes_Bytes(
  "#\184r\221",
  _+Bytes__BYTES-HOOKED_Bytes_Bytes_Bytes(
    buf("32", Rule#VarVV0_from_114b9705:SortInt{}),
    _+Bytes__BYTES-HOOKED_Bytes_Bytes_Bytes(
      buf("32", Rule#VarVV1_to_114b9705:SortInt{}),
      buf("32", Rule#VarVV2_value_114b9705:SortInt{}))))

 ==

_+Bytes__BYTES-HOOKED_Bytes_Bytes_Bytes(
  "#\184r\221",
  _+Bytes__BYTES-HOOKED_Bytes_Bytes_Bytes(
    buf("32", VarCALLER_ID:SortInt{}),
    _+Bytes__BYTES-HOOKED_Bytes_Bytes_Bytes(
      buf("32", VarCONTRACT_ID:SortInt{}),
      buf("32", VarVV0_amount_114b9705:SortInt{}))))
```

these expressions are the same modulo variable renaming.
