### PR TITLE
Fix LIST.in hook for non-constructor-like list elements

### DIFF
--- a/booster/library/Booster/Builtin/LIST.hs
+++ b/booster/library/Booster/Builtin/LIST.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 {- |
 Copyright   : (c) Runtime Verification, 2023
 License     : BSD-3-Clause
@@ -17,7 +19,6 @@ import Data.ByteString.Char8 (ByteString, pack)
 import Data.Map (Map)
 import Data.Map qualified as Map
 
-import Booster.Builtin.BOOL (boolTerm)
 import Booster.Builtin.Base
 import Booster.Builtin.INT
 import Booster.Definition.Attributes.Base (
@@ -25,6 +26,7 @@ import Booster.Definition.Attributes.Base (
     KListDefinition (..),
  )
 import Booster.Pattern.Base
+import Booster.Pattern.Bool (pattern FalseBool, pattern TrueBool)
 
 builtinsLIST :: Map ByteString BuiltinFunction
 builtinsLIST =
@@ -109,11 +111,16 @@ listGetHook args =
 listInHook :: BuiltinFunction
 listInHook [e, KList _ heads rest] =
     case rest of
-        Nothing -> pure $ Just $ boolTerm (e `elem` heads)
+        Nothing
+            | e `elem` heads -> pure $ Just TrueBool
+            | not (e `elem` heads)
+            , all isConstructorLike_ (e : heads) ->
+                pure $ Just FalseBool
+            | otherwise -> pure Nothing
         Just (_mid, tails)
             | e `elem` tails ->
-                pure $ Just $ boolTerm True
-            | otherwise -> -- could be in opaque _mid
+                pure $ Just TrueBool
+            | otherwise -> -- could be in opaque _mid or not constructor-like
                 pure Nothing
 listInHook args =
     arityError "LIST.in" 2 args

--- a/booster/library/Booster/Pattern/Base.hs
+++ b/booster/library/Booster/Pattern/Base.hs
@@ -125,6 +125,9 @@ data TermAttributes = TermAttributes
     -- variables, recursive through AndTerm
     , hash :: !Int
     , isConstructorLike :: !Bool
+    -- ^ Means that logic equality is the same as syntactic equality.
+    -- True for domain values and constructor symbols (recursive
+    -- through arg.s), recursive through AndTerm.
     , canBeEvaluated :: !Bool
     -- ^ false for function calls, variables, and AndTerms
     }


### PR DESCRIPTION
The previous list hook implementation `LIST.in` was testing membership based on _syntactic_ equality. This is incorrect if the elements of the list are not constructor-like (like variables or unevaluated function calls), `False` cannot be returned in those cases. When all known list elements are constructor-like, syntactic equality is sufficient. A unit test was added for this case.

