### PR TITLE
Fix an off-by-one error in the `Bytes2Int` hook

### DIFF
--- a/kore/src/Kore/Builtin/InternalBytes.hs
+++ b/kore/src/Kore/Builtin/InternalBytes.hs
@@ -529,7 +529,7 @@ bytes2int bytes end sign =
     case sign of
         Unsigned _ -> unsigned
         Signed _
-            | 2 * unsigned > modulus -> unsigned - modulus
+            | 2 * unsigned >= modulus -> unsigned - modulus
             | otherwise -> unsigned
   where
     (modulus, unsigned) = ByteString.foldl' go (1, 0) littleEndian


### PR DESCRIPTION
```
jost@freshcode-1:$ kompile test.k
[Warning] Compiler: Could not find main syntax module with name TEST-SYNTAX in
jost@freshcode-1:$ krun -cPGM='Bytes2Int(b"\x00\x80", LE, Signed)'
<k>
  -32768 ~> .K
</k>
jost@freshcode-1:$ kompile test.k --backend haskell
[Warning] Compiler: Could not find main syntax module with name TEST-SYNTAX in
definition.  Use --syntax-module to specify one. Using TEST as default.
jost@freshcode-1:$ krun -cPGM='Bytes2Int(b"\x00\x80", LE, Signed)'
<k>
  32768 ~> .K
</k>
```

32768 is not representable in 16 bit signed integers.

Root cause was a missing `=` , tests did not catch it because they applied the same (wrong) logic as the conversion itself.
