### PR TITLE
Fix handling of logging contextx in `booster-dev`

### DIFF
--- a/booster/library/Booster/CLOptions.hs
+++ b/booster/library/Booster/CLOptions.hs
@@ -66,7 +66,7 @@ data LogFormat
     = Standard
     | OneLine
     | Json
-    deriving (Eq)
+    deriving (Eq, Enum)
 
 instance Show LogFormat where
     show = \case
@@ -155,7 +155,10 @@ parseLogOptions =
             ( metavar "LOGFORMAT"
                 <> value OneLine
                 <> long "log-format"
-                <> help "Format to output logs in"
+                <> help
+                    ( "Format to output logs in. Available formats: "
+                        <> intercalate ", " (map show $ enumFrom (toEnum @LogFormat 0))
+                    )
                 <> showDefault
             )
         <*> many

--- a/dev-tools/booster-dev/Server.hs
+++ b/dev-tools/booster-dev/Server.hs
@@ -163,10 +163,12 @@ runServer port definitions defaultMain mLlvmLibrary rewriteOpts logFile mSMTOpti
                         }
             jsonRpcServer
                 (serverSettings port "*")
-                ( const $
+                ( \rawReq req ->
                     flip runReaderT (filteredBoosterContextLogger, toModifiersRep prettyPrintOptions)
                         . Booster.Log.unLoggerT
+                        . Booster.Log.withContextFor (getReqId rawReq)
                         . Booster.Log.withContext Booster.Log.CtxBooster
                         . respond stateVar
+                        $ req
                 )
                 [handleSmtError, RpcError.handleErrorCall, RpcError.handleSomeException]

--- a/dev-tools/booster-dev/Server.hs
+++ b/dev-tools/booster-dev/Server.hs
@@ -143,7 +143,7 @@ runServer port definitions defaultMain mLlvmLibrary rewriteOpts logFile mSMTOpti
         withFastLogger mTimeCache logFile $ \stderrLogger mFileLogger -> do
             let boosterContextLogger = case logFormat of
                     Json -> Booster.Log.jsonLogger $ fromMaybe stderrLogger mFileLogger
-                    _ -> Booster.Log.textLogger stderrLogger
+                    _ -> Booster.Log.textLogger $ fromMaybe stderrLogger mFileLogger
                 filteredBoosterContextLogger =
                     flip Booster.Log.filterLogger boosterContextLogger $ \(Booster.Log.LogMessage (Booster.Flag alwaysDisplay) ctxts _) ->
                         alwaysDisplay


### PR DESCRIPTION
This small PR:
- adds `[request ID]` contexts to logs emitted from `booster-dev`, similarly to `kore-rpc-booster`
- the above also makes the per-defined logging contexts `Booster.CLIOptions` useful again, as they did not match before due to the absence of `[request ID]`
- redirects the log messages to a file if asked for
- also lists the available logging formats in `--help`