### PR TITLE
Remove support for antiLeft rules and aliases

### DIFF
--- a/booster/library/Booster/Definition/Base.hs
+++ b/booster/library/Booster/Definition/Base.hs
@@ -43,7 +43,6 @@ data KoreDefinition = KoreDefinition
     , modules :: Map ByteString ModuleAttributes
     , sorts :: Map SortName (SortAttributes, Set SortName)
     , symbols :: Map SymbolName Symbol -- constructors and functions
-    , aliases :: Map AliasName Alias
     , rewriteTheory :: Theory (RewriteRule "Rewrite")
     , functionEquations :: Theory (RewriteRule "Function")
     , simplifications :: Theory (RewriteRule "Simplification")
@@ -63,7 +62,6 @@ emptyKoreDefinition attributes =
         , modules = Map.empty
         , sorts = Map.empty
         , symbols = Map.empty
-        , aliases = Map.empty
         , rewriteTheory = Map.empty
         , functionEquations = Map.empty
         , simplifications = Map.empty
@@ -76,17 +74,6 @@ data RewriteRule (tag :: k) = RewriteRule
     , attributes :: AxiomAttributes
     , computedAttributes :: ComputedAxiomAttributes
     , existentials :: Set Variable
-    }
-    deriving stock (Eq, Ord, Show, GHC.Generic)
-    deriving anyclass (NFData)
-
-type AliasName = ByteString
-
-data Alias = Alias
-    { name :: AliasName
-    , params :: [Sort]
-    , args :: [Variable]
-    , rhs :: Term
     }
     deriving stock (Eq, Ord, Show, GHC.Generic)
     deriving anyclass (NFData)

--- a/booster/test/llvm-integration/LLVM.hs
+++ b/booster/test/llvm-integration/LLVM.hs
@@ -316,7 +316,6 @@ testDef =
         Map.empty -- no modules (HACK)
         defSorts
         defSymbols
-        Map.empty -- no aliases
         Map.empty -- no rules
         Map.empty -- no function equations
         Map.empty -- no simplifications
@@ -334,7 +333,6 @@ displayTestDef = do
         prunedDef =
             def
                 { modules = Map.empty
-                , aliases = Map.empty
                 , functionEquations = Map.empty
                 , simplifications = Map.empty
                 }

--- a/booster/unit-tests/Test/Booster/Fixture.hs
+++ b/booster/unit-tests/Test/Booster/Fixture.hs
@@ -63,7 +63,6 @@ testDefinition =
                 ]
                 <> listSymbols
                 <> setSymbols
-        , aliases = Map.empty
         , rewriteTheory = Map.empty
         , functionEquations = Map.empty
         , simplifications = Map.empty


### PR DESCRIPTION
Follow up to #4028, which further cleans up the code-base by removing internalisation of anti-left rules, as these are:
a) unused for over a year now (since #3391)
b) the previous PR essentially left the inernalisation of anti-left broken, but we wanted to remove it fully in a separate PR for ease of review.