### PR TITLE
4100 booster abort rewrite on subject vars

### DIFF
--- a/booster/library/Booster/Pattern/Implies.hs
+++ b/booster/library/Booster/Pattern/Implies.hs
@@ -126,13 +126,13 @@ runImplies def mLlvmLibrary mSMTOptions antecedent consequent =
                                 (Right simplifedSubstPatL, _) ->
                                     if patL == simplifedSubstPatL
                                         then -- we are being conservative here for now and returning "not-implied".
-                                             -- We could return implies, but the condition will contain the remainder
-                                             -- as an equality contraint, predicating the implication on that equality being true.
+                                        -- We could return implies, but the condition will contain the remainder
+                                        -- as an equality contraint, predicating the implication on that equality being true.
+
                                             doesNotImply
                                                 (sortOfPattern patL)
                                                 (externaliseExistTerm existsL patL.term)
                                                 (externaliseExistTerm existsR patR.term)
-
                                         else checkImpliesMatchTerms existsL simplifedSubstPatL existsR patR
                                 (Left err, _) ->
                                     pure . Left . RpcError.backendError $ RpcError.Aborted (Text.pack . constructorName $ err)

--- a/booster/library/Booster/Pattern/Match.hs
+++ b/booster/library/Booster/Pattern/Match.hs
@@ -79,8 +79,6 @@ data FailReason
       SubsortingError SortError
     | -- | The two terms have differing argument lengths
       ArgLengthsDiffer Term Term
-    | -- | Not a matching substitution
-      SubjectVariableMatch Term Variable
     deriving stock (Eq, Show)
 
 instance FromModifiersT mods => Pretty (PrettyWithModifiers mods FailReason) where
@@ -115,8 +113,6 @@ instance FromModifiersT mods => Pretty (PrettyWithModifiers mods FailReason) whe
             pretty $ show err
         ArgLengthsDiffer t1 t2 ->
             hsep ["Argument length differ", pretty' @mods t1, pretty' @mods t2]
-        SubjectVariableMatch t v ->
-            hsep ["Cannot match variable in subject:", pretty' @mods v, pretty' @mods t]
 
 {- | Attempts to find a simple unifying substitution for the given
    terms.
@@ -217,9 +213,10 @@ match1 _       t1@DomainValue{}                           t2@ConsApplication{}  
 match1 _       t1@DomainValue{}                           t2@FunctionApplication{}                   = addIndeterminate t1 t2
 -- match with var on the RHS must be indeterminate when evaluating functions. see: https://github.com/runtimeverification/hs-backend-booster/issues/231
 match1 Eval    t1@DomainValue{}                           t2@Var{}                                   = addIndeterminate t1 t2
--- match with var on RHS is specially marked at the moment but must abort the rewriting (or lead to branching), see https://github.com/runtimeverification/haskell-backend/issues/4100
-match1 Rewrite t1@DomainValue{}                           (Var t2)                                   = failWith $ SubjectVariableMatch t1 t2
-match1 Implies t1@DomainValue{}                           (Var t2)                                   = failWith $ SubjectVariableMatch t1 t2
+-- match with var on RHS may lead to branching during rewriting, see https://github.com/runtimeverification/haskell-backend/issues/4100
+-- Related cases are currently marked with a special function so they can be identified and changed together later (extending branching functionality)
+match1 Rewrite t1@DomainValue{}                           (Var v2)                                   = subjectVariableMatch t1 v2
+match1 Implies t1@DomainValue{}                           (Var v2)                                   = subjectVariableMatch t1 v2
 match1 Eval    t1@Injection{}                             t2@AndTerm{}                               = addIndeterminate t1 t2
 match1 _       t1@Injection{}                             (AndTerm t2a t2b)                          = enqueueRegularProblem t1 t2a >> enqueueRegularProblem t1 t2b
 match1 _       t1@Injection{}                             t2@DomainValue{}                           = failWith $ DifferentSymbols t1 t2
@@ -229,7 +226,7 @@ match1 _       t1@Injection{}                             t2@KList{}            
 match1 _       t1@Injection{}                             t2@KSet{}                                  = failWith $ DifferentSymbols t1 t2
 match1 _       t1@Injection{}                             t2@ConsApplication{}                       = failWith $ DifferentSymbols t1 t2
 match1 _       t1@Injection{}                             t2@FunctionApplication{}                   = addIndeterminate t1 t2
-match1 Rewrite t1@Injection{}                             (Var t2)                                   = failWith $ SubjectVariableMatch t1 t2
+match1 Rewrite t1@Injection{}                             (Var v2)                                   = subjectVariableMatch t1 v2
 match1 _       t1@Injection{}                             t2@Var{}                                   = addIndeterminate t1 t2
 match1 Eval    t1@KMap{}                                  t2@AndTerm{}                               = addIndeterminate t1 t2
 match1 _       t1@KMap{}                                  (AndTerm t2a t2b)                          = enqueueRegularProblem t1 t2a >> enqueueRegularProblem t1 t2b
@@ -241,7 +238,7 @@ match1 _       t1@KMap{}                                  t2@KList{}            
 match1 _       t1@KMap{}                                  t2@KSet{}                                  = failWith $ DifferentSymbols t1 t2
 match1 _       t1@KMap{}                                  t2@ConsApplication{}                       = failWith $ DifferentSymbols t1 t2
 match1 _       t1@KMap{}                                  t2@FunctionApplication{}                   = addIndeterminate t1 t2
-match1 Rewrite t1@KMap{}                                  (Var t2)                                   = failWith $ SubjectVariableMatch t1 t2
+match1 Rewrite t1@KMap{}                                  (Var v2)                                   = subjectVariableMatch t1 v2
 match1 _       t1@KMap{}                                  t2@Var{}                                   = addIndeterminate t1 t2
 match1 Eval    t1@KList{}                                 t2@AndTerm{}                               = addIndeterminate t1 t2
 match1 _       t1@KList{}                                 (AndTerm t2a t2b)                          = enqueueRegularProblem t1 t2a >> enqueueRegularProblem t1 t2b
@@ -254,7 +251,7 @@ match1 _       t1@(KList def1 heads1 rest1)               t2@(KList def2 heads2 
 match1 _       t1@KList{}                                 t2@KSet{}                                  = failWith $ DifferentSymbols t1 t2
 match1 _       t1@KList{}                                 t2@ConsApplication{}                       = failWith $ DifferentSymbols t1 t2
 match1 _       t1@KList{}                                 t2@FunctionApplication{}                   = addIndeterminate t1 t2
-match1 Rewrite t1@KList{}                                 (Var t2)                                   = failWith $ SubjectVariableMatch t1 t2
+match1 Rewrite t1@KList{}                                 (Var t2)                                   = subjectVariableMatch t1 t2
 match1 _       t1@KList{}                                 t2@Var{}                                   = addIndeterminate t1 t2
 match1 Eval    t1@KSet{}                                  t2@AndTerm{}                               = addIndeterminate t1 t2
 match1 _       t1@KSet{}                                  (AndTerm t2a t2b)                          = enqueueRegularProblem t1 t2a >> enqueueRegularProblem t1 t2b
@@ -266,7 +263,7 @@ match1 _       t1@KSet{}                                  t2@KList{}            
 match1 _       t1@(KSet def1 patElements patRest)         t2@(KSet def2 subjElements subjRest)       = if def1 == def2 then matchSets def1 patElements patRest subjElements subjRest else failWith $ DifferentSorts t1 t2
 match1 _       t1@KSet{}                                  t2@ConsApplication{}                       = failWith $ DifferentSymbols t1 t2
 match1 _       t1@KSet{}                                  t2@FunctionApplication{}                   = addIndeterminate t1 t2
-match1 Rewrite t1@KSet{}                                  (Var t2)                                   = failWith $ SubjectVariableMatch t1 t2
+match1 Rewrite t1@KSet{}                                  (Var t2)                                   = subjectVariableMatch t1 t2
 match1 _       t1@KSet{}                                  t2@Var{}                                   = addIndeterminate t1 t2
 match1 Eval    t1@ConsApplication{}                       t2@AndTerm{}                               = addIndeterminate t1 t2
 match1 _       t1@ConsApplication{}                       (AndTerm t2a t2b)                          = enqueueRegularProblem t1 t2a >> enqueueRegularProblem t1 t2b
@@ -278,7 +275,7 @@ match1 _       t1@ConsApplication{}                       t2@KSet{}             
 match1 matchTy (ConsApplication symbol1 sorts1 args1)     (ConsApplication symbol2 sorts2 args2)     = matchSymbolAplications matchTy symbol1 sorts1 args1 symbol2 sorts2 args2
 match1 Eval    (ConsApplication symbol1 sorts1 args1)     (FunctionApplication symbol2 sorts2 args2) = matchSymbolAplications Eval symbol1 sorts1 args1 symbol2 sorts2 args2
 match1 _       t1@ConsApplication{}                       t2@FunctionApplication{}                   = addIndeterminate t1 t2
-match1 Rewrite t1@ConsApplication{}                       (Var t2)                                   = failWith $ SubjectVariableMatch t1 t2
+match1 Rewrite t1@ConsApplication{}                       (Var t2)                                   = subjectVariableMatch t1 t2
 match1 _       t1@ConsApplication{}                       t2@Var{}                                   = addIndeterminate t1 t2
 match1 Eval    t1@FunctionApplication{}                   t2@AndTerm{}                               = addIndeterminate t1 t2
 match1 _       t1@FunctionApplication{}                   (AndTerm t2a t2b)                          = enqueueRegularProblem t1 t2a >> enqueueRegularProblem t1 t2b
@@ -296,7 +293,7 @@ match1 Eval    (FunctionApplication symbol1 sorts1 args1) (ConsApplication symbo
 match1 _       t1@FunctionApplication{}                   t2@ConsApplication{}                       = addIndeterminate t1 t2
 match1 Eval    (FunctionApplication symbol1 sorts1 args1) (FunctionApplication symbol2 sorts2 args2) = matchSymbolAplications Eval symbol1 sorts1 args1 symbol2 sorts2 args2
 match1 _       t1@FunctionApplication{}                   t2@FunctionApplication{}                   = addIndeterminate t1 t2
-match1 Rewrite t1@FunctionApplication{}                   (Var t2)                                   = failWith $ SubjectVariableMatch t1 t2
+match1 Rewrite t1@FunctionApplication{}                   (Var t2)                                   = subjectVariableMatch t1 t2
 match1 _       t1@FunctionApplication{}                   t2@Var{}                                   = addIndeterminate t1 t2
 match1 Eval    t1@Var{}                                   t2@AndTerm{}                               = addIndeterminate t1 t2
 match1 _       t1@Var{}                                   (AndTerm t2a t2b)                          = enqueueRegularProblem t1 t2a >> enqueueRegularProblem t1 t2b
@@ -449,6 +446,12 @@ matchVar
                             then term2
                             else Injection termSort variableSort term2
                 else failWith $ DifferentSorts (Var var) term2
+
+-- Subject variable matches are currently marked as indeterminate.
+-- The code may be extended to collect these as separate conditional
+-- results (for branching).
+subjectVariableMatch :: Term -> Variable -> StateT MatchState (Except MatchResult) ()
+subjectVariableMatch t v = addIndeterminate t (Var v)
 
 {- | pair up the argument lists and return the pairs in the first argument. If the lists
 are of equal length, return Nothing in second, else return the remaining

--- a/booster/library/Booster/Pattern/Match.hs
+++ b/booster/library/Booster/Pattern/Match.hs
@@ -216,9 +216,10 @@ match1 _       t1@DomainValue{}                           t2@KSet{}             
 match1 _       t1@DomainValue{}                           t2@ConsApplication{}                       = failWith $ DifferentSymbols t1 t2
 match1 _       t1@DomainValue{}                           t2@FunctionApplication{}                   = addIndeterminate t1 t2
 -- match with var on the RHS must be indeterminate when evaluating functions. see: https://github.com/runtimeverification/hs-backend-booster/issues/231
+match1 Eval    t1@DomainValue{}                           t2@Var{}                                   = addIndeterminate t1 t2
+-- match with var on RHS is specially marked at the moment but must abort the rewriting (or lead to branching), see https://github.com/runtimeverification/haskell-backend/issues/4100
 match1 Rewrite t1@DomainValue{}                           (Var t2)                                   = failWith $ SubjectVariableMatch t1 t2
 match1 Implies t1@DomainValue{}                           (Var t2)                                   = failWith $ SubjectVariableMatch t1 t2
-match1 Eval    t1@DomainValue{}                           t2@Var{}                                   = addIndeterminate t1 t2
 match1 Eval    t1@Injection{}                             t2@AndTerm{}                               = addIndeterminate t1 t2
 match1 _       t1@Injection{}                             (AndTerm t2a t2b)                          = enqueueRegularProblem t1 t2a >> enqueueRegularProblem t1 t2b
 match1 _       t1@Injection{}                             t2@DomainValue{}                           = failWith $ DifferentSymbols t1 t2
@@ -228,6 +229,7 @@ match1 _       t1@Injection{}                             t2@KList{}            
 match1 _       t1@Injection{}                             t2@KSet{}                                  = failWith $ DifferentSymbols t1 t2
 match1 _       t1@Injection{}                             t2@ConsApplication{}                       = failWith $ DifferentSymbols t1 t2
 match1 _       t1@Injection{}                             t2@FunctionApplication{}                   = addIndeterminate t1 t2
+match1 Rewrite t1@Injection{}                             (Var t2)                                   = failWith $ SubjectVariableMatch t1 t2
 match1 _       t1@Injection{}                             t2@Var{}                                   = addIndeterminate t1 t2
 match1 Eval    t1@KMap{}                                  t2@AndTerm{}                               = addIndeterminate t1 t2
 match1 _       t1@KMap{}                                  (AndTerm t2a t2b)                          = enqueueRegularProblem t1 t2a >> enqueueRegularProblem t1 t2b

--- a/booster/library/Booster/Pattern/Rewrite.hs
+++ b/booster/library/Booster/Pattern/Rewrite.hs
@@ -64,7 +64,7 @@ import Booster.Pattern.Base
 import Booster.Pattern.Bool
 import Booster.Pattern.Index qualified as Idx
 import Booster.Pattern.Match (
-    FailReason (ArgLengthsDiffer, SubsortingError),
+    FailReason (ArgLengthsDiffer, SubjectVariableMatch, SubsortingError),
     MatchResult (MatchFailed, MatchIndeterminate, MatchSuccess),
     MatchType (Rewrite),
     SortError,
@@ -392,6 +392,10 @@ applyRule pat@Pattern{ceilConditions} rule =
                             withContext CtxError $
                                 logPretty' @mods err
                             failRewrite $ InternalMatchError $ renderText $ pretty' @mods err
+                        MatchFailed err@(SubjectVariableMatch t v) -> do
+                            withContext CtxError $
+                                logPretty' @mods err
+                            failRewrite $ RuleApplicationUnclear rule pat.term $ NE.singleton (t, Var v)
                         MatchFailed reason -> do
                             withContext CtxFailure $ logPretty' @mods reason
                             returnNotApplied

--- a/booster/library/Booster/Pattern/Rewrite.hs
+++ b/booster/library/Booster/Pattern/Rewrite.hs
@@ -64,7 +64,7 @@ import Booster.Pattern.Base
 import Booster.Pattern.Bool
 import Booster.Pattern.Index qualified as Idx
 import Booster.Pattern.Match (
-    FailReason (ArgLengthsDiffer, SubjectVariableMatch, SubsortingError),
+    FailReason (ArgLengthsDiffer, SubsortingError),
     MatchResult (MatchFailed, MatchIndeterminate, MatchSuccess),
     MatchType (Rewrite),
     SortError,
@@ -392,10 +392,6 @@ applyRule pat@Pattern{ceilConditions} rule =
                             withContext CtxError $
                                 logPretty' @mods err
                             failRewrite $ InternalMatchError $ renderText $ pretty' @mods err
-                        MatchFailed err@(SubjectVariableMatch t v) -> do
-                            withContext CtxError $
-                                logPretty' @mods err
-                            failRewrite $ RuleApplicationUnclear rule pat.term $ NE.singleton (t, Var v)
                         MatchFailed reason -> do
                             withContext CtxFailure $ logPretty' @mods reason
                             returnNotApplied

--- a/booster/unit-tests/Test/Booster/Pattern/Rewrite.hs
+++ b/booster/unit-tests/Test/Booster/Pattern/Rewrite.hs
@@ -209,9 +209,13 @@ rewriteSuccess =
                          )
 subjectVariables =
     testCase "Aborts case when subject has variables" $ do
-        let t = [trm| kCell{}( kseq{}( inj{SomeSort{}, SortKItem{}}( con3{}( X:SomeSort{}, \dv{SomeSort{}}("thing") ) ), ConfigVar:SortK{}) ) |]
-        t `failsWith`
-            RuleApplicationUnclear rule3 t (NE.singleton ([trm| \dv{SomeSort{}}("otherThing")|], [trm| X:SomeSort{} |]))
+        let t =
+                [trm| kCell{}( kseq{}( inj{SomeSort{}, SortKItem{}}( con3{}( X:SomeSort{}, \dv{SomeSort{}}("thing") ) ), ConfigVar:SortK{}) ) |]
+        t
+            `failsWith` RuleApplicationUnclear
+                rule3
+                t
+                (NE.singleton ([trm| \dv{SomeSort{}}("otherThing")|], [trm| X:SomeSort{} |]))
 definednessUnclear =
     testCase "con4 rewrite to f2 might become undefined" $ do
         let pcon4 =

--- a/booster/unit-tests/Test/Booster/Pattern/Rewrite.hs
+++ b/booster/unit-tests/Test/Booster/Pattern/Rewrite.hs
@@ -41,7 +41,7 @@ test_rewriteStep =
         "Rewriting"
         [ errorCases
         , rewriteSuccess
-        , unifyNotMatch
+        , subjectVariables
         , definednessUnclear
         , rewriteStuck
         , rulePriority
@@ -176,7 +176,7 @@ testConf = do
 ----------------------------------------
 errorCases
     , rewriteSuccess
-    , unifyNotMatch
+    , subjectVariables
     , definednessUnclear
     , rewriteStuck
     , rulePriority ::
@@ -207,10 +207,11 @@ rewriteSuccess =
             `rewritesTo` ( "con1-f1"
                          , [trm| kCell{}( kseq{}( inj{SomeSort{}, SortKItem{}}( f1{}(   \dv{SomeSort{}}("thing") ) ), ConfigVar:SortK{}) ) |]
                          )
-unifyNotMatch =
-    testCase "Stuck case when subject has variables" $
-        getsStuck
-            [trm| kCell{}( kseq{}( inj{SomeSort{}, SortKItem{}}( con3{}( X:SomeSort{}, \dv{SomeSort{}}("thing") ) ), ConfigVar:SortK{}) ) |]
+subjectVariables =
+    testCase "Aborts case when subject has variables" $ do
+        let t = [trm| kCell{}( kseq{}( inj{SomeSort{}, SortKItem{}}( con3{}( X:SomeSort{}, \dv{SomeSort{}}("thing") ) ), ConfigVar:SortK{}) ) |]
+        t `failsWith`
+            RuleApplicationUnclear rule3 t (NE.singleton ([trm| \dv{SomeSort{}}("otherThing")|], [trm| X:SomeSort{} |]))
 definednessUnclear =
     testCase "con4 rewrite to f2 might become undefined" $ do
         let pcon4 =

--- a/scripts/performance-tests-kontrol.sh
+++ b/scripts/performance-tests-kontrol.sh
@@ -104,7 +104,7 @@ master_shell() {
 }
 
 # kompile Kontrol's K dependencies
-feature_shell "poetry install && poetry run kdist --verbose build evm-semantics.plugin evm-semantics.haskell kontrol.foundry --jobs 4"
+feature_shell "poetry install && poetry run kdist --verbose build evm-semantics.plugin evm-semantics.haskell kontrol.* --jobs 4"
 
 # kompile the test contracts, to be reused in feature_shell and master_shell. Copy the result from pytest's temp directory
 PYTEST_TEMP_DIR=$TEMPD/pytest-temp-dir


### PR DESCRIPTION
Fixes #4100 

During rewriting, booster was reporting the rule match as "failed" when trying to match a non-variable in the rule to a variable in the subject (introduced by a refactoring mid 2024).
This produces unsound results because the subject variable could be constrained to have a value that would match the rule term, enabling the application of this rule.
The result in `booster` should therefore be `aborted` as long as we don't allow for introducing constraints like this to the rule application.

The new code adds the subject variable to a set of "indeterminate" match pairs. Code has been kept separate so we can later extend the branching mechanism by the collected constraints on subject variables.