### PR TITLE
Recognise ==Int and ==K equations as substitutions when internalising

### DIFF
--- a/booster/test/rpc-integration/test-vacuous/README.md
+++ b/booster/test/rpc-integration/test-vacuous/README.md
@@ -37,6 +37,7 @@ Rules `init` and `AC` introduce constraints on this variable:
 
    _Expected:_
    - The rewrite is stuck with `<k>d</k><int>N</int> \and...(contradiction)`
+   - The `N` is substituted by value `1` in the final result (booster).
    - The result is simplified and discovered to be `vacuous` (with state `d`).
 1) _vacuous-but-rewritten_
 
@@ -47,6 +48,7 @@ Rules `init` and `AC` introduce constraints on this variable:
    _Expected:_
    - Rewrite with `BD` (despite the contradiction)
    - The rewrite is stuck with `<k>d</k><int>N</int> \and...(contradiction)`
+   - The `N` is substituted by value `1` in the final result (booster).
    - The result is simplified and discovered to be `vacuous` (with state `d`).
 
 With `kore-rpc-dev`, some contradictions will be discovered before or while

--- a/booster/test/rpc-integration/test-vacuous/response-vacuous-but-rewritten.json
+++ b/booster/test/rpc-integration/test-vacuous/response-vacuous-but-rewritten.json
@@ -66,13 +66,13 @@
                             "sorts": [],
                             "args": [
                                 {
-                                    "tag": "EVar",
-                                    "name": "N",
+                                    "tag": "DV",
                                     "sort": {
                                         "tag": "SortApp",
                                         "name": "SortInt",
                                         "args": []
-                                    }
+                                    },
+                                    "value": "0"
                                 }
                             ]
                         },
@@ -95,119 +95,74 @@
                     ]
                 }
             },
-            "predicate": {
+            "substitution": {
                 "format": "KORE",
                 "version": 1,
                 "term": {
-                    "tag": "And",
+                    "tag": "Equals",
+                    "argSort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    },
                     "sort": {
                         "tag": "SortApp",
                         "name": "SortGeneratedTopCell",
                         "args": []
                     },
-                    "patterns": [
-                        {
-                            "tag": "Equals",
-                            "argSort": {
-                                "tag": "SortApp",
-                                "name": "SortBool",
-                                "args": []
-                            },
-                            "sort": {
-                                "tag": "SortApp",
-                                "name": "SortGeneratedTopCell",
-                                "args": []
-                            },
-                            "first": {
-                                "tag": "DV",
-                                "sort": {
-                                    "tag": "SortApp",
-                                    "name": "SortBool",
-                                    "args": []
-                                },
-                                "value": "true"
-                            },
-                            "second": {
-                                "tag": "App",
-                                "name": "Lbl'UndsEqlsEqls'Int'Unds'",
-                                "sorts": [],
-                                "args": [
-                                    {
-                                        "tag": "EVar",
-                                        "name": "N",
-                                        "sort": {
-                                            "tag": "SortApp",
-                                            "name": "SortInt",
-                                            "args": []
-                                        }
-                                    },
-                                    {
-                                        "tag": "DV",
-                                        "sort": {
-                                            "tag": "SortApp",
-                                            "name": "SortInt",
-                                            "args": []
-                                        },
-                                        "value": "0"
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "tag": "Equals",
-                            "argSort": {
-                                "tag": "SortApp",
-                                "name": "SortBool",
-                                "args": []
-                            },
-                            "sort": {
-                                "tag": "SortApp",
-                                "name": "SortGeneratedTopCell",
-                                "args": []
-                            },
-                            "first": {
-                                "tag": "DV",
-                                "sort": {
-                                    "tag": "SortApp",
-                                    "name": "SortBool",
-                                    "args": []
-                                },
-                                "value": "true"
-                            },
-                            "second": {
-                                "tag": "App",
-                                "name": "LblnotBool'Unds'",
-                                "sorts": [],
-                                "args": [
-                                    {
-                                        "tag": "App",
-                                        "name": "Lbl'UndsEqlsEqls'Int'Unds'",
-                                        "sorts": [],
-                                        "args": [
-                                            {
-                                                "tag": "EVar",
-                                                "name": "N",
-                                                "sort": {
-                                                    "tag": "SortApp",
-                                                    "name": "SortInt",
-                                                    "args": []
-                                                }
-                                            },
-                                            {
-                                                "tag": "DV",
-                                                "sort": {
-                                                    "tag": "SortApp",
-                                                    "name": "SortInt",
-                                                    "args": []
-                                                },
-                                                "value": "0"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
+                    "first": {
+                        "tag": "EVar",
+                        "name": "N",
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortInt",
+                            "args": []
                         }
-                    ]
+                    },
+                    "second": {
+                        "tag": "DV",
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortInt",
+                            "args": []
+                        },
+                        "value": "0"
+                    }
+                }
+            },
+            "predicate": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "Equals",
+                    "argSort": {
+                        "tag": "SortApp",
+                        "name": "SortBool",
+                        "args": []
+                    },
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortGeneratedTopCell",
+                        "args": []
+                    },
+                    "first": {
+                        "tag": "DV",
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortBool",
+                            "args": []
+                        },
+                        "value": "true"
+                    },
+                    "second": {
+                        "tag": "DV",
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortBool",
+                            "args": []
+                        },
+                        "value": "false"
+                    }
                 }
             }
         }

--- a/booster/test/rpc-integration/test-vacuous/response-vacuous-without-rewrite.json
+++ b/booster/test/rpc-integration/test-vacuous/response-vacuous-without-rewrite.json
@@ -66,13 +66,13 @@
                             "sorts": [],
                             "args": [
                                 {
-                                    "tag": "EVar",
-                                    "name": "N",
+                                    "tag": "DV",
                                     "sort": {
                                         "tag": "SortApp",
                                         "name": "SortInt",
                                         "args": []
-                                    }
+                                    },
+                                    "value": "0"
                                 }
                             ]
                         },
@@ -95,119 +95,74 @@
                     ]
                 }
             },
-            "predicate": {
+            "substitution": {
                 "format": "KORE",
                 "version": 1,
                 "term": {
-                    "tag": "And",
+                    "tag": "Equals",
+                    "argSort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    },
                     "sort": {
                         "tag": "SortApp",
                         "name": "SortGeneratedTopCell",
                         "args": []
                     },
-                    "patterns": [
-                        {
-                            "tag": "Equals",
-                            "argSort": {
-                                "tag": "SortApp",
-                                "name": "SortBool",
-                                "args": []
-                            },
-                            "sort": {
-                                "tag": "SortApp",
-                                "name": "SortGeneratedTopCell",
-                                "args": []
-                            },
-                            "first": {
-                                "tag": "DV",
-                                "sort": {
-                                    "tag": "SortApp",
-                                    "name": "SortBool",
-                                    "args": []
-                                },
-                                "value": "true"
-                            },
-                            "second": {
-                                "tag": "App",
-                                "name": "Lbl'UndsEqlsEqls'Int'Unds'",
-                                "sorts": [],
-                                "args": [
-                                    {
-                                        "tag": "EVar",
-                                        "name": "N",
-                                        "sort": {
-                                            "tag": "SortApp",
-                                            "name": "SortInt",
-                                            "args": []
-                                        }
-                                    },
-                                    {
-                                        "tag": "DV",
-                                        "sort": {
-                                            "tag": "SortApp",
-                                            "name": "SortInt",
-                                            "args": []
-                                        },
-                                        "value": "0"
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "tag": "Equals",
-                            "argSort": {
-                                "tag": "SortApp",
-                                "name": "SortBool",
-                                "args": []
-                            },
-                            "sort": {
-                                "tag": "SortApp",
-                                "name": "SortGeneratedTopCell",
-                                "args": []
-                            },
-                            "first": {
-                                "tag": "DV",
-                                "sort": {
-                                    "tag": "SortApp",
-                                    "name": "SortBool",
-                                    "args": []
-                                },
-                                "value": "true"
-                            },
-                            "second": {
-                                "tag": "App",
-                                "name": "LblnotBool'Unds'",
-                                "sorts": [],
-                                "args": [
-                                    {
-                                        "tag": "App",
-                                        "name": "Lbl'UndsEqlsEqls'Int'Unds'",
-                                        "sorts": [],
-                                        "args": [
-                                            {
-                                                "tag": "EVar",
-                                                "name": "N",
-                                                "sort": {
-                                                    "tag": "SortApp",
-                                                    "name": "SortInt",
-                                                    "args": []
-                                                }
-                                            },
-                                            {
-                                                "tag": "DV",
-                                                "sort": {
-                                                    "tag": "SortApp",
-                                                    "name": "SortInt",
-                                                    "args": []
-                                                },
-                                                "value": "0"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
+                    "first": {
+                        "tag": "EVar",
+                        "name": "N",
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortInt",
+                            "args": []
                         }
-                    ]
+                    },
+                    "second": {
+                        "tag": "DV",
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortInt",
+                            "args": []
+                        },
+                        "value": "0"
+                    }
+                }
+            },
+            "predicate": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "Equals",
+                    "argSort": {
+                        "tag": "SortApp",
+                        "name": "SortBool",
+                        "args": []
+                    },
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortGeneratedTopCell",
+                        "args": []
+                    },
+                    "first": {
+                        "tag": "DV",
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortBool",
+                            "args": []
+                        },
+                        "value": "true"
+                    },
+                    "second": {
+                        "tag": "DV",
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortBool",
+                            "args": []
+                        },
+                        "value": "false"
+                    }
                 }
             }
         }


### PR DESCRIPTION
Booster now recognises predicates of shape `true #Equals (VAR ==Int <expr>)` and `true #Equals (VAR ==K <expr>)` as substitutions (given the global scope does not contradict that, i.e., no cycles or multiple substitutions for the same VAR...).

Currently only matches ==Int and ==K.
We could also match notBool (_ =/=Int _) and notBool (_ =/=K _) (more magic).

When internalising rules and equations, the substitution must be turned back into predicates for the `requires` clause. Currently we also turn back the ensures clause substitutions into predicates (might want to change that).

Part of #4059 
