### PR TITLE
Bump z3 to v4.13.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -63,16 +63,16 @@
     "z3": {
       "flake": false,
       "locked": {
-        "lastModified": 1709835916,
-        "narHash": "sha256-MIbP3QgKIGF/qUMTupaO7xD46LbmH69kF/394Sajhkg=",
+        "lastModified": 1734346855,
+        "narHash": "sha256-8hWXCr6IuNVKkOegEmWooo5jkdmln9nU7wI8T882BSE=",
         "owner": "Z3Prover",
         "repo": "z3",
-        "rev": "3049f578a8f98a0b0992eca193afe57a73b30ca3",
+        "rev": "6f24123f0c9d1d8bd84dec275c5c7aea939a19fe",
         "type": "github"
       },
       "original": {
         "owner": "Z3Prover",
-        "ref": "z3-4.13.0",
+        "ref": "z3-4.13.4",
         "repo": "z3",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.follows = "rv-utils/nixpkgs";
     stacklock2nix.url = "github:cdepillabout/stacklock2nix";
     z3 = {
-      url = "github:Z3Prover/z3/z3-4.13.0";
+      url = "github:Z3Prover/z3/z3-4.13.4";
       flake = false;
     };
   };


### PR DESCRIPTION
This PR updates Z3 to its latest version. It was observed that this version is performing much more efficiently in Kontrol engagement proofs, which require reasoning about complex non-linear arithmetic. 

The improvements in performance are as follows (will be updated as I collect more information):
- SAT checks that would take ~64 seconds in v4.13.0 now take ~3 seconds.