### PR TITLE
modified:   .github/workflows/release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,10 +55,20 @@ jobs:
         uses: cachix/cachix-action@v14
         with:
           name: k-framework
+          extraPullNames: k-framework-binary
           authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
 
-      - name: Build
-        run: nix build .#kore-exec .#kore-rpc-booster
+      - name: 'Build and Cache'
+        uses: workflow/nix-shell-action@v3
+        env:
+          GC_DONT_GC: 1
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_PUBLIC_TOKEN }}
+        with:
+          packages: jq
+          script: |
+            HASKELL_BACKEND=$(nix build --extra-experimental-features 'nix-command flakes' .#kore-exec .#kore-rpc-booster --json | jq -r '.[].outputs | to_entries[].value')
+            DRV=$(nix-store --query --deriver ${HASKELL_BACKEND})
+            nix-store --query --requisites --include-outputs ${DRV} | cachix push k-framework-binary
 
   ubuntu-package:
     name: 'Build Ubuntu package'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,8 +112,17 @@ jobs:
           name: k-framework
           authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
 
-      - name: Build
-        run: GC_DONT_GC=1 nix build .#kore-exec .#kore-rpc-booster
+      - name: 'Build and Cache'
+        uses: workflow/nix-shell-action@v3
+        env:
+          GC_DONT_GC: 1
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_PUBLIC_TOKEN }}
+        with:
+          packages: jq
+          script: |
+            HASKELL_BACKEND=$(nix build --extra-experimental-features 'nix-command flakes' .#kore-exec .#kore-rpc-booster --json | jq -r '.[].outputs | to_entries[].value')
+            DRV=$(nix-store --query --deriver ${HASKELL_BACKEND})
+            nix-store --query --requisites --include-outputs ${DRV} | cachix push k-framework
 
       - name: Test
         run: GC_DONT_GC=1 nix develop .#cabal --command bash -c "hpack ./booster && hpack dev-tools && cabal update && cabal build all && cabal test --enable-tests --test-show-details=direct kore-test unit-tests"


### PR DESCRIPTION
modified:   .github/workflows/test.yml
- Update nix release process for test/release workflows
- Publish release builds to k-framework-binar
- Publish iterative CI builds to k-framework.
- Reduce build times upstream and in CI PR testing.
- Supporting issue of haskell-backend components being built upstream by
  dependents.

