### PR TITLE
Only markSimplified when we are sure the predicate is in fact simplified

### DIFF
--- a/kore/src/Kore/Simplify/Not.hs
+++ b/kore/src/Kore/Simplify/Not.hs
@@ -149,7 +149,7 @@ makeEvaluatePredicate
         Conditional
             { term = ()
             , predicate =
-                Predicate.markSimplified $
+                (if Predicate.isSimplifiedAnyCondition predicate then Predicate.markSimplified else id) $
                     makeNotPredicate $
                         makeAndPredicate predicate $
                             Substitution.toPredicate substitution

--- a/test/map-symbolic/lookup-14-spec.k.out.golden
+++ b/test/map-symbolic/lookup-14-spec.k.out.golden
@@ -23,8 +23,8 @@
   {
     true
   #Equals
-    Z:MyId in_keys ( ( MAP
-    X:MyId |-> 1 ) [ Y:MyId <- 2 ] )
+    Z:MyId in_keys ( MAP
+    ( X:MyId |-> 1 ) )
   }
 #And
   {

--- a/test/map-symbolic/lookup-3-spec.k.out.golden
+++ b/test/map-symbolic/lookup-3-spec.k.out.golden
@@ -18,7 +18,7 @@
     true
   #Equals
     Z:MyId in_keys ( MAP
-    ( Y:MyId |-> 2 ) )
+    ( Y:MyId |-> 1 ) )
   }
 #And
   {


### PR DESCRIPTION
Kore is currently is crashing for @bbyalcinkaya in komet, with:

```
CallStack (from HasCallStack):
  error, called at src/Kore/Internal/Predicate.hs:1091:5 in kore-0.1.76-9jTVMLO4n9YCl9sOQx8AFb:Kore.Internal.Predicate
  cannotSimplifyNotSimplifiedError, called at src/Kore/Internal/Predicate.hs:1120:36 in kore-0.1.76-9jTVMLO4n9YCl9sOQx8AFb:Kore.Internal.Predicate
  checkedSimplifiedFromChildren, called at src/Kore/Internal/Predicate.hs:1130:14 in kore-0.1.76-9jTVMLO4n9YCl9sOQx8AFb:Kore.Internal.Predicate
  markSimplified, called at src/Kore/Simplify/Not.hs:152:17 in kore-0.1.76-9jTVMLO4n9YCl9sOQx8AFb:Kore.Simplify.Not","error":"Unexpectedly marking term with NotSimplified children as simplified:
...
```