### PR TITLE
Set user supplied value when checking the SMT prelude in booster

### DIFF
--- a/booster/library/Booster/SMT/Interface.hs
+++ b/booster/library/Booster/SMT/Interface.hs
@@ -157,10 +157,10 @@ translatePrelude def =
 
 checkPrelude :: Log.LoggerMIO io => SMT io ()
 checkPrelude = do
+    ctxt <- SMT get
     -- set the user defined timeout for queries
     setTimeout ctxt.options.timeout
     Log.logMessage ("Checking definition prelude" :: Text)
-    ctxt <- SMT get
     -- send the commands from the definition's SMT prelude
     check <- mapM_ runCmd ctxt.prelude >> runCmd CheckSat
     case check of

--- a/booster/library/Booster/SMT/Interface.hs
+++ b/booster/library/Booster/SMT/Interface.hs
@@ -157,14 +157,12 @@ translatePrelude def =
 
 checkPrelude :: Log.LoggerMIO io => SMT io ()
 checkPrelude = do
-    -- set large default timeout value for checking the prelude
-    setTimeout defaultSMTOptions.timeout
+    -- set the user defined timeout for queries
+    setTimeout ctxt.options.timeout
     Log.logMessage ("Checking definition prelude" :: Text)
     ctxt <- SMT get
     -- send the commands from the definition's SMT prelude
     check <- mapM_ runCmd ctxt.prelude >> runCmd CheckSat
-    -- set user defined timeout value for the general queries
-    setTimeout ctxt.options.timeout
     case check of
         Sat -> pure ()
         other -> do


### PR DESCRIPTION
Followup to #4017 addressing a potential issue I noticed whilst refactoring the SMT interface in booster. Namely, we set the hard-coded timeout value when checking the consistency of the prelude, before setting the user supplied value for general queries. This PR instead just sets the user supplied timeout value before checking the prelude.