### PR TITLE
Adjusting default timeout

### DIFF
--- a/booster/library/Booster/SMT/Interface.hs
+++ b/booster/library/Booster/SMT/Interface.hs
@@ -157,14 +157,12 @@ translatePrelude def =
 
 checkPrelude :: Log.LoggerMIO io => SMT io ()
 checkPrelude = do
-    -- set large default timeout value for checking the prelude
-    setTimeout defaultSMTOptions.timeout
+    -- set solver timeout
+    setTimeout ctxt.options.timeout
     Log.logMessage ("Checking definition prelude" :: Text)
     ctxt <- SMT get
     -- send the commands from the definition's SMT prelude
     check <- mapM_ runCmd ctxt.prelude >> runCmd CheckSat
-    -- set user defined timeout value for the general queries
-    setTimeout ctxt.options.timeout
     case check of
         Sat -> pure ()
         other -> do

--- a/booster/library/Booster/SMT/Interface.hs
+++ b/booster/library/Booster/SMT/Interface.hs
@@ -157,10 +157,10 @@ translatePrelude def =
 
 checkPrelude :: Log.LoggerMIO io => SMT io ()
 checkPrelude = do
-    -- set solver timeout
-    setTimeout ctxt.options.timeout
     Log.logMessage ("Checking definition prelude" :: Text)
     ctxt <- SMT get
+    -- set solver timeout
+    setTimeout ctxt.options.timeout
     -- send the commands from the definition's SMT prelude
     check <- mapM_ runCmd ctxt.prelude >> runCmd CheckSat
     case check of

--- a/booster/library/Booster/SMT/Interface.hs
+++ b/booster/library/Booster/SMT/Interface.hs
@@ -157,12 +157,14 @@ translatePrelude def =
 
 checkPrelude :: Log.LoggerMIO io => SMT io ()
 checkPrelude = do
+    -- set large default timeout value for checking the prelude
+    setTimeout defaultSMTOptions.timeout
     Log.logMessage ("Checking definition prelude" :: Text)
     ctxt <- SMT get
-    -- set solver timeout
-    setTimeout ctxt.options.timeout
     -- send the commands from the definition's SMT prelude
     check <- mapM_ runCmd ctxt.prelude >> runCmd CheckSat
+    -- set user defined timeout value for the general queries
+    setTimeout ctxt.options.timeout
     case check of
         Sat -> pure ()
         other -> do

--- a/booster/library/Booster/SMT/Runner.hs
+++ b/booster/library/Booster/SMT/Runner.hs
@@ -68,7 +68,7 @@ defaultSMTOptions :: SMTOptions
 defaultSMTOptions =
     SMTOptions
         { transcript = Nothing
-        , timeout = 125
+        , timeout = 300000
         , retryLimit = Just 3
         , tactic = Nothing
         , args = []


### PR DESCRIPTION
The PR sets the default timout to a large value, which is consistent with the requirements of Kontrol engagement proofs.