### PR TITLE
Add `--dry-run` mode for `kore-rpc-client run-tarball`

### DIFF
--- a/kore-rpc-types/src/Kore/JsonRpc/Types.hs
+++ b/kore-rpc-types/src/Kore/JsonRpc/Types.hs
@@ -130,6 +130,17 @@ data HaltReason
         (FromJSON, ToJSON)
         via CustomJSON '[OmitNothingFields, ConstructorTagModifier '[CamelToKebab]] HaltReason
 
+instance Pretty.Pretty HaltReason where
+    pretty = \case
+        Branching -> "branching"
+        Stuck -> "stuck"
+        Vacuous -> "vacuous"
+        DepthBound -> "depth-bound"
+        CutPointRule -> "cut-point-rule"
+        TerminalRule -> "terminal-rule"
+        Aborted -> "aborted"
+        Timeout -> "timeout"
+
 data ExecuteResult = ExecuteResult
     { reason :: HaltReason
     , depth :: Depth
@@ -258,6 +269,14 @@ instance Pretty.Pretty (API 'Req) where
         AddModule _ -> "add-module"
         GetModel _ -> "get-model"
         Cancel -> "cancel"
+
+instance Pretty.Pretty (API 'Res) where
+    pretty = \case
+        Execute (ExecuteResult{reason, depth}) -> "execute" Pretty.<+> Pretty.pretty reason Pretty.<+> Pretty.pretty depth
+        Implies _ -> "implies"
+        Simplify _ -> "simplify"
+        AddModule _ -> "add-module"
+        GetModel _ -> "get-model"
 
 rpcJsonConfig :: PrettyJson.Config
 rpcJsonConfig =

--- a/kore-rpc-types/src/Kore/JsonRpc/Types/Depth.hs
+++ b/kore-rpc-types/src/Kore/JsonRpc/Types/Depth.hs
@@ -2,7 +2,8 @@ module Kore.JsonRpc.Types.Depth (module Kore.JsonRpc.Types.Depth) where
 
 import Data.Aeson.Types (FromJSON (..), ToJSON (..))
 import Numeric.Natural
+import Prettyprinter qualified as Pretty
 
 newtype Depth = Depth {getNat :: Natural}
     deriving stock (Show, Eq)
-    deriving newtype (FromJSON, ToJSON, Num)
+    deriving newtype (FromJSON, ToJSON, Num, Pretty.Pretty)


### PR DESCRIPTION
This is useful when triaging bug reports. Example output:
```
$(cabal -O0 exec which kore-rpc-client) --dry-run run-tarball ~/org/rv/lido-fv/EscrowLockUnlockTest.testLockStEth/report.tar
[Info] unpacking json files from tarball /home/geo2a/org/rv/lido-fv/EscrowLockUnlockTest.testLockStEth/report.tar into /tmp/extra-dir-34574320739964
[Info] test%kontrol%EscrowLockUnlockTest.setUp():3/140098541805216/140098541805456-001, simplify, simplify
[Info] test%kontrol%EscrowLockUnlockTest.setUp():3/140098541805216/140098541805456-002, simplify, simplify
[Info] test%kontrol%EscrowLockUnlockTest.setUp():3/140098541805216/140098541805456-003, simplify, simplify
[Info] test%kontrol%EscrowLockUnlockTest.setUp():3/140098541805216/140098541805456-004, simplify, simplify
[Info] test%kontrol%EscrowLockUnlockTest.setUp():3/140098273255120/140098633989184-001, add-module, add-module
[Info] test%kontrol%EscrowLockUnlockTest.setUp():3/140098273255120/140098633989184-002, add-module, add-module
[Info] test%kontrol%EscrowLockUnlockTest.setUp():3/140098282190880/140098282178976-001, execute, execute terminal-rule 954
[Info] test%kontrol%EscrowLockUnlockTest.setUp():3/140098282190880/140098282178976-002, execute, execute terminal-rule 3390
[Info] test%kontrol%EscrowLockUnlockTest.setUp():3/140098282190880/140098282178976-003, execute, execute terminal-rule 330
```