### PR TITLE
Handle inconsistent ground truth and SMT unknowns when checking `ensures`

### DIFF
--- a/booster/library/Booster/JsonRpc.hs
+++ b/booster/library/Booster/JsonRpc.hs
@@ -363,7 +363,7 @@ respond stateVar request =
                                         withContext CtxGetModel $
                                             withContext CtxSMT $
                                                 logMessage ("No predicates or substitutions given, returning Unknown" :: Text)
-                                        pure $ SMT.IsUnknown "No predicates or substitutions given"
+                                        pure $ SMT.IsUnknown (SMT.SMTUnknownReason "No predicates or substitutions given")
                                     else do
                                         solver <- SMT.initSolver def smtOptions
                                         result <- SMT.getModelFor solver boolPs suppliedSubst
@@ -407,7 +407,7 @@ respond stateVar request =
                                             , substitution = Nothing
                                             }
                                 SMT.IsUnknown reason -> do
-                                    logMessage $ "SMT result: Unknown - " <> reason
+                                    logMessage $ "SMT result: Unknown - " <> show reason
                                     pure . Right . RpcTypes.GetModel $
                                         RpcTypes.GetModelResult
                                             { satisfiable = RpcTypes.Unknown

--- a/booster/library/Booster/SMT/Interface.hs
+++ b/booster/library/Booster/SMT/Interface.hs
@@ -12,7 +12,7 @@ module Booster.SMT.Interface (
     SMTOptions (..), -- re-export
     defaultSMTOptions, -- re-export
     SMTError (..),
-    UnkwnonReason (..),
+    UnknownReason (..),
     initSolver,
     noSolver,
     finaliseSolver,
@@ -198,7 +198,7 @@ finaliseSolver ctxt = do
     Log.logMessage ("Closing SMT solver" :: Text)
     destroyContext ctxt
 
-data UnkwnonReason
+data UnknownReason
     = -- | SMT prelude is UNSAT
       InconsistentGroundTruth
     | -- | (P, not P) is (SAT, SAT)
@@ -208,18 +208,18 @@ data UnkwnonReason
     deriving (Show, Eq, Generic)
     deriving
         (FromJSON, ToJSON)
-        via CustomJSON '[OmitNothingFields, FieldLabelModifier '[CamelToKebab, StripPrefix "_"]] UnkwnonReason
+        via CustomJSON '[OmitNothingFields, FieldLabelModifier '[CamelToKebab, StripPrefix "_"]] UnknownReason
 
-instance Log.ToLogFormat UnkwnonReason where
+instance Log.ToLogFormat UnknownReason where
     toTextualLog = pack . show
     toJSONLog = toJSON
 
-pattern IsUnknown :: UnkwnonReason -> Either UnkwnonReason b
+pattern IsUnknown :: UnknownReason -> Either UnknownReason b
 pattern IsUnknown u = Left u
 
 newtype IsSat' a = IsSat' (Maybe a) deriving (Functor)
 
-type IsSatResult a = Either UnkwnonReason (IsSat' a)
+type IsSatResult a = Either UnknownReason (IsSat' a)
 
 pattern IsSat :: a -> IsSatResult a
 pattern IsSat a = Right (IsSat' (Just a))
@@ -373,7 +373,7 @@ mkComment = BS.pack . Pretty.renderDefault . pretty' @'[Decoded]
 
 newtype IsValid' = IsValid' Bool
 
-type IsValidResult = Either UnkwnonReason IsValid'
+type IsValidResult = Either UnknownReason IsValid'
 
 pattern IsValid, IsInvalid :: IsValidResult
 pattern IsValid = Right (IsValid' True)

--- a/booster/test/rpc-integration/test-substitutions/README.md
+++ b/booster/test/rpc-integration/test-substitutions/README.md
@@ -42,6 +42,6 @@ NB: Booster applies the given substitution before performing any action.
 * `state-symbolic-bottom-predicate.execute`
   - starts from `symbolic-subst`
   - with an equation that is instantly false: `X = 1 +Int X`
-  - leading to a vacuous state in `kore-rpc-booster` after rewriting once,
+  - leading to a vacuous state in `kore-rpc-booster` and `booster-dev` at 0 steps,
   - while `kore-rpc-dev` returns `stuck` instantly after 0 steps,
     returning the exact input as `state`.

--- a/booster/test/rpc-integration/test-substitutions/response-circular-equations.booster-dev
+++ b/booster/test/rpc-integration/test-substitutions/response-circular-equations.booster-dev
@@ -225,61 +225,13 @@
                                         }
                                     },
                                     {
-                                        "tag": "App",
-                                        "name": "Lbl'UndsPlus'Int'Unds'",
-                                        "sorts": [],
-                                        "args": [
-                                            {
-                                                "tag": "App",
-                                                "name": "Lbl'UndsPlus'Int'Unds'",
-                                                "sorts": [],
-                                                "args": [
-                                                    {
-                                                        "tag": "EVar",
-                                                        "name": "X",
-                                                        "sort": {
-                                                            "tag": "SortApp",
-                                                            "name": "SortInt",
-                                                            "args": []
-                                                        }
-                                                    },
-                                                    {
-                                                        "tag": "DV",
-                                                        "sort": {
-                                                            "tag": "SortApp",
-                                                            "name": "SortInt",
-                                                            "args": []
-                                                        },
-                                                        "value": "1"
-                                                    }
-                                                ]
-                                            },
-                                            {
-                                                "tag": "App",
-                                                "name": "Lbl'Unds'-Int'Unds'",
-                                                "sorts": [],
-                                                "args": [
-                                                    {
-                                                        "tag": "DV",
-                                                        "sort": {
-                                                            "tag": "SortApp",
-                                                            "name": "SortInt",
-                                                            "args": []
-                                                        },
-                                                        "value": "0"
-                                                    },
-                                                    {
-                                                        "tag": "DV",
-                                                        "sort": {
-                                                            "tag": "SortApp",
-                                                            "name": "SortInt",
-                                                            "args": []
-                                                        },
-                                                        "value": "1"
-                                                    }
-                                                ]
-                                            }
-                                        ]
+                                        "tag": "EVar",
+                                        "name": "X",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        }
                                     }
                                 ]
                             }

--- a/booster/test/rpc-integration/test-substitutions/response-symbolic-bottom-predicate.booster-dev
+++ b/booster/test/rpc-integration/test-substitutions/response-symbolic-bottom-predicate.booster-dev
@@ -2,8 +2,8 @@
     "jsonrpc": "2.0",
     "id": 1,
     "result": {
-        "reason": "stuck",
-        "depth": 1,
+        "reason": "vacuous",
+        "depth": 0,
         "state": {
             "term": {
                 "format": "KORE",
@@ -46,7 +46,7 @@
                                                         "name": "SortState",
                                                         "args": []
                                                     },
-                                                    "value": "a"
+                                                    "value": "symbolic-subst"
                                                 }
                                             ]
                                         },
@@ -115,102 +115,54 @@
                 "format": "KORE",
                 "version": 1,
                 "term": {
-                    "tag": "And",
+                    "tag": "Equals",
+                    "argSort": {
+                        "tag": "SortApp",
+                        "name": "SortBool",
+                        "args": []
+                    },
                     "sort": {
                         "tag": "SortApp",
                         "name": "SortGeneratedTopCell",
                         "args": []
                     },
-                    "patterns": [
-                        {
-                            "tag": "Equals",
-                            "argSort": {
-                                "tag": "SortApp",
-                                "name": "SortBool",
-                                "args": []
-                            },
-                            "sort": {
-                                "tag": "SortApp",
-                                "name": "SortGeneratedTopCell",
-                                "args": []
-                            },
-                            "first": {
-                                "tag": "DV",
-                                "sort": {
-                                    "tag": "SortApp",
-                                    "name": "SortBool",
-                                    "args": []
-                                },
-                                "value": "true"
-                            },
-                            "second": {
-                                "tag": "App",
-                                "name": "Lbl'UndsEqlsEqls'Int'Unds'",
-                                "sorts": [],
-                                "args": [
-                                    {
-                                        "tag": "EVar",
-                                        "name": "X",
-                                        "sort": {
-                                            "tag": "SortApp",
-                                            "name": "SortInt",
-                                            "args": []
-                                        }
-                                    },
-                                    {
-                                        "tag": "App",
-                                        "name": "Lbl'UndsPlus'Int'Unds'",
-                                        "sorts": [],
-                                        "args": [
-                                            {
-                                                "tag": "EVar",
-                                                "name": "X",
-                                                "sort": {
-                                                    "tag": "SortApp",
-                                                    "name": "SortInt",
-                                                    "args": []
-                                                }
-                                            },
-                                            {
-                                                "tag": "DV",
-                                                "sort": {
-                                                    "tag": "SortApp",
-                                                    "name": "SortInt",
-                                                    "args": []
-                                                },
-                                                "value": "1"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
+                    "first": {
+                        "tag": "DV",
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortBool",
+                            "args": []
                         },
-                        {
-                            "tag": "Equals",
-                            "argSort": {
-                                "tag": "SortApp",
-                                "name": "SortBool",
-                                "args": []
-                            },
-                            "sort": {
-                                "tag": "SortApp",
-                                "name": "SortGeneratedTopCell",
-                                "args": []
-                            },
-                            "first": {
-                                "tag": "DV",
+                        "value": "true"
+                    },
+                    "second": {
+                        "tag": "App",
+                        "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                        "sorts": [],
+                        "args": [
+                            {
+                                "tag": "EVar",
+                                "name": "X",
                                 "sort": {
                                     "tag": "SortApp",
-                                    "name": "SortBool",
+                                    "name": "SortInt",
                                     "args": []
-                                },
-                                "value": "true"
+                                }
                             },
-                            "second": {
+                            {
                                 "tag": "App",
-                                "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                                "name": "Lbl'UndsPlus'Int'Unds'",
                                 "sorts": [],
                                 "args": [
+                                    {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        },
+                                        "value": "1"
+                                    },
                                     {
                                         "tag": "EVar",
                                         "name": "X",
@@ -219,20 +171,11 @@
                                             "name": "SortInt",
                                             "args": []
                                         }
-                                    },
-                                    {
-                                        "tag": "EVar",
-                                        "name": "Y",
-                                        "sort": {
-                                            "tag": "SortApp",
-                                            "name": "SortInt",
-                                            "args": []
-                                        }
                                     }
                                 ]
                             }
-                        }
-                    ]
+                        ]
+                    }
                 }
             }
         }

--- a/booster/test/rpc-integration/test-substitutions/response-symbolic-bottom-predicate.json
+++ b/booster/test/rpc-integration/test-substitutions/response-symbolic-bottom-predicate.json
@@ -3,7 +3,7 @@
     "id": 1,
     "result": {
         "reason": "vacuous",
-        "depth": 1,
+        "depth": 0,
         "state": {
             "term": {
                 "format": "KORE",
@@ -46,7 +46,7 @@
                                                         "name": "SortState",
                                                         "args": []
                                                     },
-                                                    "value": "a"
+                                                    "value": "symbolic-subst"
                                                 }
                                             ]
                                         },
@@ -115,102 +115,54 @@
                 "format": "KORE",
                 "version": 1,
                 "term": {
-                    "tag": "And",
+                    "tag": "Equals",
+                    "argSort": {
+                        "tag": "SortApp",
+                        "name": "SortBool",
+                        "args": []
+                    },
                     "sort": {
                         "tag": "SortApp",
                         "name": "SortGeneratedTopCell",
                         "args": []
                     },
-                    "patterns": [
-                        {
-                            "tag": "Equals",
-                            "argSort": {
-                                "tag": "SortApp",
-                                "name": "SortBool",
-                                "args": []
-                            },
-                            "sort": {
-                                "tag": "SortApp",
-                                "name": "SortGeneratedTopCell",
-                                "args": []
-                            },
-                            "first": {
-                                "tag": "DV",
-                                "sort": {
-                                    "tag": "SortApp",
-                                    "name": "SortBool",
-                                    "args": []
-                                },
-                                "value": "true"
-                            },
-                            "second": {
-                                "tag": "App",
-                                "name": "Lbl'UndsEqlsEqls'Int'Unds'",
-                                "sorts": [],
-                                "args": [
-                                    {
-                                        "tag": "EVar",
-                                        "name": "X",
-                                        "sort": {
-                                            "tag": "SortApp",
-                                            "name": "SortInt",
-                                            "args": []
-                                        }
-                                    },
-                                    {
-                                        "tag": "App",
-                                        "name": "Lbl'UndsPlus'Int'Unds'",
-                                        "sorts": [],
-                                        "args": [
-                                            {
-                                                "tag": "EVar",
-                                                "name": "X",
-                                                "sort": {
-                                                    "tag": "SortApp",
-                                                    "name": "SortInt",
-                                                    "args": []
-                                                }
-                                            },
-                                            {
-                                                "tag": "DV",
-                                                "sort": {
-                                                    "tag": "SortApp",
-                                                    "name": "SortInt",
-                                                    "args": []
-                                                },
-                                                "value": "1"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
+                    "first": {
+                        "tag": "DV",
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortBool",
+                            "args": []
                         },
-                        {
-                            "tag": "Equals",
-                            "argSort": {
-                                "tag": "SortApp",
-                                "name": "SortBool",
-                                "args": []
-                            },
-                            "sort": {
-                                "tag": "SortApp",
-                                "name": "SortGeneratedTopCell",
-                                "args": []
-                            },
-                            "first": {
-                                "tag": "DV",
+                        "value": "true"
+                    },
+                    "second": {
+                        "tag": "App",
+                        "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                        "sorts": [],
+                        "args": [
+                            {
+                                "tag": "EVar",
+                                "name": "X",
                                 "sort": {
                                     "tag": "SortApp",
-                                    "name": "SortBool",
+                                    "name": "SortInt",
                                     "args": []
-                                },
-                                "value": "true"
+                                }
                             },
-                            "second": {
+                            {
                                 "tag": "App",
-                                "name": "Lbl'UndsEqlsEqls'Int'Unds'",
+                                "name": "Lbl'UndsPlus'Int'Unds'",
                                 "sorts": [],
                                 "args": [
+                                    {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        },
+                                        "value": "1"
+                                    },
                                     {
                                         "tag": "EVar",
                                         "name": "X",
@@ -219,20 +171,11 @@
                                             "name": "SortInt",
                                             "args": []
                                         }
-                                    },
-                                    {
-                                        "tag": "EVar",
-                                        "name": "Y",
-                                        "sort": {
-                                            "tag": "SortApp",
-                                            "name": "SortInt",
-                                            "args": []
-                                        }
                                     }
                                 ]
                             }
-                        }
-                    ]
+                        ]
+                    }
                 }
             }
         }


### PR DESCRIPTION
When checking `ensures` conditions of rewrite rules with the SMT solver, we must mark rewrite as trivial if the ground truth is inconsistent. If the SMT solver returns unknown, we must abort rewriting.

Previously, we were swallowing both of there cases and finalizing the rewrite step successfully. This behavior of Booster went undetected for a long time since we would usually abort rewriting or detect a vacuous state at the next step, resulting in wasted work but no unsoundness.

We also tweak the return type of `checkPredicates` to convey addition information why the result is unknown. This will be useful when we start tolerating SMT unknowns and branching on that.