### PR TITLE
Turn `Pattern` into `#Bottom` if any constraint is literal false

### DIFF
--- a/booster/library/Booster/Pattern/Rewrite.hs
+++ b/booster/library/Booster/Pattern/Rewrite.hs
@@ -1034,7 +1034,9 @@ performRewrite rewriteConfig pat = do
             case res of
                 Right newPattern -> do
                     emitRewriteTrace $ RewriteSimplified Nothing
-                    pure $ Just newPattern
+                    if isBottom newPattern
+                        then pure Nothing
+                        else pure $ Just newPattern
                 Left r@SideConditionFalse{} -> do
                     emitRewriteTrace $ RewriteSimplified (Just r)
                     pure Nothing

--- a/booster/test/rpc-integration/test-vacuous/README.md
+++ b/booster/test/rpc-integration/test-vacuous/README.md
@@ -1,6 +1,6 @@
 # Tests for `kore-rpc-booster` returning vacuous results after simplification
 
-Since `kore-rpc-booster` does not consider combinations of constraints, it won't discover when a reached state (or the initial state) simplifies to `\bottom`. In such cases, the `execute` request should return the current state with `"reason": "vacuous"` in the result.
+Since Booster does not check consistently of the initial pattern before starting rewriting, it won't always discover when a reached state (or the initial state) simplifies to `\bottom`. Ultimately, `kore-rpc-booster` relies on Kore's simplifier to detect such cases. When Kore prunes a `\bottom` branch, the `execute` endpoint of `kore-rpc-booster` should return the current state with `"reason": "vacuous"` in the result.
 
 The `diamond/test.k` semantics is used, which consists of simple state
 transition rules featuring additional constraints on a variable

--- a/booster/test/rpc-integration/test-vacuous/response-vacuous-but-rewritten.json
+++ b/booster/test/rpc-integration/test-vacuous/response-vacuous-but-rewritten.json
@@ -155,13 +155,29 @@
                         "value": "true"
                     },
                     "second": {
-                        "tag": "DV",
-                        "sort": {
-                            "tag": "SortApp",
-                            "name": "SortBool",
-                            "args": []
-                        },
-                        "value": "false"
+                        "tag": "App",
+                        "name": "Lbl'UndsEqlsSlshEqls'Int'Unds'",
+                        "sorts": [],
+                        "args": [
+                            {
+                                "tag": "DV",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortInt",
+                                    "args": []
+                                },
+                                "value": "0"
+                            },
+                            {
+                                "tag": "DV",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortInt",
+                                    "args": []
+                                },
+                                "value": "0"
+                            }
+                        ]
                     }
                 }
             }

--- a/booster/test/rpc-integration/test-vacuous/response-vacuous-without-rewrite.json
+++ b/booster/test/rpc-integration/test-vacuous/response-vacuous-without-rewrite.json
@@ -155,13 +155,29 @@
                         "value": "true"
                     },
                     "second": {
-                        "tag": "DV",
-                        "sort": {
-                            "tag": "SortApp",
-                            "name": "SortBool",
-                            "args": []
-                        },
-                        "value": "false"
+                        "tag": "App",
+                        "name": "Lbl'UndsEqlsSlshEqls'Int'Unds'",
+                        "sorts": [],
+                        "args": [
+                            {
+                                "tag": "DV",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortInt",
+                                    "args": []
+                                },
+                                "value": "0"
+                            },
+                            {
+                                "tag": "DV",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortInt",
+                                    "args": []
+                                },
+                                "value": "0"
+                            }
+                        ]
                     }
                 }
             }


### PR DESCRIPTION
- before returning a `"simplify"` response, check if any constrains are `false` and return `#Bottom` in that case
- when simplifying rewriting results, prune branches if there's a literal `false`
  - this triggers the change in the `test-vacuous` integration test, where the original state is now returned. [simplifyP](https://github.com/runtimeverification/haskell-backend/blob/booster-bottom-on-false-constaint/booster/library/Booster/Pattern/Rewrite.hs#L1029) now returns `Nothing` for the result and thus we get to return `RewriteTrivial` from `performRewrite`
  - note that the outdated responses for this integration tests actually had a literal `false` as one of the constraints.