### PR TITLE
Allow matching empty sets

### DIFF
--- a/booster/library/Booster/Pattern/Match.hs
+++ b/booster/library/Booster/Pattern/Match.hs
@@ -25,6 +25,7 @@ import Data.List (partition)
 import Data.List.NonEmpty as NE (NonEmpty, fromList)
 import Data.Map (Map)
 import Data.Map qualified as Map
+import Data.Maybe (isNothing)
 import Data.Sequence (Seq, (><), pattern (:<|), pattern (:|>))
 import Data.Sequence qualified as Seq
 
@@ -32,7 +33,7 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 import Prettyprinter
 
-import Booster.Definition.Attributes.Base (KListDefinition, KMapDefinition)
+import Booster.Definition.Attributes.Base (KListDefinition, KMapDefinition, KSetDefinition)
 import Booster.Definition.Base
 import Booster.Pattern.Base
 import Booster.Pattern.Pretty
@@ -262,7 +263,7 @@ match1 Eval    t1@KSet{}                                  t2@Injection{}        
 match1 _       t1@KSet{}                                  t2@Injection{}                             = failWith $ DifferentSymbols t1 t2
 match1 _       t1@KSet{}                                  t2@KMap{}                                  = failWith $ DifferentSymbols t1 t2
 match1 _       t1@KSet{}                                  t2@KList{}                                 = failWith $ DifferentSymbols t1 t2
-match1 _       t1@KSet{}                                  t2@KSet{}                                  = addIndeterminate t1 t2
+match1 _       t1@(KSet def1 patElements patRest)         t2@(KSet def2 subjElements subjRest)       = if def1 == def2 then matchSets def1 patElements patRest subjElements subjRest else failWith $ DifferentSorts t1 t2
 match1 _       t1@KSet{}                                  t2@ConsApplication{}                       = failWith $ DifferentSymbols t1 t2
 match1 _       t1@KSet{}                                  t2@FunctionApplication{}                   = addIndeterminate t1 t2
 match1 Rewrite t1@KSet{}                                  (Var t2)                                   = failWith $ SubjectVariableMatch t1 t2
@@ -625,6 +626,25 @@ containsOtherKeys = \case
     ConstructorKey _ _ rest -> containsOtherKeys rest
     Rest OtherKey{} -> True
     Rest _ -> False
+
+------ Internalised Sets
+matchSets ::
+    KSetDefinition ->
+    [Term] ->
+    Maybe Term ->
+    [Term] ->
+    Maybe Term ->
+    StateT MatchState (Except MatchResult) ()
+matchSets
+    def
+    patElements
+    patRest
+    subjElements
+    subjRest = do
+        -- match only empty sets, indeterminate otherwise
+        if null patElements && null subjElements && isNothing patRest && isNothing subjRest
+            then pure ()
+            else addIndeterminate (KSet def patElements patRest) (KSet def subjElements subjRest)
 
 ------ Internalised Maps
 matchMaps ::

--- a/booster/unit-tests/Test/Booster/Pattern/InternalCollections.hs
+++ b/booster/unit-tests/Test/Booster/Pattern/InternalCollections.hs
@@ -11,6 +11,7 @@ module Test.Booster.Pattern.InternalCollections (
     headList,
     tailList,
     mixedList,
+    emptySet,
 ) where
 
 import Data.ByteString.Char8 qualified as BS

--- a/booster/unit-tests/Test/Booster/Pattern/MatchEval.hs
+++ b/booster/unit-tests/Test/Booster/Pattern/MatchEval.hs
@@ -17,6 +17,7 @@ import Booster.Pattern.Base
 import Booster.Pattern.Match
 import Booster.Syntax.Json.Internalise (trm)
 import Test.Booster.Fixture
+import Test.Booster.Pattern.InternalCollections
 
 test_match_eval :: TestTree
 test_match_eval =
@@ -28,6 +29,7 @@ test_match_eval =
         , andTerms
         , composite
         , kmapTerms
+        , internalSets
         ]
 
 symbols :: TestTree
@@ -292,6 +294,19 @@ cornerCases :: TestTree
 cornerCases =
     let v = var "X" someSort
      in errors "identical variables" v v
+
+internalSets :: TestTree
+internalSets =
+    testGroup
+        "Internal sets"
+        [ test
+            "Can match an empty set with itself"
+            emptySet
+            emptySet
+            (success [])
+        ]
+
+----------------------------------------
 
 test :: String -> Term -> Term -> MatchResult -> TestTree
 test name pat subj expected =

--- a/booster/unit-tests/Test/Booster/Pattern/MatchImplies.hs
+++ b/booster/unit-tests/Test/Booster/Pattern/MatchImplies.hs
@@ -32,6 +32,7 @@ test_match_implies =
         , sorts
         , injections
         , internalLists
+        , internalSets
         , internalMaps
         ]
 
@@ -376,6 +377,17 @@ internalLists =
     lastElem = [trm| \dv{SomeSort{}}("last") |]
 
     klist = KList testKListDef
+
+internalSets :: TestTree
+internalSets =
+    testGroup
+        "Internal sets"
+        [ test
+            "Can match an empty set with itself"
+            emptySet
+            emptySet
+            (success [])
+        ]
 
 internalMaps :: TestTree
 internalMaps =

--- a/booster/unit-tests/Test/Booster/Pattern/MatchRewrite.hs
+++ b/booster/unit-tests/Test/Booster/Pattern/MatchRewrite.hs
@@ -32,6 +32,7 @@ test_match_rewrite =
         , sorts
         , injections
         , internalLists
+        , internalSets
         , internalMaps
         ]
 
@@ -375,6 +376,17 @@ internalLists =
     lastElem = [trm| \dv{SomeSort{}}("last") |]
 
     klist = KList testKListDef
+
+internalSets :: TestTree
+internalSets =
+    testGroup
+        "Internal sets"
+        [ test
+            "Can match an empty set with itself"
+            emptySet
+            emptySet
+            (success [])
+        ]
 
 internalMaps :: TestTree
 internalMaps =


### PR DESCRIPTION
This PR adds rudimentary matching of internalized sets: only empty sets are allowed to match, and an indeterminate result is returned for non-empty sets.